### PR TITLE
Remove duplicate functions for add/remove model

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -4,6 +4,7 @@ Utilities API documentation
 
 .. toctree::
 
+    controller-api
     model-api
     openstack-utils
     tls-cert-utils

--- a/doc/source/controller-api.rst
+++ b/doc/source/controller-api.rst
@@ -1,0 +1,5 @@
+Juju Controller
+---------------
+
+.. automodule:: zaza.controller
+   :members:

--- a/unit_tests/test_zaza_charm_lifecycle_destroy.py
+++ b/unit_tests/test_zaza_charm_lifecycle_destroy.py
@@ -5,7 +5,7 @@ import unit_tests.utils as ut_utils
 class TestCharmLifecycleDestroy(ut_utils.BaseTestCase):
 
     def test_destroy(self):
-        self.patch_object(lc_destroy.zaza.model, 'destroy_model')
+        self.patch_object(lc_destroy.zaza.controller, 'destroy_model')
         lc_destroy.destroy('doomed')
         self.destroy_model.assert_called_once_with('doomed')
 

--- a/unit_tests/test_zaza_charm_lifecycle_prepare.py
+++ b/unit_tests/test_zaza_charm_lifecycle_prepare.py
@@ -5,7 +5,7 @@ import unit_tests.utils as ut_utils
 class TestCharmLifecyclePrepare(ut_utils.BaseTestCase):
 
     def test_prepare(self):
