### PR TITLE
Doc strings for unit tests & gate on docs strings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ juju
 juju_wait
 PyYAML
 flake8>=2.2.4,<=3.5.0
+flake8-docstrings
 mock>=1.2
 nose>=1.3.7
 pbr>=1.8.0,<1.9.0

--- a/unit_tests/__init__.py
+++ b/unit_tests/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for zaza."""

--- a/unit_tests/test_zaza_charm_lifecycle_configure.py
+++ b/unit_tests/test_zaza_charm_lifecycle_configure.py
@@ -1,3 +1,4 @@
+"""Module containing unit tests for zaza.charm_lifecycle.configure."""
 import mock
 
 import zaza.charm_lifecycle.configure as lc_configure
@@ -5,8 +6,10 @@ import unit_tests.utils as ut_utils
 
 
 class TestCharmLifecycleConfigure(ut_utils.BaseTestCase):
+    """Unit tests for zaza.charm_lifecycle.configure."""
 
     def test_run_configure_list(self):
+        """Test run_configure_list."""
         self.patch_object(lc_configure.utils, 'get_class')
         self.get_class.side_effect = lambda x: x
         mock1 = mock.MagicMock()
@@ -16,6 +19,7 @@ class TestCharmLifecycleConfigure(ut_utils.BaseTestCase):
         self.assertTrue(mock2.called)
 
     def test_configure(self):
+        """Test configure."""
         self.patch_object(lc_configure, 'run_configure_list')
         mock1 = mock.MagicMock()
         mock2 = mock.MagicMock()
@@ -23,6 +27,7 @@ class TestCharmLifecycleConfigure(ut_utils.BaseTestCase):
         self.run_configure_list.assert_called_once_with([mock1, mock2])
 
     def test_parser(self):
+        """Test parse_args."""
         args = lc_configure.parse_args(
             ['-m', 'modelname', '-c', 'my.func1', 'my.func2'])
         self.assertEqual(args.configfuncs, ['my.func1', 'my.func2'])

--- a/unit_tests/test_zaza_charm_lifecycle_deploy.py
+++ b/unit_tests/test_zaza_charm_lifecycle_deploy.py
@@ -1,3 +1,4 @@
+"""Module containing unit tests for zaza.charm_lifecycle.deploy."""
 import jinja2
 import mock
 
@@ -6,8 +7,10 @@ import unit_tests.utils as ut_utils
 
 
 class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
+    """Unit tests for zaza.charm_lifecycle.deploy."""
 
     def test_is_valid_env_key(self):
+        """Test is_valid_env_key for different env vars."""
         self.assertTrue(lc_deploy.is_valid_env_key('OS_VIP04'))
         self.assertTrue(lc_deploy.is_valid_env_key('FIP_RANGE'))
         self.assertTrue(lc_deploy.is_valid_env_key('GATEWAY'))
@@ -19,6 +22,7 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
         self.assertFalse(lc_deploy.is_valid_env_key('PATH'))
 
     def test_get_template_context_from_env(self):
+        """Test get_template_context_from_env."""
         self.patch_object(lc_deploy.os, 'environ')
         self.environ.items.return_value = [
             ('AMULET_OS_VIP', '10.10.0.2'),
@@ -31,6 +35,7 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
         )
 
     def test_get_charm_config_context(self):
+        """Test get_charm_config_context."""
         self.patch_object(lc_deploy.utils, 'get_charm_config')
         self.get_charm_config.return_value = {
             'charm_name': 'mycharm'}
@@ -39,6 +44,7 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
             {'charm_location': '../../../mycharm', 'charm_name': 'mycharm'})
 
     def test_get_template_overlay_context(self):
+        """Test get_template_overlay_context."""
         self.patch_object(lc_deploy, 'get_template_context_from_env')
         self.patch_object(lc_deploy, 'get_charm_config_context')
         self.get_template_context_from_env.return_value = {
@@ -54,11 +60,13 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
                 'charm_name': 'mycharm'})
 
     def test_get_overlay_template_dir(self):
+        """Test get_overlay_template_dir."""
         self.assertEqual(
             lc_deploy.get_overlay_template_dir(),
             'tests/bundles/overlays')
 
     def test_get_jinja2_env(self):
+        """Test get_jinja2_env."""
         self.patch_object(lc_deploy, 'get_overlay_template_dir')
         self.get_overlay_template_dir.return_value = 'mytemplatedir'
         self.patch_object(lc_deploy.jinja2, 'Environment')
@@ -71,11 +79,13 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
         self.FileSystemLoader.assert_called_once_with('mytemplatedir')
 
     def test_get_template_name(self):
+        """Test get_template_name."""
         self.assertEqual(
             lc_deploy.get_template_name('mybundles/mybundle.yaml'),
             'mybundle.yaml.j2')
 
     def test_get_template(self):
+        """Test get_template."""
         self.patch_object(lc_deploy, 'get_jinja2_env')
         jinja_env_mock = mock.MagicMock()
         self.get_jinja2_env.return_value = jinja_env_mock
@@ -85,6 +95,7 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
             'mytemplate')
 
     def test_get_template_missing_template(self):
+        """Test get_template when template is missing."""
         self.patch_object(lc_deploy, 'get_jinja2_env')
         jinja_env_mock = mock.MagicMock()
         self.get_jinja2_env.return_value = jinja_env_mock
@@ -93,6 +104,7 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
         self.assertIsNone(lc_deploy.get_template('mybundle.yaml'))
 
     def test_render_template(self):
+        """Test render_template."""
         self.patch_object(lc_deploy, 'get_template_overlay_context')
         template_mock = mock.MagicMock()
         template_mock.render.return_value = 'Template contents'
@@ -104,6 +116,7 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
         handle.write.assert_called_once_with('Template contents')
 
     def test_render_overlay(self):
+        """Test render_overlay."""
         self.patch_object(lc_deploy, 'render_template')
         template_mock = mock.MagicMock()
         self.patch_object(lc_deploy, 'get_template')
@@ -114,11 +127,13 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
             '/tmp/special-dir/my_overlay.yaml')
 
     def test_render_overlay_no_template(self):
+        """Test render_overlay when template is missing."""
         self.patch_object(lc_deploy, 'get_template')
         self.get_template.return_value = None
         self.assertIsNone(lc_deploy.render_overlay('mybundle.yaml', '/tmp/'))
 
     def test_render_overlays(self):
+        """Test render_overlays."""
         RESP = {
             'mybundles/mybundle.yaml': '/tmp/mybundle.yaml'}
         self.patch_object(lc_deploy, 'render_local_overlay')
@@ -130,6 +145,7 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
             ['/tmp/local-overlay.yaml', '/tmp/mybundle.yaml'])
 
     def test_render_overlays_missing(self):
+        """Test render_overlays when template is missing."""
         RESP = {'mybundles/mybundle.yaml': None}
         self.patch_object(lc_deploy, 'render_overlay')
         self.patch_object(lc_deploy, 'render_local_overlay')
@@ -140,6 +156,7 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
             ['/tmp/local.yaml'])
 
     def test_deploy_bundle(self):
+        """Test deploy_bundle."""
         self.patch_object(lc_deploy.utils, 'get_charm_config')
         self.get_charm_config.return_value = {}
         self.patch_object(lc_deploy, 'render_overlays')
@@ -150,6 +167,7 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
             ['juju', 'deploy', '-m', 'newmodel', 'bun.yaml'])
 
     def test_deploy(self):
+        """Test deploy."""
         self.patch_object(lc_deploy.zaza.model, 'wait_for_application_states')
         self.patch_object(lc_deploy.utils, 'get_charm_config')
         self.get_charm_config.return_value = {}
@@ -161,6 +179,7 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
             {})
 
     def test_deploy_bespoke_states(self):
+        """Test deploy with bespoke states."""
         self.patch_object(lc_deploy.zaza.model, 'wait_for_application_states')
         self.patch_object(lc_deploy.utils, 'get_charm_config')
         self.get_charm_config.return_value = {
@@ -178,6 +197,7 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
                 'workload-status-message': 'Vault needs to be inited'}})
 
     def test_deploy_nowait(self):
+        """Test deploy without checking wl states."""
         self.patch_object(lc_deploy.zaza.model, 'wait_for_application_states')
         self.patch_object(lc_deploy, 'deploy_bundle')
         lc_deploy.deploy('bun.yaml', 'newmodel', wait=False)
@@ -185,6 +205,7 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
         self.assertFalse(self.wait_for_application_states.called)
 
     def test_parser(self):
+        """Test parse_args."""
         args = lc_deploy.parse_args([
             '-m', 'mymodel',
             '-b', 'bun.yaml'])
@@ -193,6 +214,7 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
         self.assertTrue(args.wait)
 
     def test_parser_nowait(self):
+        """Test parse_args processes --no-wait correctly."""
         args = lc_deploy.parse_args([
             '-m', 'mymodel',
             '-b', 'bun.yaml',

--- a/unit_tests/test_zaza_charm_lifecycle_destroy.py
+++ b/unit_tests/test_zaza_charm_lifecycle_destroy.py
@@ -1,14 +1,18 @@
+"""Module containing unit tests for zaza.charm_lifecycle.destroy."""
 import zaza.charm_lifecycle.destroy as lc_destroy
 import unit_tests.utils as ut_utils
 
 
 class TestCharmLifecycleDestroy(ut_utils.BaseTestCase):
+    """Unit tests for zaza.charm_lifecycle.destroy."""
 
     def test_destroy(self):
+        """Test destroy."""
         self.patch_object(lc_destroy.zaza.controller, 'destroy_model')
         lc_destroy.destroy('doomed')
         self.destroy_model.assert_called_once_with('doomed')
 
     def test_parser(self):
+        """Test parse_args."""
         args = lc_destroy.parse_args(['-m', 'doomed'])
         self.assertEqual(args.model_name, 'doomed')

--- a/unit_tests/test_zaza_charm_lifecycle_func_test_runner.py
+++ b/unit_tests/test_zaza_charm_lifecycle_func_test_runner.py
@@ -1,3 +1,4 @@
+"""Module containing unit tests for zaza.charm_lifecycle.func_test_runner."""
 import mock
 
 import zaza.charm_lifecycle.func_test_runner as lc_func_test_runner
@@ -5,14 +6,17 @@ import unit_tests.utils as ut_utils
 
 
 class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
+    """Define unit tests for zaza.charm_lifecycle.func_test_runner."""
 
     def test_generate_model_name(self):
+        """Test generate_model_name."""
         self.patch_object(lc_func_test_runner.uuid, "uuid4")
         self.uuid4.return_value = "longer-than-12characters"
         self.assertEqual(lc_func_test_runner.generate_model_name(),
                          "zaza-12characters")
 
     def test_parser(self):
+        """Test parse_args."""
         # Test defaults
         args = lc_func_test_runner.parse_args([])
         self.assertFalse(args.keep_model)
@@ -29,6 +33,7 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
         self.assertEqual(args.loglevel, 'DEBUG')
 
     def test_func_test_runner(self):
+        """Test func_test_runner."""
         self.patch_object(lc_func_test_runner.utils, 'get_charm_config')
         self.patch_object(lc_func_test_runner, 'generate_model_name')
         self.patch_object(lc_func_test_runner.prepare, 'prepare')
@@ -77,6 +82,7 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
         self.destroy.assert_has_calls(destroy_calls)
 
     def test_func_test_runner_smoke(self):
+        """Test func_test_runner smoke test."""
         self.patch_object(lc_func_test_runner.utils, 'get_charm_config')
         self.patch_object(lc_func_test_runner, 'generate_model_name')
         self.patch_object(lc_func_test_runner.prepare, 'prepare')
@@ -101,6 +107,7 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
         self.deploy.assert_has_calls(deploy_calls)
 
     def test_func_test_runner_specify_bundle(self):
+        """Test func_test_runner with explicit bundle."""
         self.patch_object(lc_func_test_runner.utils, 'get_charm_config')
         self.patch_object(lc_func_test_runner, 'generate_model_name')
         self.patch_object(lc_func_test_runner.prepare, 'prepare')
@@ -125,6 +132,7 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
         self.deploy.assert_has_calls(deploy_calls)
 
     def test_main_loglevel(self):
+        """Test running main setting log level."""
         self.patch_object(lc_func_test_runner, 'parse_args')
         self.patch_object(lc_func_test_runner, 'logging')
         self.patch_object(lc_func_test_runner, 'func_test_runner')
@@ -137,6 +145,7 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
         self.logging.basicConfig.assert_called_with(level=10)
 
     def test_main_loglevel_invalid(self):
+        """Test running main with invalid log level."""
         self.patch_object(lc_func_test_runner, 'parse_args')
         self.patch_object(lc_func_test_runner, 'logging')
         self.patch_object(lc_func_test_runner, 'func_test_runner')

--- a/unit_tests/test_zaza_charm_lifecycle_prepare.py
+++ b/unit_tests/test_zaza_charm_lifecycle_prepare.py
@@ -1,10 +1,13 @@
+"""Module containing unit tests for zaza.charm_lifecycle.prepare."""
 import zaza.charm_lifecycle.prepare as lc_prepare
 import unit_tests.utils as ut_utils
 
 
 class TestCharmLifecyclePrepare(ut_utils.BaseTestCase):
+    """Unit tests for zaza.charm_lifecycle.prepare."""
 
     def test_prepare(self):
+        """Test prepare."""
         self.patch_object(lc_prepare.zaza.controller, 'add_model')
         lc_prepare.prepare('newmodel')
         self.add_model.assert_called_once_with(
@@ -20,5 +23,6 @@ class TestCharmLifecyclePrepare(ut_utils.BaseTestCase):
                 'use-default-secgroup': 'true'})
 
     def test_parser(self):
+        """Test parse_args."""
         args = lc_prepare.parse_args(['-m', 'newmodel'])
         self.assertEqual(args.model_name, 'newmodel')

--- a/unit_tests/test_zaza_charm_lifecycle_test.py
+++ b/unit_tests/test_zaza_charm_lifecycle_test.py
@@ -1,3 +1,4 @@
+"""Module containing unit tests for zaza.charm_lifecycle.test."""
 import mock
 
 import zaza.charm_lifecycle.test as lc_test
@@ -5,8 +6,10 @@ import unit_tests.utils as ut_utils
 
 
 class TestCharmLifecycleTest(ut_utils.BaseTestCase):
+    """Unit tests for zaza.charm_lifecycle.test."""
 
     def test_run_test_list(self):
+        """Test run_test_list."""
         loader_mock = mock.MagicMock()
         runner_mock = mock.MagicMock()
         self.patch_object(lc_test.unittest, 'TestLoader')
@@ -24,12 +27,14 @@ class TestCharmLifecycleTest(ut_utils.BaseTestCase):
         loader_mock.loadTestsFromTestCase.assert_has_calls(loader_calls)
 
     def test_test(self):
+        """Test the test function."""
         self.patch_object(lc_test, 'run_test_list')
         lc_test.run_test_list(['test_class1', 'test_class2'])
         self.run_test_list.assert_called_once_with(
             ['test_class1', 'test_class2'])
 
     def test_parser(self):
+        """Test parse_args."""
         args = lc_test.parse_args(
             ['-m', 'modelname', '-t', 'my.test_class1', 'my.test_class2'])
         self.assertEqual(

--- a/unit_tests/test_zaza_charm_lifecycle_utils.py
+++ b/unit_tests/test_zaza_charm_lifecycle_utils.py
@@ -1,3 +1,4 @@
+"""Module containing unit tests for zaza.charm_lifecycle.utils."""
 import mock
 
 import zaza.charm_lifecycle.utils as lc_utils
@@ -5,8 +6,10 @@ import unit_tests.utils as ut_utils
 
 
 class TestCharmLifecycleUtils(ut_utils.BaseTestCase):
+    """Unit tests for zaza.charm_lifecycle.utils."""
 
     def test_get_charm_config(self):
+        """Test get_charm_config."""
         self.patch("builtins.open",
                    new_callable=mock.mock_open(),
                    name="_open")
@@ -25,6 +28,7 @@ class TestCharmLifecycleUtils(ut_utils.BaseTestCase):
         self.yaml.load.assert_called_once_with(_yaml)
 
     def test_get_class(self):
+        """Test get_class."""
         self.assertEqual(
             type(lc_utils.get_class('unit_tests.'
                                     'test_zaza_charm_lifecycle_utils.'

--- a/unit_tests/test_zaza_controller.py
+++ b/unit_tests/test_zaza_controller.py
@@ -1,3 +1,4 @@
+"""Module defining unit tests for zaza.controller."""
 import mock
 
 import unit_tests.utils as ut_utils
@@ -6,8 +7,10 @@ import zaza.controller as controller
 
 
 class TestController(ut_utils.BaseTestCase):
+    """Unit tests for zaza.controller."""
 
     def setUp(self):
+        """Run setup for zaza.controller unit tests."""
         super(TestController, self).setUp()
 
         async def _disconnect():
@@ -56,6 +59,7 @@ class TestController(ut_utils.BaseTestCase):
         self.Controller.return_value = self.Controller_mock
 
     def test_add_model(self):
+        """Test add_model."""
         self.assertEqual(controller.add_model(self.model1.info.name),
                          self.model1.info.name)
         self.Controller_mock.add_model.assert_called_once_with(
@@ -64,6 +68,7 @@ class TestController(ut_utils.BaseTestCase):
         self.model1.connect.assert_called_once()
 
     def test_add_model_config(self):
+        """Test add_model, with supplied config."""
         self.assertEqual(
             controller.add_model(
                 self.model1.info.name,
@@ -75,17 +80,20 @@ class TestController(ut_utils.BaseTestCase):
         self.model1.connect.assert_called_once()
 
     def test_destroy_model(self):
+        """Test destroy_model."""
         controller.destroy_model(self.model1.info.name)
         self.Controller_mock.destroy_model.assert_called_once_with(
             self.model1.info.name)
 
     def test_get_cloud(self):
+        """Test get_cloud."""
         self.assertEqual(
             controller.get_cloud(),
             self.cloud)
         self.Controller_mock.get_cloud.assert_called_once()
 
     def test_list_models(self):
+        """Test list_models."""
         self.assertEqual(
             controller.list_models(),
             self.models)

--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -1,4 +1,4 @@
-"""Module containing unit tests for zaza.model"""
+"""Module containing unit tests for zaza.model."""
 import aiounittest
 import asyncio.futures
 import mock

--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -148,6 +148,7 @@ class TestModel(ut_utils.BaseTestCase):
         self.get_current_model.assert_not_called()
 
     def test_get_juju_model_alt(self):
+        """Test get_juju_model with fallback env var MODEL_NAME."""
         self.patch_object(model.os, 'environ')
         self.patch_object(model, 'get_current_model')
         self.get_current_model.return_value = 'modelsmodel'

--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -1,3 +1,4 @@
+"""Module containing unit tests for zaza.model"""
 import aiounittest
 import asyncio.futures
 import mock
@@ -9,13 +10,16 @@ import zaza.model as model
 
 
 class TestModel(ut_utils.BaseTestCase):
+    """Unit tests for zaza.model."""
 
     def tearDown(self):
+        """Run teardown of mocks."""
         super(TestModel, self).tearDown()
         # Clear cached model name
         model.CURRENT_MODEL = None
 
     def setUp(self):
+        """Run setup of mocks for testing juju.model."""
         super(TestModel, self).setUp()
 
         async def _scp_to(source, destination, user=None, proxy=None,
@@ -129,6 +133,7 @@ class TestModel(ut_utils.BaseTestCase):
         self.Controller_mock.destroy_models.side_effect = _ctrl_destroy_models
 
     def test_get_juju_model(self):
+        """Test get_juju_model."""
         self.patch_object(model.os, 'environ')
         self.patch_object(model, 'get_current_model')
         self.get_current_model.return_value = 'modelsmodel'
@@ -157,6 +162,7 @@ class TestModel(ut_utils.BaseTestCase):
         self.get_current_model.assert_not_called()
 
     def test_get_juju_model_noenv(self):
+        """Test get_juju_model, JUJU_MODEL not set."""
         self.patch_object(model.os, 'environ')
         self.patch_object(model, 'get_current_model')
         self.get_current_model.return_value = 'modelsmodel'
@@ -167,6 +173,7 @@ class TestModel(ut_utils.BaseTestCase):
         self.get_current_model.assert_called_once()
 
     def test_run_in_model(self):
+        """Test run_in_model."""
         self.patch_object(model, 'Model')
         self.Model.return_value = self.Model_mock
 
@@ -178,6 +185,7 @@ class TestModel(ut_utils.BaseTestCase):
         self.Model_mock.disconnect.assert_called_once_with()
 
     def test_scp_to_unit(self):
+        """Test scp_to_unit."""
         self.patch_object(model, 'get_juju_model', return_value='mname')
         self.patch_object(model, 'Model')
         self.patch_object(model, 'get_unit_from_name')
@@ -188,6 +196,7 @@ class TestModel(ut_utils.BaseTestCase):
             '/tmp/src', '/tmp/dest', proxy=False, scp_opts='', user='ubuntu')
 
     def test_scp_to_all_units(self):
+        """Test scp_to_all_units."""
         self.patch_object(model, 'get_juju_model', return_value='mname')
         self.patch_object(model, 'Model')
         self.Model.return_value = self.Model_mock
@@ -198,6 +207,7 @@ class TestModel(ut_utils.BaseTestCase):
             '/tmp/src', '/tmp/dest', proxy=False, scp_opts='', user='ubuntu')
 
     def test_scp_from_unit(self):
+        """Test scp_from_unit."""
         self.patch_object(model, 'get_juju_model', return_value='mname')
         self.patch_object(model, 'Model')
         self.patch_object(model, 'get_unit_from_name')
@@ -208,6 +218,7 @@ class TestModel(ut_utils.BaseTestCase):
             '/tmp/src', '/tmp/dest', proxy=False, scp_opts='', user='ubuntu')
 
     def test_get_units(self):
+        """Test get_units."""
         self.patch_object(model, 'get_juju_model', return_value='mname')
         self.patch_object(model, 'Model')
         self.Model.return_value = self.Model_mock
@@ -216,6 +227,7 @@ class TestModel(ut_utils.BaseTestCase):
             self.units)
 
     def test_get_machines(self):
+        """Test get_machines."""
         self.patch_object(model, 'get_juju_model', return_value='mname')
         self.patch_object(model, 'Model')
         self.Model.return_value = self.Model_mock
@@ -224,6 +236,7 @@ class TestModel(ut_utils.BaseTestCase):
             ['machine3', 'machine7'])
 
     def test_get_first_unit_name(self):
+        """Test get_first_unit_name."""
         self.patch_object(model, 'get_juju_model', return_value='mname')
         self.patch_object(model, 'get_units')
         self.get_units.return_value = self.units
@@ -232,18 +245,21 @@ class TestModel(ut_utils.BaseTestCase):
             'app/2')
 
     def test_get_unit_from_name(self):
+        """Test get_unit_from_name."""
         self.patch_object(model, 'get_juju_model', return_value='mname')
         self.assertEqual(
             model.get_unit_from_name('app/4', self.mymodel),
             self.unit2)
 
     def test_get_app_ips(self):
+        """Test get_app_ips."""
         self.patch_object(model, 'get_juju_model', return_value='mname')
         self.patch_object(model, 'get_units')
         self.get_units.return_value = self.units
         self.assertEqual(model.get_app_ips('model', 'app'), ['ip1', 'ip2'])
 
     def test_run_on_unit(self):
+        """Test run_on_unit."""
         self.patch_object(model, 'get_juju_model', return_value='mname')
         expected = {'Code': '0', 'Stderr': '', 'Stdout': 'RESULT'}
         self.cmd = cmd = 'somecommand someargument'
@@ -256,12 +272,14 @@ class TestModel(ut_utils.BaseTestCase):
         self.unit1.run.assert_called_once_with(cmd, timeout=None)
 
     def test_get_relation_id(self):
+        """Test get_relation_id."""
         self.patch_object(model, 'get_juju_model', return_value='mname')
         self.patch_object(model, 'Model')
         self.Model.return_value = self.Model_mock
         self.assertEqual(model.get_relation_id('app', 'app'), 42)
 
     def test_get_relation_id_interface(self):
+        """Test get_relation_id with remote_interface_name."""
         self.patch_object(model, 'get_juju_model', return_value='mname')
         self.patch_object(model, 'Model')
         self.Model.return_value = self.Model_mock
@@ -271,6 +289,7 @@ class TestModel(ut_utils.BaseTestCase):
             51)
 
     def test_run_action(self):
+        """Test run_action."""
         self.patch_object(model, 'get_juju_model', return_value='mname')
         self.patch_object(model, 'Model')
         self.patch_object(model, 'get_unit_from_name')
@@ -285,6 +304,7 @@ class TestModel(ut_utils.BaseTestCase):
             backup_dir='/dev/null')
 
     def test_get_actions(self):
+        """Test get_actions."""
         self.patch_object(model, 'get_juju_model', return_value='mname')
         self.patch_object(model.subprocess, 'check_output')
         self.check_output.return_value = 'action: "action desc"'
@@ -295,6 +315,7 @@ class TestModel(ut_utils.BaseTestCase):
             ['juju', 'actions', '-m', 'mname', 'myapp', '--format', 'yaml'])
 
     def test_run_action_on_leader(self):
+        """Test run_action_on_leader."""
         self.patch_object(model, 'get_juju_model', return_value='mname')
         self.patch_object(model, 'Model')
         self.Model.return_value = self.Model_mock
@@ -308,6 +329,7 @@ class TestModel(ut_utils.BaseTestCase):
             backup_dir='/dev/null')
 
     def _application_states_setup(self, setup, units_idle=True):
+        """Create mocks for testing workload statuses."""
         self.system_ready = True
 
         async def _block_until(f, timeout=None):
@@ -332,6 +354,7 @@ class TestModel(ut_utils.BaseTestCase):
         type(self.unit2).workload_status_message = p_mock_wsmsg
 
     def test_units_with_wl_status_state(self):
+        """Test units_with_wl_status_state, match."""
         self._application_states_setup({
             'workload-status': 'active',
             'workload-status-message': 'Unit is ready'})
@@ -341,6 +364,7 @@ class TestModel(ut_utils.BaseTestCase):
         self.assertIn(self.unit2, units)
 
     def test_units_with_wl_status_state_no_match(self):
+        """Test units_with_wl_status_state, no match."""
         self._application_states_setup({
             'workload-status': 'blocked',
             'workload-status-message': 'Unit is ready'})
@@ -348,18 +372,21 @@ class TestModel(ut_utils.BaseTestCase):
         self.assertTrue(len(units) == 0)
 
     def test_check_model_for_hard_errors(self):
+        """Test check_model_for_hard_errors, errors not found."""
         self.patch_object(model, 'units_with_wl_status_state')
         self.units_with_wl_status_state.return_value = []
         # Test will fail if an Exception is raised
         model.check_model_for_hard_errors(self.Model_mock)
 
     def test_check_model_for_hard_errors_found(self):
+        """Test check_model_for_hard_errors, errors found."""
         self.patch_object(model, 'units_with_wl_status_state')
         self.units_with_wl_status_state.return_value = [self.unit1]
         with self.assertRaises(model.UnitError):
             model.check_model_for_hard_errors(self.Model_mock)
 
     def test_check_unit_workload_status(self):
+        """Test workload_status_message."""
         self.patch_object(model, 'check_model_for_hard_errors')
         self._application_states_setup({
             'workload-status': 'active',
@@ -369,6 +396,7 @@ class TestModel(ut_utils.BaseTestCase):
                                              self.unit1, 'active'))
 
     def test_check_unit_workload_status_no_match(self):
+        """Test workload_status_message, no match."""
         self.patch_object(model, 'check_model_for_hard_errors')
         self._application_states_setup({
             'workload-status': 'blocked',
@@ -378,6 +406,7 @@ class TestModel(ut_utils.BaseTestCase):
                                              self.unit1, 'active'))
 
     def test_check_unit_workload_status_message_message(self):
+        """Test workload_status_message, bespoke message match."""
         self.patch_object(model, 'check_model_for_hard_errors')
         self._application_states_setup({
             'workload-status': 'blocked',
@@ -388,6 +417,7 @@ class TestModel(ut_utils.BaseTestCase):
                                                      message='Unit is ready'))
 
     def test_check_unit_workload_status_message_message_not_found(self):
+        """Test workload_status_message, bespoke message not found."""
         self.patch_object(model, 'check_model_for_hard_errors')
         self._application_states_setup({
             'workload-status': 'blocked',
@@ -398,6 +428,7 @@ class TestModel(ut_utils.BaseTestCase):
                                                      message='Unit is ready'))
 
     def test_check_unit_workload_status_message_prefix(self):
+        """Test workload_status_message, use prefix."""
         self.patch_object(model, 'check_model_for_hard_errors')
         self._application_states_setup({
             'workload-status': 'blocked',
@@ -409,6 +440,7 @@ class TestModel(ut_utils.BaseTestCase):
                 prefixes=('Readyish', 'Unit is ready')))
 
     def test_check_unit_workload_status_message_prefix_no_match(self):
+        """Test workload_status_message, use prefix, no match."""
         self.patch_object(model, 'check_model_for_hard_errors')
         self._application_states_setup({
             'workload-status': 'blocked',
@@ -420,6 +452,7 @@ class TestModel(ut_utils.BaseTestCase):
                 prefixes=('Readyish', 'Unit is ready')))
 
     def test_wait_for_application_states(self):
+        """Test wait_for_application_states."""
         self._application_states_setup({
             'workload-status': 'active',
             'workload-status-message': 'Unit is ready'})
@@ -427,6 +460,7 @@ class TestModel(ut_utils.BaseTestCase):
         self.assertTrue(self.system_ready)
 
     def test_wait_for_application_states_not_ready_ws(self):
+        """Test wait_for_application_states, not ready wls."""
         self._application_states_setup({
             'workload-status': 'blocked',
             'workload-status-message': 'Unit is ready'})
@@ -434,6 +468,7 @@ class TestModel(ut_utils.BaseTestCase):
         self.assertFalse(self.system_ready)
 
     def test_wait_for_application_states_not_ready_wsmsg(self):
+        """Test wait_for_application_states, not ready wls message."""
         self._application_states_setup({
             'workload-status': 'active',
             'workload-status-message': 'Unit is not ready'})
@@ -441,6 +476,7 @@ class TestModel(ut_utils.BaseTestCase):
         self.assertFalse(self.system_ready)
 
     def test_wait_for_application_states_blocked_ok(self):
+        """Test wait_for_application_states, check blocked."""
         self._application_states_setup({
             'workload-status': 'blocked',
             'workload-status-message': 'Unit is ready'})
@@ -452,6 +488,7 @@ class TestModel(ut_utils.BaseTestCase):
         self.assertTrue(self.system_ready)
 
     def test_wait_for_application_states_bespoke_msg(self):
+        """Test wait_for_application_states, bespoke message."""
         self._application_states_setup({
             'workload-status': 'active',
             'workload-status-message': 'Sure, I could do something'})
@@ -463,6 +500,7 @@ class TestModel(ut_utils.BaseTestCase):
         self.assertTrue(self.system_ready)
 
     def test_wait_for_application_states_bespoke_msg_bloked_ok(self):
+        """Test wait_for_application_states, bespoke message, bespoke state."""
         self._application_states_setup({
             'workload-status': 'blocked',
             'workload-status-message': 'Sure, I could do something'})
@@ -475,11 +513,13 @@ class TestModel(ut_utils.BaseTestCase):
         self.assertTrue(self.system_ready)
 
     def test_get_current_model(self):
+        """Test get_current_model."""
         self.patch_object(model, 'Model')
         self.Model.return_value = self.Model_mock
         self.assertEqual(model.get_current_model(), self.model_name)
 
     def test_block_until_file_has_contents(self):
+        """Test block_until_file_has_contents."""
         self.patch_object(model, 'Model')
         self.Model.return_value = self.Model_mock
         self.patch_object(model, 'get_juju_model', return_value='mname')
@@ -500,6 +540,7 @@ class TestModel(ut_utils.BaseTestCase):
             '/tmp/src/myfile.txt', mock.ANY)
 
     def test_block_until_file_has_contents_missing(self):
+        """Test block_until_file_has_contents, contents missing."""
         self.patch_object(model, 'Model')
         self.Model.return_value = self.Model_mock
         self.patch_object(model, 'get_juju_model', return_value='mname')
@@ -519,7 +560,7 @@ class TestModel(ut_utils.BaseTestCase):
             '/tmp/src/myfile.txt', mock.ANY)
 
     def test_async_block_until_all_units_idle(self):
-
+        """Test block_until_all_units_idle."""
         async def _block_until(f, timeout=None):
             if not f():
                 raise asyncio.futures.TimeoutError
@@ -534,7 +575,7 @@ class TestModel(ut_utils.BaseTestCase):
         model.block_until_all_units_idle('modelname')
 
     def test_async_block_until_all_units_idle_false(self):
-
+        """Test block_until_all_units_idle, timeout."""
         async def _block_until(f, timeout=None):
             if not f():
                 raise asyncio.futures.TimeoutError
@@ -550,7 +591,7 @@ class TestModel(ut_utils.BaseTestCase):
             model.block_until_all_units_idle('modelname')
 
     def block_until_service_status_base(self, rou_return):
-
+        """Run mocks for testing block_until_service_status."""
         async def _block_until(f, timeout=None):
             rc = await f()
             if not rc:
@@ -566,6 +607,7 @@ class TestModel(ut_utils.BaseTestCase):
         self.async_block_until.side_effect = _block_until
 
     def test_block_until_service_status_check_running(self):
+        """Test block_until_service_status, check running."""
         self.patch_object(model, 'get_juju_model', return_value='mname')
         self.block_until_service_status_base({'Stdout': '152 409 54'})
         model.block_until_service_status(
@@ -574,6 +616,7 @@ class TestModel(ut_utils.BaseTestCase):
             'running')
 
     def test_block_until_service_status_check_running_fail(self):
+        """Test block_until_service_status, check running timeout."""
         self.patch_object(model, 'get_juju_model', return_value='mname')
         self.block_until_service_status_base({'Stdout': ''})
         with self.assertRaises(asyncio.futures.TimeoutError):
@@ -583,6 +626,7 @@ class TestModel(ut_utils.BaseTestCase):
                 'running')
 
     def test_block_until_service_status_check_stopped(self):
+        """Test block_until_service_status, check stopped."""
         self.patch_object(model, 'get_juju_model', return_value='mname')
         self.block_until_service_status_base({'Stdout': ''})
         model.block_until_service_status(
@@ -591,6 +635,7 @@ class TestModel(ut_utils.BaseTestCase):
             'stopped')
 
     def test_block_until_service_status_check_stopped_fail(self):
+        """Test block_until_service_status, check stopped but timeout."""
         self.patch_object(model, 'get_juju_model', return_value='mname')
         self.block_until_service_status_base({'Stdout': '152 409 54'})
         with self.assertRaises(asyncio.futures.TimeoutError):
@@ -600,6 +645,7 @@ class TestModel(ut_utils.BaseTestCase):
                 'stopped')
 
     def test_get_unit_time(self):
+        """Test test_get_unit_time."""
         async def _run_on_unit(model_name, unit_name, cmd, timeout=None):
             return {'Stdout': '1524409654'}
         self.patch_object(model, 'async_run_on_unit')
@@ -609,6 +655,7 @@ class TestModel(ut_utils.BaseTestCase):
             1524409654)
 
     def test_get_unit_service_start_time(self):
+        """Test get_unit_service_start_time."""
         async def _run_on_unit(model_name, unit_name, cmd, timeout=None):
             return {'Stdout': '1524409654'}
         self.patch_object(model, 'async_run_on_unit')
@@ -617,6 +664,7 @@ class TestModel(ut_utils.BaseTestCase):
             model.get_unit_service_start_time('app/2', 'mysvc1'), 1524409654)
 
     def test_get_unit_service_start_time_not_running(self):
+        """Test get_unit_service_start_time, service not running."""
         async def _run_on_unit(model_name, unit_name, cmd, timeout=None):
             return {'Stdout': ''}
         self.patch_object(model, 'async_run_on_unit')
@@ -626,6 +674,7 @@ class TestModel(ut_utils.BaseTestCase):
 
     def block_until_oslo_config_entries_match_base(self, file_contents,
                                                    expected_contents):
+        """Create mocks for testing block_until_oslo_config_entries_match."""
         async def _scp_from(remote_file, tmpdir):
             with open('{}/myfile.txt'.format(tmpdir), 'w') as f:
                 f.write(file_contents)
@@ -641,6 +690,7 @@ class TestModel(ut_utils.BaseTestCase):
             timeout=0.1)
 
     def test_block_until_oslo_config_entries_match(self):
+        """Test block_until_oslo_config_entries_match."""
         file_contents = """
 [DEFAULT]
 verbose = False
