### PR TITLE
Vault charm action needs to be run on leader

### DIFF
--- a/zaza/charm_tests/vault/utils.py
+++ b/zaza/charm_tests/vault/utils.py
@@ -203,9 +203,8 @@ def auth_all(clients, token):
 
 
 def run_charm_authorize(token):
-    unit = zaza.model.get_first_unit_name(utils.get_juju_model(), 'vault')
-    return zaza.model.run_action(
+    return zaza.model.run_action_on_leader(
         utils.get_juju_model(),
-        unit,
+        'vault',
         'authorize-charm',
         action_params={'token': token})

--- a/zaza/model.py
+++ b/zaza/model.py
@@ -366,7 +366,7 @@ run_action = sync_wrapper(async_run_action)
 
 async def async_run_action_on_leader(model_name, application_name, action_name,
                                      action_params=None):
-    """Run action on given unit
+    """Run action on lead unit of the given application
 
     :param model_name: Name of model to query.
     :type model_name: str

--- a/zaza/model.py
+++ b/zaza/model.py
@@ -364,6 +364,33 @@ async def async_run_action(model_name, unit_name, action_name,
 run_action = sync_wrapper(async_run_action)
 
 
+async def async_run_action_on_leader(model_name, application_name, action_name,
+                                     action_params=None):
+    """Run action on given unit
+
+    :param model_name: Name of model to query.
+    :type model_name: str
+    :param application_name: Name of application
+    :type application_name: str
+    :param action_name: Name of action to run
+    :type action_name: str
+    :param action_params: Dictionary of config options for action
+    :type action_params: dict
+    :returns: Action object
+    :rtype: juju.action.Action
+    """
+    async with run_in_model(model_name) as model:
+        for unit in model.applications[application_name].units:
+            is_leader = await unit.is_leader_from_status()
+            if is_leader:
+                action_obj = await unit.run_action(action_name,
+                                                   **action_params)
+                await action_obj.wait()
+                return action_obj
+
+run_action_on_leader = sync_wrapper(async_run_action_on_leader)
+
+
 def get_actions(model_name, application_name):
     """Get the actions an applications supports
 


### PR DESCRIPTION
The vault charm action to authorise the charm within vault needs to
be run on the leader. This mp adds run_action_on_leader to support
that and updates the tests.