### PR TITLE
Add tests for vault authorize-charm action

### DIFF
--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -166,3 +166,12 @@ class TestModel(ut_utils.BaseTestCase):
         self.unit1.run_action.assert_called_once_with(
             'backup',
             backup_dir='/dev/null')
+
+    def test_get_actions(self):
+        self.patch_object(model.subprocess, 'check_output')
+        self.check_output.return_value = 'action: "action desc"'
+        self.assertEqual(
+            model.get_actions('mname', 'myapp'),
+            {'action': "action desc"})
+        self.check_output.assert_called_once_with(
+            ['juju', 'actions', '-m', 'mname', 'myapp', '--format', 'yaml'])

--- a/zaza/charm_tests/vault/utils.py
+++ b/zaza/charm_tests/vault/utils.py
@@ -200,3 +200,12 @@ def auth_all(clients, token):
     """
     for client in clients:
         client.hvac_client.token = token
+
+
+def run_charm_authorize(token):
+    unit = zaza.model.get_first_unit_name(utils.get_juju_model(), 'vault')
+    return zaza.model.run_action(
+        utils.get_juju_model(),
+        unit,
+        'authorize-charm',
+        action_params={'token': token})

--- a/zaza/model.py
+++ b/zaza/model.py
@@ -1,5 +1,7 @@
 import asyncio
 from async_generator import async_generator, yield_, asynccontextmanager
+import subprocess
+import yaml
 
 from juju import loop
 from juju.model import Model
@@ -360,6 +362,23 @@ async def async_run_action(model_name, unit_name, action_name,
         return action_obj
 
 run_action = sync_wrapper(async_run_action)
+
+
+def get_actions(model_name, application_name):
+    """Get the actions an applications supports
+
+    :param model_name: Name of model to query.
+    :type model_name: str
+    :param application_name: Name of application
+    :type application_name: str
+    :returns: Dictionary of actions and their descriptions
+    :rtype: dict
+    """
+    # libjuju has not implemented get_actions yet
+    # https://github.com/juju/python-libjuju/issues/226
+    cmd = ['juju', 'actions', '-m', model_name, application_name,
+           '--format', 'yaml']
+    return yaml.load(subprocess.check_output(cmd))
 
 
 def main():


### PR DESCRIPTION
Add tests for the authorize-charm action on the vault app. To
support this add get_action method to return an applications
actions. However, this is not implemented in libjuju yet so
fallback to subprocess