@@ -672,6 +722,7 @@ disk_formats = ami,ari,aki,vhd,vmdk,raw,qcow2,vdi,iso,root-tar
             '/tmp/src/myfile.txt', mock.ANY)
 
     def test_block_until_oslo_config_entries_match_fail(self):
+        """Test block_until_oslo_config_entries_match, match fail."""
         file_contents = """
 [DEFAULT]
 verbose = False
@@ -702,6 +753,7 @@ disk_formats = ami,ari,aki,vhd,vmdk,raw,qcow2,vdi,iso,root-tar
             '/tmp/src/myfile.txt', mock.ANY)
 
     def test_block_until_oslo_config_entries_match_missing_entry(self):
+        """Test block_until_oslo_config_entries_match, with entry missing."""
         file_contents = """
 [DEFAULT]
 verbose = False
@@ -731,6 +783,7 @@ disk_formats = ami,ari,aki,vhd,vmdk,raw,qcow2,vdi,iso,root-tar
             '/tmp/src/myfile.txt', mock.ANY)
 
     def test_block_until_oslo_config_entries_match_missing_section(self):
+        """Test block_until_oslo_config_entries_match, with section missing."""
         file_contents = """
 [DEFAULT]
 verbose = False
@@ -756,6 +809,7 @@ disk_formats = ami,ari,aki,vhd,vmdk,raw,qcow2,vdi,iso,root-tar
 
     def block_until_services_restarted_base(self, gu_return=None,
                                             gu_raise_exception=False):
+        """Run setup mocks for testing block_until_services_restarted."""
         async def _block_until(f, timeout=None):
             rc = await f()
             if not rc:
@@ -776,6 +830,7 @@ disk_formats = ami,ari,aki,vhd,vmdk,raw,qcow2,vdi,iso,root-tar
         self.Model.return_value = self.Model_mock
 
     def test_block_until_services_restarted(self):
+        """Test block_until_services_restarted."""
         self.block_until_services_restarted_base(gu_return=10)
         model.block_until_services_restarted(
             'app',
@@ -783,6 +838,7 @@ disk_formats = ami,ari,aki,vhd,vmdk,raw,qcow2,vdi,iso,root-tar
             ['svc1', 'svc2'])
 
     def test_block_until_services_restarted_fail(self):
+        """Test model.block_until_services_restarted timeout."""
         self.block_until_services_restarted_base(gu_return=10)
         with self.assertRaises(asyncio.futures.TimeoutError):
             model.block_until_services_restarted(
@@ -791,6 +847,7 @@ disk_formats = ami,ari,aki,vhd,vmdk,raw,qcow2,vdi,iso,root-tar
                 ['svc1', 'svc2'])
 
     def test_block_until_services_restarted_not_running(self):
+        """Test block_until_services_restarted_not_running timeout."""
         self.block_until_services_restarted_base(gu_raise_exception=True)
         with self.assertRaises(asyncio.futures.TimeoutError):
             model.block_until_services_restarted(
@@ -799,6 +856,7 @@ disk_formats = ami,ari,aki,vhd,vmdk,raw,qcow2,vdi,iso,root-tar
                 ['svc1', 'svc2'])
 
     def test_block_until_unit_wl_status(self):
+        """Test block_until_unit_wl_status."""
         async def _block_until(f, timeout=None):
             if not f():
                 raise asyncio.futures.TimeoutError
@@ -815,6 +873,7 @@ disk_formats = ami,ari,aki,vhd,vmdk,raw,qcow2,vdi,iso,root-tar
             timeout=0.1)
 
     def test_block_until_unit_wl_status_fail(self):
+        """Test block_until_unit_wl_status timeout."""
         async def _block_until(f, timeout=None):
             if not f():
                 raise asyncio.futures.TimeoutError
@@ -833,9 +892,10 @@ disk_formats = ami,ari,aki,vhd,vmdk,raw,qcow2,vdi,iso,root-tar
 
 
 class AsyncModelTests(aiounittest.AsyncTestCase):
+    """Run juju.model tests using async unit test framework."""
 
     async def test_async_block_until_timeout(self):
-
+        """Test async_block_until_pass, timeout."""
         async def _f():
             return False
 
@@ -846,7 +906,7 @@ class AsyncModelTests(aiounittest.AsyncTestCase):
             await model.async_block_until(_f, _g, timeout=0.1)
 
     async def test_async_block_until_pass(self):
-
+        """Test async_block_until_pass."""
         async def _f():
             return True
 

--- a/unit_tests/utilities/__init__.py
+++ b/unit_tests/utilities/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for zaza.utilities.* ."""

