### PR TITLE
Add tests for testing the glance charm

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,10 @@ install_require = [
     'juju-wait',
     'PyYAML',
     'tenacity',
+    'oslo.config',
+    'python-keystoneclient',
+    'python-novaclient',
+    'python-neutronclient',
 ]
 
 tests_require = [

--- a/unit_tests/utilities/test_zaza_utilities_openstack.py
+++ b/unit_tests/utilities/test_zaza_utilities_openstack.py
@@ -307,7 +307,7 @@ class TestOpenStackUtils(ut_utils.BaseTestCase):
             self.resource_reaches_status.assert_called_once_with(
                 glance_mock.images,
                 '9d1125af',
-                expected_stat='active',
+                expected_status='active',
                 msg='Image status wait')
 
     def test_create_image(self):

--- a/zaza/charm_tests/glance/setup.py
+++ b/zaza/charm_tests/glance/setup.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+
+
+def basic_setup():
+    """Glance setup for testing glance is currently part of glance functional
+       tests. Image setup for other tests to use should go here"""
+    pass

--- a/zaza/charm_tests/glance/tests.py
+++ b/zaza/charm_tests/glance/tests.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+
+import logging
+
+import zaza.utilities.openstack as openstack_utils
+import zaza.charm_tests.test_utils as test_utils
+
+
+class GlanceTest(test_utils.OpenStackAPITest):
+
+    @classmethod
+    def setUpClass(cls):
+        super(GlanceTest, cls).setUpClass()
+        cls.glance_client = openstack_utils.get_glance_session_client(
+            cls.keystone_session)
+
+    def test_410_glance_image_create_delete(self):
+        """Create an image and then delete it"""
+        image_url = openstack_utils.find_cirros_image(arch='x86_64')
+        image = openstack_utils.create_image(
+            self.glance_client,
+            image_url,
+            'cirrosimage')
+        openstack_utils.delete_image(self.glance_client, image.id)
+
+    def test_411_set_disk_format(self):
+        """Change disk format and assert then change propagates to the correct
+           file and that services are restarted as a result"""
+        # Expected default and alternate values
+        set_default = {
+            'disk-formats': 'ami,ari,aki,vhd,vmdk,raw,qcow2,vdi,iso,root-tar'}
+        set_alternate = {'disk-formats': 'qcow2'}
+
+        # Config file affected by juju set config change
+        conf_file = '/etc/glance/glance-api.conf'
+
+        # Make config change, check for service restarts
+        logging.debug('Setting disk format glance...')
+        self.restart_on_changed(
+            conf_file,
+            set_default,
+            set_alternate,
+            {'image_format': {
+                'disk_formats': [
+                    'ami,ari,aki,vhd,vmdk,raw,qcow2,vdi,iso,root-tar']}},
+            {'image_format': {'disk_formats': ['qcow2']}},
+            ['glance-api'])
+
+    def test_901_pause_resume(self):
+        """Pause service and check services are stopped then resume and check
+           they are started"""
+        self.pause_resume(['glance-api'])

--- a/zaza/charm_tests/glance/tests.py
+++ b/zaza/charm_tests/glance/tests.py
@@ -6,7 +6,7 @@ import zaza.utilities.openstack as openstack_utils
 import zaza.charm_tests.test_utils as test_utils
 
 
-class GlanceTest(test_utils.OpenStackAPITest):
+class GlanceTest(test_utils.OpenStackBaseTest):
 
     @classmethod
     def setUpClass(cls):

--- a/zaza/charm_tests/test_utils.py
+++ b/zaza/charm_tests/test_utils.py
@@ -1,13 +1,18 @@
 import logging
+import unittest
 import zaza.model
 
-import zaza.charm_lifecycle.utils as utils
+import zaza.model as model
+import zaza.charm_lifecycle.utils as lifecycle_utils
+import zaza.utilities.openstack as openstack_utils
 
 
 def skipIfNotHA(service_name):
     def _skipIfNotHA_inner_1(f):
         def _skipIfNotHA_inner_2(*args, **kwargs):
-            ips = zaza.model.get_app_ips(utils.get_juju_model(), service_name)
+            ips = zaza.model.get_app_ips(
+                lifecycle_utils.get_juju_model(),
+                service_name)
             if len(ips) > 1:
                 return f(*args, **kwargs)
             else:
@@ -16,3 +21,136 @@ def skipIfNotHA(service_name):
         return _skipIfNotHA_inner_2
 
     return _skipIfNotHA_inner_1
+
+
+class OpenStackAPITest(unittest.TestCase):
+    """Generic helpers for testing OpenStack API charms"""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.keystone_session = openstack_utils.get_overcloud_keystone_session()
+        cls.model_name = lifecycle_utils.get_juju_model()
+        cls.test_config = lifecycle_utils.get_charm_config()
+        cls.application_name = cls.test_config['charm_name']
+
+    def restart_on_changed(self, config_file, default_config, alternate_config,
+                           default_entry, alternate_entry, services):
+        """Test that changing config results in config file being updates and
+           services restarted. Return config to default_config afterwards
+
+        :param config_file: Config file to check for settings
+        :type config_file: str
+        :param default_config: Dict of charm settings to set on completion
+        :type default_config: dict
+        :param alternate_config: Dict of charm settings to change to
+        :type alternate_config: dict
+        :param default_entry: Config file entries that correspond to
+                              default_config
+        :type default_entry: dict
+        :param alternate_entry: Config file entries that correspond to
+        :type alternate_entry: alternate_config
+        :param services: Services expected to be restarted when config_file is
+                         changed.
+        :type services: list
+        """
+        # first_unit is only useed to grab a timestamp, the assumption being
+        # that all the units times are in sync.
+        first_unit = model.get_first_unit_name(
+            self.model_name,
+            self.application_name)
+        logging.debug('First unit is {}'.format(first_unit))
+
+        mtime = model.get_unit_time(self.model_name, first_unit)
+        logging.debug('Remote unit timestamp {}'.format(mtime))
+
+        logging.debug('Changing charm setting to {}'.format(alternate_config))
+        model.set_application_config(
+            self.model_name,
+            self.application_name,
+            alternate_config)
+
+        logging.debug(
+            'Waiting for updates to propagate to {}'.format(config_file))
+        model.block_until_oslo_config_entries_match(
+            self.model_name,
+            self.application_name,
+            config_file,
+            alternate_entry)
+
+        logging.debug(
+            'Waiting for units to reach target states'.format(config_file))
+        model.wait_for_application_states(
+            self.model_name,
+            self.test_config.get('target_deploy_status', {}))
+
+        # Config update has occured and hooks are idle. Any services should
+        # have been restarted by now:
+        logging.debug(
+            'Waiting for services ({}) to be restarted'.format(services))
+        model.block_until_services_restarted(
+            self.model_name,
+            self.application_name,
+            mtime,
+            services)
+
+        logging.debug('Restoring charm setting to {}'.format(default_config))
+        model.set_application_config(
+            self.model_name,
+            self.application_name,
+            default_config)
+
+        logging.debug(
+            'Waiting for updates to propagate to '.format(config_file))
+        model.block_until_oslo_config_entries_match(
+            self.model_name,
+            self.application_name,
+            config_file,
+            default_entry)
+
+        logging.debug(
+            'Waiting for units to reach target states'.format(config_file))
+        model.wait_for_application_states(
+            self.model_name,
+            self.test_config.get('target_deploy_status', {}))
+
+    def pause_resume(self, services):
+        """Pause and then resume a unit checking that services are in the
+           required state after each action
+
+        :param services: Services expected to be restarted when config_file is
+                         changed.
+        :type services: list
+        """
+        first_unit = model.get_first_unit_name(
+            self.model_name,
+            self.application_name)
+        model.block_until_service_status(
+            self.model_name,
+            first_unit,
+            services,
+            'running')
+        model.block_until_unit_wl_status(
+            self.model_name,
+            first_unit,
+            'active')
+        model.run_action(self.model_name, first_unit, 'pause', {})
+        model.block_until_unit_wl_status(
+            self.model_name,
+            first_unit,
+            'maintenance')
+        model.block_until_all_units_idle(self.model_name)
+        model.block_until_service_status(
+            self.model_name,
+            first_unit,
+            services,
+            'stopped')
+        model.run_action(self.model_name, first_unit, 'resume', {})
+        model.block_until_unit_wl_status(
+            self.model_name,
+            first_unit,
+            'active')
+        model.block_until_all_units_idle(self.model_name)
+        model.block_until_service_status(
+            self.model_name,
+            first_unit, services,
+            'running')

--- a/zaza/utilities/openstack.py
+++ b/zaza/utilities/openstack.py
@@ -1440,7 +1440,7 @@ def upload_image_to_glance(glance, local_path, image_name, disk_format='qcow2',
     resource_reaches_status(
         glance.images,
         image.id,
-        expected_stat='active',
+        expected_status='active',
         msg='Image status wait')
 
     return image


### PR DESCRIPTION
* Add OpenStackAPITest class which can be used by OpenStack API
  charms. It provides the framework for common tests like pause
  and resume. It also provides lower level entites like an
  authenticated keystone session.
* Add generic openstack resource managment functions to
  zaza.utilities.openstack. These are based on existing functions
  in charmhelpers. Main difference is that they use tenacity to
  manage retry logic and throw AssertionError if then required state
  is not reached rather than returning True/False
* Add image management functions to zaza.utilities.openstack.
* Add set of glance setup/configuration/tests. These are equivalent
  to the existing glance amulet tests with all the introspection
  tests removed (see below for more detail).

Tests replicated here:
    test_410_glance_image_create_delete
    test_411_set_disk_format
    test_900_glance_restart_on_config_change
    test_901_pause_resume

Tests removed
    test_100_services
    test_102_service_catalog
    test_104_glance_endpoint
    test_106_keystone_endpoint
    test_110_users
    test_115_memcache
    test_200_mysql_glance_db_relation
    test_201_glance_mysql_db_relation
    test_202_keystone_glance_id_relation
    test_203_glance_keystone_id_relation
    test_204_rabbitmq_glance_amqp_relation
    test_205_glance_rabbitmq_amqp_relation
    test_300_glance_api_default_config
    test_302_glance_registry_default_config