### PR TITLE
Allow quick development testing iterations 

### DIFF
--- a/zaza/charm_lifecycle/func_test_runner.py
+++ b/zaza/charm_lifecycle/func_test_runner.py
@@ -18,7 +18,8 @@ def generate_model_name(charm_name, bundle_name):
     return '{}{}{}'.format(charm_name, bundle_name, timestamp)
 
 
-def func_test_runner(keep_model=False, smoke=False):
+def func_test_runner(keep_model=False, smoke=False, destroy_model=True,
+                     deploy_model=True):
     """Deploy the bundles and run the tests as defined by the charms tests.yaml
 
     :param keep_model: Whether to destroy model at end of run
@@ -34,13 +35,17 @@ def func_test_runner(keep_model=False, smoke=False):
     bundles = test_config[bundle_key]
     last_test = bundles[-1]
     for t in bundles:
-        model_name = generate_model_name(test_config['charm_name'], t)
-        # Prepare
-        prepare.prepare(model_name)
-        # Deploy
-        deploy.deploy(
-            os.path.join(utils.BUNDLE_DIR, '{}.yaml'.format(t)),
-            model_name)
+        if destroy_model:
+            model_name = generate_model_name(test_config['charm_name'], t)
+            # Prepare
+            prepare.prepare(model_name)
+        else:
+            model_name = utils.get_juju_model()
+        if deploy_model:
+            # Deploy
+            deploy.deploy(
+                os.path.join(utils.BUNDLE_DIR, '{}.yaml'.format(t)),
+                model_name)
         # Configure
         configure.configure(model_name, test_config['configure'])
         # Test
@@ -70,12 +75,26 @@ def parse_args(args):
     parser.add_argument('--smoke', dest='smoke',
                         help='Just run smoke test',
                         action='store_true')
-    parser.set_defaults(keep_model=False, smoke=False)
+    parser.add_argument('--no-destroy',
+                        dest='destroy_model',
+                        help=('Do not destroy existing model '
+                              'before test run.'
+                              'For use during development'),
+                        action='store_false')
+    parser.add_argument('--no-deploy',
+                        dest='deploy_model',
+                        help=('Do not deploy model before test run. '
+                              'For use during development.'),
+                        action='store_false')
+    parser.set_defaults(keep_model=False, smoke=False,
+                        destroy_model=True, deploy_model=True)
     return parser.parse_args(args)
 
 
 def main():
     logging.basicConfig(level=logging.INFO)
     args = parse_args(sys.argv[1:])
-    func_test_runner(keep_model=args.keep_model, smoke=args.smoke)
+    func_test_runner(keep_model=args.keep_model, smoke=args.smoke,
+                     destroy_model=args.destroy_model,
+                     deploy_model=args.deploy_model)
     asyncio.get_event_loop().close()


### PR DESCRIPTION
Zaza should avoid the failures of the past. Namely, requiring a full
re-deploy for every test run. During development of the tests
themselves this causes painful turn around times.

This is trivially avoided by adding a couple of extra command line
switches to functest-run-suite.

--do-not-destroy-existing-model to avoid destroying what is already
deployed.
--do-not-deploy-model to avoid redeploying the existing model.

With these switches we can either upgrade-charm and change settings
with --do-not-destroy-existing-model alone or skip model setup entirely
with both --do-not-destroy-existing-model and --do-not-deploy-model.

The main question at hand is the confusion of the original switch
--keep-model which is intended for use for after the test suite runs.
Do we really need this at all? Should we just default to keeping the
model?

What other naming convention questions are there?