### PR TITLE
Fix race in checking deployment complete

### DIFF
--- a/zaza/model.py
+++ b/zaza/model.py
@@ -510,6 +510,10 @@ async def async_wait_for_application_states(model_name, states=None,
         states = {}
     async with run_in_model(model_name) as model:
         check_model_for_hard_errors(model)
+        logging.info("Waiting for a unit to appear")
+        await model.block_until(
+            lambda: len(model.units) > 0
+        )
         logging.info("Waiting for all units to be idle")
         await model.block_until(
             lambda: model.all_units_idle(), timeout=timeout)


### PR DESCRIPTION
If the deployment state is assessed before any units have been
provisioned then the checks passes as there are no active units
or units with bad states etc. So, wait for at least one unit to
be provisioned before running checks