### PR TITLE
Rename get_net_info to get_network_config

### DIFF
--- a/unit_tests/utilitites/test_zaza_utilitites_local_utils.py
+++ b/unit_tests/utilitites/test_zaza_utilitites_local_utils.py
@@ -56,7 +56,7 @@ class TestLocalUtils(ut_utils.BaseTestCase):
         self.assertEqual(_local_utils.get_undercloud_env_vars(),
                          _expected_result)
 
-    def test_get_net_info(self):
+    def test_get_network_config(self):
         self.patch_object(_local_utils.os.path, "exists")
         self.patch_object(_local_utils, "get_yaml_config")
         self.patch_object(_local_utils, "get_undercloud_env_vars")
@@ -67,12 +67,13 @@ class TestLocalUtils(ut_utils.BaseTestCase):
         # YAML file does not exist
         self.exists.return_value = False
         with self.assertRaises(Exception):
-            _local_utils.get_net_info(net_topology)
+            _local_utils.get_network_config(net_topology)
 
         # No environmental variables
         self.exists.return_value = True
         self.assertEqual(
-            _local_utils.get_net_info(net_topology, ignore_env_vars=True),
+            _local_utils.get_network_config(net_topology,
+                                            ignore_env_vars=True),
             _data[net_topology])
         self.get_yaml_config.assert_called_once_with("network.yaml")
         self.get_undercloud_env_vars.assert_not_called()
@@ -83,6 +84,6 @@ class TestLocalUtils(ut_utils.BaseTestCase):
         self.get_undercloud_env_vars.return_value = _more_data
         _data[net_topology].update(_more_data)
         self.assertEqual(
-            _local_utils.get_net_info(net_topology),
+            _local_utils.get_network_config(net_topology),
             _data[net_topology])
         self.get_undercloud_env_vars.assert_called_once_with()

--- a/zaza/utilities/_local_utils.py
+++ b/zaza/utilities/_local_utils.py
@@ -111,8 +111,8 @@ def get_yaml_config(config_file):
     return yaml.load(open(config_file, 'r').read())
 
 
-def get_net_info(net_topology, ignore_env_vars=False,
-                 net_topology_file="network.yaml"):
+def get_network_config(net_topology, ignore_env_vars=False,
+                       net_topology_file="network.yaml"):
     """Get network info from network.yaml, override the values if specific
     environment variables are set for the undercloud.
 


### PR DESCRIPTION
The configure.network script had already made this change. Using
run_from_cli ran into the fact that it was not changed in
utilities._local_utils.

Update for consistency.