--- a/unit_tests/utilities/test_zaza_utilities_cert.py
+++ b/unit_tests/utilities/test_zaza_utilities_cert.py
@@ -1,3 +1,4 @@
+"""Module containing unit tests for zaza.utilities.cert."""
 import mock
 
 import unit_tests.utils as ut_utils
@@ -5,8 +6,10 @@ import zaza.utilities.cert as cert
 
 
 class TestUtilitiesCert(ut_utils.BaseTestCase):
+    """Collection of unit tests for zaza.utilities.cert."""
 
     def test_generate_cert(self):
+        """Test generate_cert."""
         self.patch_object(cert, 'serialization')
         self.patch_object(cert, 'rsa')
         self.patch_object(cert, 'cryptography')
@@ -26,6 +29,7 @@ class TestUtilitiesCert(ut_utils.BaseTestCase):
         )
 
     def test_generate_cert_san(self):
+        """Test generate_cert with SANs."""
         self.patch_object(cert, 'serialization')
         self.patch_object(cert, 'rsa')
         self.patch_object(cert, 'cryptography')
@@ -50,6 +54,7 @@ class TestUtilitiesCert(ut_utils.BaseTestCase):
         )
 
     def test_generate_cert_password(self):
+        """Test generate_cert_password."""
         self.patch_object(cert, 'serialization')
         self.patch_object(cert, 'rsa')
         self.patch_object(cert, 'cryptography')