-        self.patch_object(lc_prepare.zaza.model, 'add_model')
+        self.patch_object(lc_prepare.zaza.controller, 'add_model')
         lc_prepare.prepare('newmodel')
         self.add_model.assert_called_once_with(
             'newmodel',

--- a/unit_tests/test_zaza_controller.py
+++ b/unit_tests/test_zaza_controller.py
@@ -19,7 +19,7 @@ class TestController(ut_utils.BaseTestCase):
         async def _list_models():
             return self.models
 
-        async def _add_model(model_name):
+        async def _add_model(model_name, config=None):
             return self.model1
 
         async def _destroy_model(model_name):
@@ -59,7 +59,19 @@ class TestController(ut_utils.BaseTestCase):
         self.assertEqual(controller.add_model(self.model1.info.name),
                          self.model1.info.name)
         self.Controller_mock.add_model.assert_called_once_with(
+            self.model1.info.name,
+            config=None)
+        self.model1.connect.assert_called_once()
+
+    def test_add_model_config(self):
+        self.assertEqual(
+            controller.add_model(
+                self.model1.info.name,
+                {'run-faster': 'true'}),
             self.model1.info.name)
+        self.Controller_mock.add_model.assert_called_once_with(
+            self.model1.info.name,
+            config={'run-faster': 'true'})
         self.model1.connect.assert_called_once()
 
     def test_destroy_model(self):

--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -123,31 +123,6 @@ class TestModel(ut_utils.BaseTestCase):
         self.Controller_mock.add_model.side_effect = _ctrl_add_model
         self.Controller_mock.destroy_models.side_effect = _ctrl_destroy_models
 
-    def test_add_model(self):
-        self.patch_object(model, 'Controller')
-        self.Controller.return_value = self.Controller_mock
-        model.add_model('newmodel')
-        self.Controller_mock.connect.assert_called_once_with()
-        self.Controller_mock.add_model.assert_called_once_with(
-            'newmodel',
-            config=None)
-
-    def test_add_model_config(self):
-        self.patch_object(model, 'Controller')
-        self.Controller.return_value = self.Controller_mock
-        model.add_model('newmodel', config={'run-faster': 'true'})
-        self.Controller_mock.connect.assert_called_once_with()
-        self.Controller_mock.add_model.assert_called_once_with(
-            'newmodel',
-            config={'run-faster': 'true'})
-
-    def test_destroy_model(self):
-        self.patch_object(model, 'Controller')
-        self.Controller.return_value = self.Controller_mock
-        model.destroy_model('newmodel')
-        self.Controller_mock.connect.assert_called_once_with()
-        self.Controller_mock.destroy_models.assert_called_once_with('newmodel')
-
     def test_run_in_model(self):
         self.patch_object(model, 'Model')
         self.Model.return_value = self.Model_mock

--- a/zaza/charm_lifecycle/destroy.py
+++ b/zaza/charm_lifecycle/destroy.py
@@ -2,7 +2,7 @@ import argparse
 import logging
 import sys
 
-import zaza.model
+import zaza.controller
 
 
 def destroy(model_name):
@@ -11,7 +11,7 @@ def destroy(model_name):
     :param model: Name of model to remove
     :type bundle: str
     """
-    zaza.model.destroy_model(model_name)
+    zaza.controller.destroy_model(model_name)
 
 
 def parse_args(args):

--- a/zaza/charm_lifecycle/prepare.py
+++ b/zaza/charm_lifecycle/prepare.py
@@ -2,7 +2,7 @@ import argparse
 import logging
 import sys
 
-import zaza.model
+import zaza.controller
 
 MODEL_DEFAULTS = {
     # Model defaults from charm-test-infra
@@ -26,7 +26,7 @@ def prepare(model_name):
     :param model: Name of model to add
     :type bundle: str
     """
-    zaza.model.add_model(model_name, config=MODEL_DEFAULTS)
+    zaza.controller.add_model(model_name, config=MODEL_DEFAULTS)
 
 
 def parse_args(args):

--- a/zaza/controller.py
+++ b/zaza/controller.py
@@ -3,11 +3,17 @@ from juju.controller import Controller
 from zaza import sync_wrapper
 
 
-async def async_add_model(model_name):
+async def async_add_model(model_name, config=None):
+    """Add a model to the current controller
+
+    :param model_name: Name to give the new model.
+    :type model_name: str
+    :param config: Model configuration.
+    :type config: dict"""
     controller = Controller()
     await controller.connect()
     logging.debug("Adding model {}".format(model_name))
-    model = await controller.add_model(model_name)
+    model = await controller.add_model(model_name, config=config)
     await model.connect()
     model_name = model.info.name
     await model.disconnect()
@@ -18,6 +24,10 @@ add_model = sync_wrapper(async_add_model)
 
 
 async def async_destroy_model(model_name):
+    """Remove a model from the current controller
+
+    :param model_name: Name of model to remove
+    :type model_name: str"""
     controller = Controller()
     await controller.connect()
     logging.debug("Destroying model {}".format(model_name))
@@ -28,6 +38,11 @@ destroy_model = sync_wrapper(async_destroy_model)
 
 
 async def async_get_cloud():
+    """Return the name of the current cloud
+
+    :returns: Name of cloud
+    :rtype: str
+    """
     controller = Controller()
     await controller.connect()
     cloud = await controller.get_cloud()
@@ -38,6 +53,11 @@ get_cloud = sync_wrapper(async_get_cloud)
 
 
 async def async_list_models():
+    """Return a list of tha available clouds
+
+    :returns: List of clouds
+    :rtype: list
+    """
     controller = Controller()
     await controller.connect()
     models = await controller.list_models()

--- a/zaza/model.py
+++ b/zaza/model.py
@@ -8,37 +8,10 @@ import yaml
 from oslo_config import cfg
 
 from juju import loop
-from juju.controller import Controller
 from juju.errors import JujuError
 from juju.model import Model
 
 from zaza import sync_wrapper
-
-
-async def async_add_model(model_name, config=None):
-    """Add a model to the current controller
-
-    :param model_name: Name to give the new model.
-    :type model_name: str
-    :param config: Model configuration.
-    :type config: dict"""
-    controller = Controller()
-    await controller.connect()
-    await controller.add_model(model_name, config=config)
-
-add_model = sync_wrapper(async_add_model)
-
-
-async def async_destroy_model(model_name):
-    """Remove a model from the current controller
-
-    :param model_name: Name of model to remove
-    :type model_name: str"""
-    controller = Controller()
-    await controller.connect()
-    await controller.destroy_models(model_name)
-
-destroy_model = sync_wrapper(async_destroy_model)
 
 
 async def deployed(filter=None):


### PR DESCRIPTION
Recently functions were added to zaza.model for adding and removing
models. These duplicated existing functions in zaza.controller.
Given these functions act against the controller, zaza.controller
feels like the correct location. In addition the implementations in
zaza.controller correctly handle disconnects which the new ones
did not.
This PR removes the duplicates and points any existing references
from zaza.model to zaza.controller. Finally, docstrings were added
and documentation links.