### PR TITLE
Use short model names

### DIFF
--- a/unit_tests/test_zaza_charm_lifecycle_func_test_runner.py
+++ b/unit_tests/test_zaza_charm_lifecycle_func_test_runner.py
@@ -7,8 +7,8 @@ import unit_tests.utils as ut_utils
 class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
 
     def test_generate_model_name(self):
-        mname = lc_func_test_runner.generate_model_name('mycharm', 'bundle')
-        self.assertTrue(mname.startswith('zaza-mycharmbundle'))
+        mname = lc_func_test_runner.generate_model_name()
+        self.assertTrue(mname.startswith('zaza-'))
 
     def test_parser(self):
         # Test defaults

--- a/unit_tests/test_zaza_charm_lifecycle_func_test_runner.py
+++ b/unit_tests/test_zaza_charm_lifecycle_func_test_runner.py
@@ -7,8 +7,10 @@ import unit_tests.utils as ut_utils
 class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
 
     def test_generate_model_name(self):
-        mname = lc_func_test_runner.generate_model_name()
-        self.assertTrue(mname.startswith('zaza-'))
+        self.patch_object(lc_func_test_runner.uuid, "uuid4")
+        self.uuid4.return_value = "longer-than-12characters"
+        self.assertEqual(lc_func_test_runner.generate_model_name(),
+                         "zaza-12characters")
 
     def test_parser(self):
         # Test defaults

--- a/zaza/charm_lifecycle/func_test_runner.py
+++ b/zaza/charm_lifecycle/func_test_runner.py
@@ -13,9 +13,9 @@ import zaza.charm_lifecycle.deploy as deploy
 import zaza.charm_lifecycle.test as test
 
 
-def generate_model_name(charm_name, bundle_name):
+def generate_model_name():
     timestamp = datetime.datetime.now().strftime('%Y%m%d%H%M%S')
-    return 'zaza-{}{}{}'.format(charm_name, bundle_name, timestamp)
+    return 'zaza-{}'.format(timestamp)
 
 
 def func_test_runner(keep_model=False, smoke=False):
@@ -34,7 +34,7 @@ def func_test_runner(keep_model=False, smoke=False):
     bundles = test_config[bundle_key]
     last_test = bundles[-1]
     for t in bundles:
-        model_name = generate_model_name(test_config['charm_name'], t)
+        model_name = generate_model_name()
         # Prepare
         prepare.prepare(model_name)
         # Deploy

--- a/zaza/charm_lifecycle/func_test_runner.py
+++ b/zaza/charm_lifecycle/func_test_runner.py
@@ -1,9 +1,9 @@
 import argparse
 import asyncio
-import datetime
 import logging
 import os
 import sys
+import uuid
 
 import zaza.charm_lifecycle.configure as configure
 import zaza.charm_lifecycle.destroy as destroy
@@ -14,8 +14,7 @@ import zaza.charm_lifecycle.test as test
 
 
 def generate_model_name():
-    timestamp = datetime.datetime.now().strftime('%Y%m%d%H%M%S')
-    return 'zaza-{}'.format(timestamp)
+    return 'zaza-{}'.format(str(uuid.uuid4())[-12:])
 
 
 def func_test_runner(keep_model=False, smoke=False):


### PR DESCRIPTION
Issue #34 Long model names cause OpenStack DNS to break. We gain fairly
little by stacking information in the model name.

This change uses zaza-$TIMESTAMP as model names.

Closes Issue: #34