@@ -69,6 +74,7 @@ class TestUtilitiesCert(ut_utils.BaseTestCase):
         )
 
     def test_generate_cert_issuer_name(self):
+        """Test generate_cert with an issuer_name."""
         self.patch_object(cert, 'serialization')
         self.patch_object(cert, 'rsa')
         self.patch_object(cert, 'cryptography')
@@ -82,6 +88,7 @@ class TestUtilitiesCert(ut_utils.BaseTestCase):
         )
 
     def test_generate_cert_signing_key(self):
+        """Test generate_cert with a provided signing key."""
         self.patch_object(cert, 'serialization')
         self.patch_object(cert, 'rsa')
         self.patch_object(cert, 'cryptography')
@@ -106,6 +113,7 @@ class TestUtilitiesCert(ut_utils.BaseTestCase):
         )
 
     def test_generate_cert_signing_key_signing_key_password(self):
+        """Test generate_cert with a password protected key."""
         self.patch_object(cert, 'serialization')
         self.patch_object(cert, 'rsa')
         self.patch_object(cert, 'cryptography')
@@ -134,6 +142,7 @@ class TestUtilitiesCert(ut_utils.BaseTestCase):
         )
 
     def test_generate_cert_generate_ca(self):
+        """Test generate_cert for a CA."""
         self.patch_object(cert, 'serialization')
         self.patch_object(cert, 'rsa')
         self.patch_object(cert, 'cryptography')
