### PR TITLE
Ensure we use default model constraints

### DIFF
--- a/unit_tests/test_zaza_charm_lifecycle_prepare.py
+++ b/unit_tests/test_zaza_charm_lifecycle_prepare.py
@@ -8,7 +8,17 @@ class TestCharmLifecyclePrepare(ut_utils.BaseTestCase):
         self.patch_object(lc_prepare.subprocess, 'check_call')
         lc_prepare.add_model('newmodel')
         self.check_call.assert_called_once_with(
-            ['juju', 'add-model', 'newmodel'])
+            [
+                'juju', 'add-model', 'newmodel',
+                '--config', 'agent-stream=proposed',
+                '--config', 'default-series=xenial',
+                '--config', 'image-stream=daily',
+                '--config', 'test-mode=true',
+                '--config', 'transmit-vendor-metrics=false',
+                '--config', 'enable-os-upgrade=false',
+                '--config', 'automatically-retry-hooks=false',
+                '--config', 'use-default-secgroup=true'
+            ])
 
     def test_prepare(self):
         self.patch_object(lc_prepare, 'add_model')

--- a/zaza/charm_lifecycle/prepare.py
+++ b/zaza/charm_lifecycle/prepare.py
@@ -4,6 +4,22 @@ import subprocess
 import sys
 
 
+MODEL_DEFAULTS = [
+    # Model defaults from charm-test-infra
+    #   https://jujucharms.com/docs/2.1/models-config
+    '--config', 'agent-stream=proposed',
+    '--config', 'default-series=xenial',
+    '--config', 'image-stream=daily',
+    '--config', 'test-mode=true',
+    '--config', 'transmit-vendor-metrics=false',
+    # https://bugs.launchpad.net/juju/+bug/1685351
+    # enable-os-refresh-update: false
+    '--config', 'enable-os-upgrade=false',
+    '--config', 'automatically-retry-hooks=false',
+    '--config', 'use-default-secgroup=true',
+]
+
+
 def add_model(model_name):
     """Add a model with the given name
 
@@ -11,7 +27,7 @@ def add_model(model_name):
     :type bundle: str
     """
     logging.info("Adding model {}".format(model_name))
-    subprocess.check_call(['juju', 'add-model', model_name])
+    subprocess.check_call(['juju', 'add-model', model_name] + MODEL_DEFAULTS)
 
 
 def prepare(model_name):


### PR DESCRIPTION
Models which are created by Zaza should enable test mode,
to prevent artificially ticking metrics in the charm store for charm usage.

In addition, models must not retry failed hooks as we
consider a hook failure to be an error.

Closes #33