### PR TITLE
Remove workaround for libjuju timeout bug

### DIFF
--- a/zaza/model.py
+++ b/zaza/model.py
@@ -161,18 +161,11 @@ async def async_run_on_unit(model_name, unit_name, command, timeout=None):
     :type unit: str
     :param command: Command to execute
     :type command: str
-    :param timeout: DISABLED due to Issue #225
-                    https://github.com/juju/python-libjuju/issues/225
+    :param timeout: How long in seconds to wait for command to complete
     :type timeout: int
     :returns: action.data['results'] {'Code': '', 'Stderr': '', 'Stdout': ''}
     :rtype: dict
     """
-
-    # Disabling timeout due to Issue #225
-    # https://github.com/juju/python-libjuju/issues/225
-    if timeout:
-        timeout = None
-
     async with run_in_model(model_name) as model:
         unit = get_unit_from_name(unit_name, model)
         action = await unit.run(command, timeout=timeout)


### PR DESCRIPTION
The timeout bug for libjuju run has been resolved:

https://github.com/juju/python-libjuju/commit/462989bbd919f209ebb7454305f53e4b94714487

so remove workaround.