@@ -153,6 +162,7 @@ class TestUtilitiesCert(ut_utils.BaseTestCase):
         )
 
     def sign_csr_mocks(self):
+        """Run setup of mocks needed for sign_csr testing."""
         self.patch_object(cert, 'serialization')
         self.patch_object(cert, 'cryptography')
         self.expect_bend = self.cryptography.hazmat.backends.default_backend()
@@ -171,6 +181,7 @@ class TestUtilitiesCert(ut_utils.BaseTestCase):
         self.cryptography.x509.BasicConstraints.side_effect = self.bcons_mock
 
     def test_sign_csr(self):
+        """Test running sign_csr."""
         self.sign_csr_mocks()
         cert.sign_csr('acsr', 'secretkey', ca_cert='cacert')
         self.serialization.load_pem_private_key.assert_called_with(
@@ -185,6 +196,7 @@ class TestUtilitiesCert(ut_utils.BaseTestCase):
             self.expect_bend)
 
     def test_sign_csr_key_password(self):
+        """Test running sign_csr with password protected key."""
         self.sign_csr_mocks()
         cert.sign_csr('acsr', 'secretkey', ca_cert='cacert',
                       ca_private_key_password='bob')
@@ -204,6 +216,7 @@ class TestUtilitiesCert(ut_utils.BaseTestCase):
             critical=True)
 
     def test_sign_csr_issuer_name(self):
