### PR TITLE
Add support for running smoke tests

### DIFF
--- a/unit_tests/test_zaza_charm_lifecycle_func_test_runner.py
+++ b/unit_tests/test_zaza_charm_lifecycle_func_test_runner.py
@@ -7,10 +7,15 @@ import unit_tests.utils as ut_utils
 class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
 
     def test_parser(self):
-        args = lc_func_test_runner.parse_args(['--keep-model'])
-        self.assertTrue(args.keep_model)
+        # Test defaults
         args = lc_func_test_runner.parse_args([])
         self.assertFalse(args.keep_model)
+        self.assertFalse(args.smoke)
+        # Test flags
+        args = lc_func_test_runner.parse_args(['--keep-model'])
+        self.assertTrue(args.keep_model)
+        args = lc_func_test_runner.parse_args(['--smoke'])
+        self.assertTrue(args.smoke)
 
     def test_func_test_runner(self):
         self.patch_object(lc_func_test_runner.utils, 'get_charm_config')
@@ -59,3 +64,27 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
         self.configure.assert_has_calls(configure_calls)
         self.test.assert_has_calls(test_calls)
         self.destroy.assert_has_calls(destroy_calls)
+
+    def test_func_test_runner_smoke(self):
+        self.patch_object(lc_func_test_runner.utils, 'get_charm_config')
+        self.patch_object(lc_func_test_runner, 'generate_model_name')
+        self.patch_object(lc_func_test_runner.prepare, 'prepare')
+        self.patch_object(lc_func_test_runner.deploy, 'deploy')
+        self.patch_object(lc_func_test_runner.configure, 'configure')
+        self.patch_object(lc_func_test_runner.test, 'test')
+        self.patch_object(lc_func_test_runner.destroy, 'destroy')
+        self.generate_model_name.return_value = 'newmodel'
+        self.get_charm_config.return_value = {
+            'charm_name': 'mycharm',
+            'gate_bundles': ['bundle1', 'bundle2'],
+            'smoke_bundles': ['bundle2'],
+            'configure': [
+                'zaza.charm_tests.mycharm.setup.basic_setup'
+                'zaza.charm_tests.othercharm.setup.setup'],
+            'tests': [
+                'zaza.charm_tests.mycharm.tests.SmokeTest',
+                'zaza.charm_tests.mycharm.tests.ComplexTest']}
+        lc_func_test_runner.func_test_runner(smoke=True)
+        deploy_calls = [
+            mock.call('./tests/bundles/bundle2.yaml', 'newmodel')]
+        self.deploy.assert_has_calls(deploy_calls)

--- a/zaza/charm_lifecycle/README.md
+++ b/zaza/charm_lifecycle/README.md
@@ -117,12 +117,12 @@ optional arguments:
  * tox.ini should include a target like:
 
 ```
-[testenv:func3]
+[testenv:func]
 basepython = python3
 commands =
     functest-run-suite --keep-model
 
-[testenv:func3-smoke]
+[testenv:func-smoke]
 basepython = python3
 commands =
     functest-run-suite --keep-model --smoke

--- a/zaza/charm_lifecycle/README.md
+++ b/zaza/charm_lifecycle/README.md
@@ -117,10 +117,15 @@ optional arguments:
  * tox.ini should include a target like:
 
 ```
-[testenv:func35]
-  basepython = python3
-  commands =
-    functest-run-suite
+[testenv:func3]
+basepython = python3
+commands =
+    functest-run-suite --keep-model
+
+[testenv:func3-smoke]
+basepython = python3
+commands =
+    functest-run-suite --keep-model --smoke
 ```
 
  * Bundles which are to be used for the tests:
@@ -144,6 +149,8 @@ gate_bundles:
   - base-bionic
 dev_bundles:
   - base-xenial-ha
+smoke_bundles:
+  - base-bionic
 ```
 
 # Adding tests to zaza

--- a/zaza/charm_lifecycle/func_test_runner.py
+++ b/zaza/charm_lifecycle/func_test_runner.py
@@ -18,15 +18,22 @@ def generate_model_name(charm_name, bundle_name):
     return '{}{}{}'.format(charm_name, bundle_name, timestamp)
 
 
-def func_test_runner(keep_model=False):
+def func_test_runner(keep_model=False, smoke=False):
     """Deploy the bundles and run the tests as defined by the charms tests.yaml
 
     :param keep_model: Whether to destroy model at end of run
     :type keep_model: boolean
+    :param smoke: Whether to just run smoke test.
+    :type smoke: boolean
     """
     test_config = utils.get_charm_config()
-    last_test = test_config['gate_bundles'][-1]
-    for t in test_config['gate_bundles']:
+    if smoke:
+        bundle_key = 'smoke_bundles'
+    else:
+        bundle_key = 'gate_bundles'
+    bundles = test_config[bundle_key]
+    last_test = bundles[-1]
+    for t in bundles:
         model_name = generate_model_name(test_config['charm_name'], t)
         # Prepare
         prepare.prepare(model_name)
@@ -60,12 +67,15 @@ def parse_args(args):
     parser.add_argument('--keep-model', dest='keep_model',
                         help='Keep model at the end of the run',
                         action='store_true')
-    parser.set_defaults(keep_model=False)
+    parser.add_argument('--smoke', dest='smoke',
+                        help='Just run smoke test',
+                        action='store_true')
+    parser.set_defaults(keep_model=False, smoke=False)
     return parser.parse_args(args)
 
 
 def main():
     logging.basicConfig(level=logging.INFO)
     args = parse_args(sys.argv[1:])
-    func_test_runner(keep_model=args.keep_model)
+    func_test_runner(keep_model=args.keep_model, smoke=args.smoke)
     asyncio.get_event_loop().close()


### PR DESCRIPTION
Add --smoke switch to functest-run-suite to allow just the smoke
tests for a charm to be run. This requires that the smoke test
bundles are listed in the charms tests/tests.yaml