### PR TITLE
Stop missing overlay templates from being fatal

### DIFF
--- a/unit_tests/test_zaza_charm_lifecycle_deploy.py
+++ b/unit_tests/test_zaza_charm_lifecycle_deploy.py
@@ -82,6 +82,11 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
         handle = m()
         handle.write.assert_called_once_with('Template contents')
 
+    def test_render_overlay_no_template(self):
+        self.patch_object(lc_deploy, 'get_template')
+        self.get_template.return_value = None
+        self.assertIsNone(lc_deploy.render_overlay('mybundle.yaml', '/tmp/'))
+
     def test_render_overlays(self):
         RESP = {
             'local-charm-overlay.yaml': '/tmp/local-charm-overlay.yaml',

--- a/zaza/charm_lifecycle/deploy.py
+++ b/zaza/charm_lifecycle/deploy.py
@@ -107,6 +107,8 @@ def render_overlay(overlay_name, target_dir):
     :rtype: str
     """
     template = get_template(overlay_name)
+    if not template:
+        return
     rendered_template_file = os.path.join(
         target_dir,
         os.path.basename(overlay_name))


### PR DESCRIPTION
Not all deployments will use overlays so a missing template should
not be fatal