+        """Test running sign_csr using issuer_name."""
         self.sign_csr_mocks()
         cert.sign_csr('acsr', 'secretkey', issuer_name='issuer')
         self.serialization.load_pem_private_key.assert_called_with(
@@ -220,6 +233,7 @@ class TestUtilitiesCert(ut_utils.BaseTestCase):
             critical=True)
 
     def test_sign_csr_generate_ca(self):
+        """Test running sign_csr for a CA cert."""
         self.sign_csr_mocks()
         cert.sign_csr('acsr', 'secretkey', issuer_name='issuer',
                       generate_ca=True)

--- a/unit_tests/utilities/test_zaza_utilities_cli.py
+++ b/unit_tests/utilities/test_zaza_utilities_cli.py
@@ -1,14 +1,18 @@
+"""Module containing unit tests for zaza.utilities.cli."""
 import mock
 import unit_tests.utils as ut_utils
 from zaza.utilities import cli as cli_utils
 
 
 class TestCLIUtils(ut_utils.BaseTestCase):
+    """Unit tests for zaza.utilities.cli."""
 
     def setUp(self):
+        """Run setup for zaza.utilities.cli tests."""
         super(TestCLIUtils, self).setUp()
 
     def test_parse_arg(self):
+        """Test parse_arg."""
         _options = mock.MagicMock()
         _arg_property = "property-value"
         _options.property = _arg_property
@@ -32,6 +36,7 @@ class TestCLIUtils(ut_utils.BaseTestCase):
                 _multi_value.split())
 
     def test_setup_logging(self):
+        """Test setup_logging."""
         self.patch_object(cli_utils, "logging")
         _logformatter = mock.MagicMock()
         _logger = mock.MagicMock()

--- a/unit_tests/utilities/test_zaza_utilities_generic.py
+++ b/unit_tests/utilities/test_zaza_utilities_generic.py
@@ -1,20 +1,26 @@
+"""Module containing tests for zaza.utilities.generic."""
 import mock
 import unit_tests.utils as ut_utils
+
 from zaza.utilities import generic as generic_utils
 
 
 class TestGenericUtils(ut_utils.BaseTestCase):
+    """Tests for zaza.utilities.generic."""
 
     def setUp(self):
+        """Run setup for testing zaza.utilities.generic."""
         super(TestGenericUtils, self).setUp()
 
     def test_dict_to_yaml(self):
+        """Test running dict_to_yaml."""
         _dict_data = {"key": "value"}
         _str_data = "key: value\n"
         self.assertEqual(generic_utils.dict_to_yaml(_dict_data),
                          _str_data)
 
     def test_get_network_config(self):
+        """Test running get_network_config."""
         self.patch_object(generic_utils.os.path, "exists")
         self.patch_object(generic_utils, "get_yaml_config")
         self.patch_object(generic_utils, "get_undercloud_env_vars")
@@ -47,6 +53,7 @@ class TestGenericUtils(ut_utils.BaseTestCase):
         self.get_undercloud_env_vars.assert_called_once_with()
 
     def test_get_pkg_version(self):
+        """Test running get_pkg_version."""
         self.patch_object(generic_utils.model, "get_units")
         self.patch_object(generic_utils.juju_utils, "remote_run")
         _pkg = "os-thingy"
