### PR TITLE
Functest fixes

### DIFF
--- a/unit_tests/test_zaza_charm_lifecycle_configure.py
+++ b/unit_tests/test_zaza_charm_lifecycle_configure.py
@@ -19,9 +19,11 @@ class TestCharmLifecycleConfigure(ut_utils.BaseTestCase):
         self.patch_object(lc_configure, 'run_configure_list')
         mock1 = mock.MagicMock()
         mock2 = mock.MagicMock()
-        lc_configure.configure([mock1, mock2])
+        lc_configure.configure('modelname', [mock1, mock2])
         self.run_configure_list.assert_called_once_with([mock1, mock2])
 
     def test_parser(self):
-        args = lc_configure.parse_args(['-c', 'my.func1', 'my.func2'])
+        args = lc_configure.parse_args(
+            ['-m', 'modelname', '-c', 'my.func1', 'my.func2'])
         self.assertEqual(args.configfuncs, ['my.func1', 'my.func2'])
+        self.assertEqual(args.model_name, 'modelname')

--- a/unit_tests/test_zaza_charm_lifecycle_func_test_runner.py
+++ b/unit_tests/test_zaza_charm_lifecycle_func_test_runner.py
@@ -32,17 +32,17 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
             mock.call('./tests/bundles/bundle1.yaml', 'newmodel'),
             mock.call('./tests/bundles/bundle2.yaml', 'newmodel')]
         configure_calls = [
-            mock.call([
+            mock.call('newmodel', [
                 'zaza.charm_tests.mycharm.setup.basic_setup'
                 'zaza.charm_tests.othercharm.setup.setup']),
-            mock.call([
+            mock.call('newmodel', [
                 'zaza.charm_tests.mycharm.setup.basic_setup'
                 'zaza.charm_tests.othercharm.setup.setup'])]
         test_calls = [
-            mock.call([
+            mock.call('newmodel', [
                 'zaza.charm_tests.mycharm.tests.SmokeTest',
                 'zaza.charm_tests.mycharm.tests.ComplexTest']),
-            mock.call([
+            mock.call('newmodel', [
                 'zaza.charm_tests.mycharm.tests.SmokeTest',
                 'zaza.charm_tests.mycharm.tests.ComplexTest'])]
         destroy_calls = [

--- a/unit_tests/test_zaza_charm_lifecycle_test.py
+++ b/unit_tests/test_zaza_charm_lifecycle_test.py
@@ -30,7 +30,9 @@ class TestCharmLifecycleTest(ut_utils.BaseTestCase):
             ['test_class1', 'test_class2'])
 
     def test_parser(self):
-        args = lc_test.parse_args(['-t', 'my.test_class1', 'my.test_class2'])
+        args = lc_test.parse_args(
+            ['-m', 'modelname', '-t', 'my.test_class1', 'my.test_class2'])
         self.assertEqual(
             args.tests,
             ['my.test_class1', 'my.test_class2'])
+        self.assertEqual(args.model_name, 'modelname')

--- a/zaza/charm_lifecycle/configure.py
+++ b/zaza/charm_lifecycle/configure.py
@@ -1,3 +1,4 @@
+import asyncio
 import argparse
 import logging
 import sys
@@ -16,11 +17,12 @@ def run_configure_list(functions):
         utils.get_class(func)()
 
 
-def configure(functions):
+def configure(model_name, functions):
     """Run all post-deployment configuration steps
 
     :param functions: List of configure functions functions
     :type tests: ['zaza.charms_tests.svc.setup', ...]"""
+    utils.set_juju_model(model_name)
     run_configure_list(functions)
 
 
@@ -36,6 +38,8 @@ def parse_args(args):
     parser.add_argument('-c', '--configfuncs', nargs='+',
                         help='Space sperated list of config functions',
                         required=False)
+    parser.add_argument('-m', '--model-name', help='Name of model to remove',
+                        required=True)
     return parser.parse_args(args)
 
 
@@ -46,4 +50,5 @@ def main():
     logging.basicConfig(level=logging.INFO)
     args = parse_args(sys.argv[1:])
     funcs = args.configfuncs or utils.get_charm_config()['configure']
-    configure(funcs)
+    configure(args.model_name, funcs)
+    asyncio.get_event_loop().close()

--- a/zaza/charm_lifecycle/deploy.py
+++ b/zaza/charm_lifecycle/deploy.py
@@ -60,4 +60,4 @@ def main():
     """Deploy bundle"""
     logging.basicConfig(level=logging.INFO)
     args = parse_args(sys.argv[1:])
-    deploy_bundle(args.bundle, args.model, wait=args.wait)
+    deploy(args.bundle, args.model, wait=args.wait)

--- a/zaza/charm_lifecycle/func_test_runner.py
+++ b/zaza/charm_lifecycle/func_test_runner.py
@@ -1,4 +1,6 @@
+import asyncio
 import datetime
+import logging
 import os
 
 import zaza.charm_lifecycle.configure as configure
@@ -35,4 +37,6 @@ def func_test_runner():
 
 
 def main():
+    logging.basicConfig(level=logging.INFO)
     func_test_runner()
+    asyncio.get_event_loop().close()

--- a/zaza/charm_lifecycle/func_test_runner.py
+++ b/zaza/charm_lifecycle/func_test_runner.py
@@ -27,9 +27,9 @@ def func_test_runner():
             os.path.join(utils.BUNDLE_DIR, '{}.yaml'.format(t)),
             model_name)
         # Configure
-        configure.configure(test_config['configure'])
+        configure.configure(model_name, test_config['configure'])
         # Test
-        test.test(test_config['tests'])
+        test.test(model_name, test_config['tests'])
         # Destroy
         destroy.destroy(model_name)
 

--- a/zaza/charm_lifecycle/test.py
+++ b/zaza/charm_lifecycle/test.py
@@ -1,3 +1,4 @@
+import asyncio
 import argparse
 import logging
 import unittest
@@ -20,8 +21,9 @@ def run_test_list(tests):
         assert test_result.wasSuccessful(), "Test run failed"
 
 
-def test(tests):
+def test(model_name, tests):
     """Run all steps to execute tests against the model"""
+    utils.set_juju_model(model_name)
     run_test_list(tests)
 
 
@@ -37,6 +39,8 @@ def parse_args(args):
     parser.add_argument('-t', '--tests', nargs='+',
                         help='Space sperated list of test classes',
                         required=False)
+    parser.add_argument('-m', '--model-name', help='Name of model to remove',
+                        required=True)
     return parser.parse_args(args)
 
 
@@ -46,4 +50,5 @@ def main():
     logging.basicConfig(level=logging.INFO)
     args = parse_args(sys.argv[1:])
     tests = args.tests or utils.get_charm_config()['tests']
-    test(tests)
+    test(args.model_name, tests)
+    asyncio.get_event_loop().close()

--- a/zaza/charm_lifecycle/utils.py
+++ b/zaza/charm_lifecycle/utils.py
@@ -1,4 +1,5 @@
 import importlib
+import os
 import yaml
 
 BUNDLE_DIR = "./tests/bundles/"
@@ -34,3 +35,21 @@ def get_class(class_str):
     class_name = class_str.split('.')[-1]
     module = importlib.import_module(module_name)
     return getattr(module, class_name)
+
+
+def set_juju_model(model_name):
+    """Point environment at the given model
+
+    :param model_name: Model to point environment at
+    :type model_name: str
+    """
+    os.environ["JUJU_MODEL"] = model_name
+
+
+def get_juju_model():
+    """Retrieve current model from environment
+
+    :returns: In focus model name
+    :rtype: str
+    """
+    return os.environ["JUJU_MODEL"]


### PR DESCRIPTION
Misc fixes to functional testing code

* Add calls to asyncio.get_event_loop().close() to close loop. libjuju does
  not do this for you and needs to be done just before exiting.
* Require model to be explicitly set when running command line tools. This is
  part of the drive to ensure that eventually multiple runs can be performed
  concurrently.
* Add set_juju_model/get_juju_model functions to manage which model is in
  focus
