### PR TITLE
Fix juju wait to work against correct model

### DIFF
--- a/zaza/charm_lifecycle/deploy.py
+++ b/zaza/charm_lifecycle/deploy.py
@@ -5,6 +5,8 @@ import sys
 
 import juju_wait
 
+import zaza.charm_lifecycle.utils as utils
+
 
 def deploy_bundle(bundle, model):
     """Deploy the given bundle file in the specified model
@@ -31,6 +33,7 @@ def deploy(bundle, model, wait=True):
     deploy_bundle(bundle, model)
     if wait:
         logging.info("Waiting for environment to settle")
+        utils.set_juju_model(model)
         juju_wait.wait()
 
 


### PR DESCRIPTION
juju_wait assumes it is working against the current model so
explicitly set the JUJU_MODEL env variable before calling it
to ensure it monitors the correct environment