@@ -73,6 +80,7 @@ class TestGenericUtils(ut_utils.BaseTestCase):
             generic_utils.get_pkg_version(_pkg, _pkg)
 
     def test_get_undercloud_env_vars(self):
+        """Test running get_undercloud_env_vars."""
         self.patch_object(generic_utils.os.environ, "get")
 
         def _get_env(key):
@@ -106,6 +114,7 @@ class TestGenericUtils(ut_utils.BaseTestCase):
                          _expected_result)
 
     def test_get_yaml_config(self):
+        """Test running get_yaml_config."""
         self.patch("builtins.open",
                    new_callable=mock.mock_open(),
                    name="_open")

--- a/unit_tests/utilities/test_zaza_utilities_juju.py
+++ b/unit_tests/utilities/test_zaza_utilities_juju.py
@@ -1,11 +1,14 @@
+"""Module containing unit tests for zaza.utilities.juju."""
 import mock
 import unit_tests.utils as ut_utils
 from zaza.utilities import juju as juju_utils
 
 
 class TestJujuUtils(ut_utils.BaseTestCase):
+    """Unit tests for zaza.utilities.juju."""
 
     def setUp(self):
+        """Run setup for zaza.utilities.juju tests."""
         super(TestJujuUtils, self).setUp()
 
         # Juju Status Object and data
@@ -46,6 +49,7 @@ class TestJujuUtils(ut_utils.BaseTestCase):
         self.controller.get_cloud.return_value = self.cloud_name
 
     def test_get_application_status(self):
+        """Test get_application_status."""
         self.patch_object(juju_utils, "get_full_juju_status")
         self.get_full_juju_status.return_value = self.juju_status
 
@@ -65,6 +69,7 @@ class TestJujuUtils(ut_utils.BaseTestCase):
             self.unit_data)
 
     def test_get_cloud_configs(self):
+        """Test get_cloud_configs."""
         self.patch_object(juju_utils.Path, "home")
         self.patch_object(juju_utils.generic_utils, "get_yaml_config")
         self.get_yaml_config.return_value = self.clouds
@@ -77,10 +82,12 @@ class TestJujuUtils(ut_utils.BaseTestCase):
                          self.clouds["clouds"][self.cloud_name])
 
     def test_get_full_juju_status(self):
+        """Test get_full_juju_status."""
         self.assertEqual(juju_utils.get_full_juju_status(), self.juju_status)
         self.model.get_status.assert_called_once_with()
 
     def test_get_machines_for_application(self):
+        """Test get_machines_for_application."""
         self.patch_object(juju_utils, "get_application_status")
         self.get_application_status.return_value = self.application_data
 
@@ -105,6 +112,7 @@ class TestJujuUtils(ut_utils.BaseTestCase):
             [self.machine])
 
     def test_get_machine_status(self):
+        """Test get_machine_status for all data and a specific key."""
         self.patch_object(juju_utils, "get_full_juju_status")
         self.get_full_juju_status.return_value = self.juju_status
 
@@ -120,6 +128,7 @@ class TestJujuUtils(ut_utils.BaseTestCase):
             self.key_data)
 
     def test_get_machine_uuids_for_application(self):
+        """Test get_machine_uuids_for_application."""
         self.patch_object(juju_utils, "get_machines_for_application")
         self.get_machines_for_application.return_value = [self.machine]
 
@@ -130,6 +139,7 @@ class TestJujuUtils(ut_utils.BaseTestCase):
             self.application)
 
     def test_get_provider_type(self):
+        """Test get_provider_type."""
         self.patch_object(juju_utils, "get_cloud_configs")
         self.get_cloud_configs.return_value = {"type": self.cloud_type}
         self.assertEqual(juju_utils.get_provider_type(),
@@ -137,6 +147,7 @@ class TestJujuUtils(ut_utils.BaseTestCase):
         self.get_cloud_configs.assert_called_once_with(self.cloud_name)
 
     def test_remote_run(self):
+        """Test remote_run."""
         _cmd = "do the thing"
 
         # Success
@@ -155,17 +166,20 @@ class TestJujuUtils(ut_utils.BaseTestCase):
             juju_utils.remote_run(self.unit, _cmd, fatal=True)
 
     def test_get_unit_names(self):
+        """Test _get_unit_names."""
         self.patch('zaza.model.get_first_unit_name', new_callable=mock.Mock(),
                    name='_get_first_unit_name')
         juju_utils._get_unit_names(['aunit/0', 'otherunit/0'])
         self.assertFalse(self._get_first_unit_name.called)
 
     def test_get_unit_names_called_with_application_name(self):
+        """Test get_first_unit_name."""
         self.patch_object(juju_utils, 'model')
         juju_utils._get_unit_names(['aunit', 'otherunit/0'])
         self.model.get_first_unit_name.assert_called()
 
     def test_get_relation_from_unit(self):
+        """Test get_relation_from_unit."""
         self.patch_object(juju_utils, '_get_unit_names')
         self.patch_object(juju_utils, 'yaml')
         self.patch_object(juju_utils, 'model')
@@ -181,6 +195,7 @@ class TestJujuUtils(ut_utils.BaseTestCase):
         self.yaml.load.assert_called_with(str(data))
 
     def test_get_relation_from_unit_fails(self):
+        """Test get_relation_from_unit raises exception on error."""
         self.patch_object(juju_utils, '_get_unit_names')
         self.patch_object(juju_utils, 'yaml')
         self.patch_object(juju_utils, 'model')

--- a/unit_tests/utilities/test_zaza_utilities_openstack.py
+++ b/unit_tests/utilities/test_zaza_utilities_openstack.py
@@ -1,3 +1,5 @@
+"""Unit test definitions for for zaza.utilities.openstack."""
+
 import copy
 import mock
 import tenacity
@@ -7,8 +9,10 @@ from zaza.utilities import openstack as openstack_utils
 
 
 class TestOpenStackUtils(ut_utils.BaseTestCase):
+    """Run unit tests for zaza.utilities.openstack."""
 
     def setUp(self):
+        """Run test setup."""
         super(TestOpenStackUtils, self).setUp()
         self.port_name = "port_name"
         self.net_uuid = "net_uuid"
@@ -62,6 +66,7 @@ class TestOpenStackUtils(ut_utils.BaseTestCase):
         self.neutronclient.create_network.return_value = self.network
 
     def test_create_port(self):
+        """Test calling create_port."""
         self.patch_object(openstack_utils, "get_net_uuid")
         self.get_net_uuid.return_value = self.net_uuid
 
@@ -80,6 +85,7 @@ class TestOpenStackUtils(ut_utils.BaseTestCase):
         self.neutronclient.create_port.assert_called_once_with(self.port)
 
     def test_create_floating_ip(self):
+        """Test calling create_floating_ip."""
         self.patch_object(openstack_utils, "get_net_uuid")
         self.get_net_uuid.return_value = self.net_uuid
 
@@ -99,6 +105,7 @@ class TestOpenStackUtils(ut_utils.BaseTestCase):
             self.floatingip)
 
     def test_create_address_scope(self):
+        """Test calling create_address_scope."""
         self.patch_object(openstack_utils, "get_net_uuid")
         self.get_net_uuid.return_value = self.net_uuid
 
@@ -120,6 +127,7 @@ class TestOpenStackUtils(ut_utils.BaseTestCase):
             address_scope_msg)
 
     def test_create_external_network(self):
+        """Test calling create_external_network."""
         self.patch_object(openstack_utils, "get_net_uuid")
         self.get_net_uuid.return_value = self.net_uuid
 
@@ -141,6 +149,7 @@ class TestOpenStackUtils(ut_utils.BaseTestCase):
             network_msg)
 
     def test_get_keystone_scope(self):
+        """Test calling get_keystone_scope."""
         self.patch_object(openstack_utils, "get_current_os_versions")
 
         # <= Liberty
@@ -151,6 +160,7 @@ class TestOpenStackUtils(ut_utils.BaseTestCase):
         self.assertEqual(openstack_utils.get_keystone_scope(), "PROJECT")
 
     def test_get_overcloud_keystone_session(self):
+        """Test calling get_overcloud_keystone_session."""
         self.patch_object(openstack_utils, "get_keystone_session")
         self.patch_object(openstack_utils, "get_keystone_scope")
         self.patch_object(openstack_utils, "get_overcloud_auth")
@@ -163,6 +173,7 @@ class TestOpenStackUtils(ut_utils.BaseTestCase):
         self.get_keystone_session.assert_called_once_with(_auth, scope=_scope)
 
     def test_get_undercloud_keystone_session(self):
+        """Test calling get_undercloud_keystone_session."""
         self.patch_object(openstack_utils, "get_keystone_session")
         self.patch_object(openstack_utils, "get_keystone_scope")
         self.patch_object(openstack_utils, "get_undercloud_auth")
@@ -175,6 +186,7 @@ class TestOpenStackUtils(ut_utils.BaseTestCase):
         self.get_keystone_session.assert_called_once_with(_auth, scope=_scope)
 
     def test_get_urllib_opener(self):
+        """Test calling get_urllib_opener."""
         self.patch_object(openstack_utils.urllib.request, "ProxyHandler")
         self.patch_object(openstack_utils.urllib.request, "HTTPHandler")
         self.patch_object(openstack_utils.urllib.request, "build_opener")
@@ -187,6 +199,7 @@ class TestOpenStackUtils(ut_utils.BaseTestCase):
         self.HTTPHandler.assert_called_once_with()
 
     def test_get_urllib_opener_proxy(self):
+        """Test calling get_urllib_opener with a proxy."""
         self.patch_object(openstack_utils.urllib.request, "ProxyHandler")
         self.patch_object(openstack_utils.urllib.request, "HTTPHandler")
         self.patch_object(openstack_utils.urllib.request, "build_opener")
@@ -199,6 +212,7 @@ class TestOpenStackUtils(ut_utils.BaseTestCase):
         self.ProxyHandler.assert_called_once_with({'http': 'http://squidy'})
 
     def test_find_cirros_image(self):
+        """Test calling find_cirros_image."""
         urllib_opener_mock = mock.MagicMock()
         self.patch_object(openstack_utils, "get_urllib_opener")
         self.get_urllib_opener.return_value = urllib_opener_mock
@@ -208,6 +222,7 @@ class TestOpenStackUtils(ut_utils.BaseTestCase):
             'http://download.cirros-cloud.net/12/cirros-12-aarch64-disk.img')
 
     def test_download_image(self):
+        """Test calling download_image."""
         urllib_opener_mock = mock.MagicMock()
         self.patch_object(openstack_utils, "get_urllib_opener")
         self.get_urllib_opener.return_value = urllib_opener_mock
@@ -219,11 +234,13 @@ class TestOpenStackUtils(ut_utils.BaseTestCase):
             'http://cirros/c.img', '/tmp/c1.img')
 
     def test_resource_reaches_status(self):
+        """Test resource_reaches_status when status is reached."""
         resource_mock = mock.MagicMock()
         resource_mock.get.return_value = mock.MagicMock(status='available')
         openstack_utils.resource_reaches_status(resource_mock, 'e01df65a')
 
     def test_resource_reaches_status_fail(self):
+        """Test resource_reaches_status when status is not reached."""
         openstack_utils.resource_reaches_status.retry.wait = \
             tenacity.wait_none()
         resource_mock = mock.MagicMock()
@@ -234,6 +251,7 @@ class TestOpenStackUtils(ut_utils.BaseTestCase):
                 'e01df65a')
 
     def test_resource_reaches_status_bespoke(self):
+        """Test resource_reaches_status when bespoke status is reached."""
         resource_mock = mock.MagicMock()
         resource_mock.get.return_value = mock.MagicMock(status='readyish')
         openstack_utils.resource_reaches_status(
@@ -242,6 +260,7 @@ class TestOpenStackUtils(ut_utils.BaseTestCase):
             'readyish')
 
     def test_resource_reaches_status_bespoke_fail(self):
+        """Test resource_reaches_status when bespoke status is not reached."""
         openstack_utils.resource_reaches_status.retry.wait = \
             tenacity.wait_none()
         resource_mock = mock.MagicMock()
@@ -253,11 +272,13 @@ class TestOpenStackUtils(ut_utils.BaseTestCase):
                 'readyish')
 
     def test_resource_removed(self):
+        """Test calling resource_removed."""
         resource_mock = mock.MagicMock()
         resource_mock.list.return_value = [mock.MagicMock(id='ba8204b0')]
         openstack_utils.resource_removed(resource_mock, 'e01df65a')
 
     def test_resource_removed_fail(self):
+        """Test how resource_removed handles failures."""
         openstack_utils.resource_reaches_status.retry.wait = \
             tenacity.wait_none()
         resource_mock = mock.MagicMock()
@@ -266,6 +287,7 @@ class TestOpenStackUtils(ut_utils.BaseTestCase):
             openstack_utils.resource_removed(resource_mock, 'e01df65a')
 
     def test_delete_resource(self):
+        """Test calling delete_resource."""
         resource_mock = mock.MagicMock()
         self.patch_object(openstack_utils, "resource_removed")
         openstack_utils.delete_resource(resource_mock, 'e01df65a')
@@ -276,6 +298,7 @@ class TestOpenStackUtils(ut_utils.BaseTestCase):
             'resource')
 
     def test_delete_image(self):
+        """Test calling delete_image."""
         self.patch_object(openstack_utils, "delete_resource")
         glance_mock = mock.MagicMock()
         openstack_utils.delete_image(glance_mock, 'b46c2d83')
@@ -285,6 +308,7 @@ class TestOpenStackUtils(ut_utils.BaseTestCase):
             msg="glance image")
 
     def test_upload_image_to_glance(self):
+        """Test calling upload_image_to_glance."""
         self.patch_object(openstack_utils, "resource_reaches_status")
         glance_mock = mock.MagicMock()
         image_mock = mock.MagicMock(id='9d1125af')
@@ -311,6 +335,7 @@ class TestOpenStackUtils(ut_utils.BaseTestCase):
                 msg='Image status wait')
 
     def test_create_image(self):
+        """Test calling create_image."""
         glance_mock = mock.MagicMock()
         self.patch_object(openstack_utils.os.path, "exists")
         self.patch_object(openstack_utils, "download_image")

--- a/unit_tests/utils.py
+++ b/unit_tests/utils.py
@@ -15,6 +15,8 @@
 # sys.modules['charmhelpers.contrib.openstack.utils'] = mock.MagicMock()
 # sys.modules['charmhelpers.contrib.network.ip'] = mock.MagicMock()
 
+"""Module to provide helper for writing unit tests."""
+
 import contextlib
 import io
 import mock
@@ -23,10 +25,13 @@ import unittest
 
 @contextlib.contextmanager
 def patch_open():
-    '''Patch open() to allow mocking both open() itself and the file that is
+    """Patch open().
+
+    Patch open() to allow mocking both open() itself and the file that is
     yielded.
 
-    Yields the mock for "open" and "file", respectively.'''
+    Yields the mock for "open" and "file", respectively.
+    """
     mock_open = mock.MagicMock(spec=open)
     mock_file = mock.MagicMock(spec=io.FileIO)
 
@@ -40,12 +45,15 @@ def patch_open():
 
 
 class BaseTestCase(unittest.TestCase):
+    """Base class for creating classes of unit tests."""
 
     def setUp(self):
+        """Run setup of patches."""
         self._patches = {}
         self._patches_start = {}
 
     def tearDown(self):
+        """Run teardown of patches."""
         for k, v in self._patches.items():
             v.stop()
             setattr(self, k, None)
@@ -54,6 +62,7 @@ class BaseTestCase(unittest.TestCase):
 
     def patch_object(self, obj, attr, return_value=None, name=None, new=None,
                      **kwargs):
+        """Patch the given object."""
         if name is None:
             name = attr
         if new is not None:
@@ -68,6 +77,7 @@ class BaseTestCase(unittest.TestCase):
         setattr(self, name, started)
 
     def patch(self, item, return_value=None, name=None, new=None, **kwargs):
+        """Patch the given item."""
         if name is None:
             raise RuntimeError("Must pass 'name' to .patch()")
         if new is not None:


### PR DESCRIPTION
This PR adds doc strings for units and adds the docstring flake8
plugin (flake8-docstrings), so all subsequent PRs will be checked
for doc strings.

The unit test doc strings are simplistic. Where there is a
function has a single unit test I have just added
"Test <function name>." as the doc string. Where there are multiple
unit tests for a function I have explained what each test is looking
for.