### PR TITLE
Allow charms to override local overlay

### DIFF
--- a/unit_tests/test_zaza_charm_lifecycle_deploy.py
+++ b/unit_tests/test_zaza_charm_lifecycle_deploy.py
@@ -118,6 +118,33 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
         self.get_template.return_value = None
         self.assertIsNone(lc_deploy.render_overlay('mybundle.yaml', '/tmp/'))
 
+    def test_render_local_overlay(self):
+        self.patch_object(lc_deploy.jinja2, 'Environment')
+        self.patch_object(lc_deploy, 'get_template', return_value='atemplate')
+        self.patch_object(lc_deploy, 'render_template')
+        self.assertEqual(
+            lc_deploy.render_local_overlay('/target'),
+            '/target/local-charm-overlay.yaml')
+        self.assertFalse(self.Environment.called)
+        self.render_template.assert_called_once_with(
+            'atemplate',
+            '/target/local-charm-overlay.yaml')
+
+    def test_render_local_overlay_default(self):
+        jenv_mock = mock.MagicMock()
+        jenv_mock.from_string.return_value = 'atemplate'
+        self.patch_object(lc_deploy.jinja2, 'Environment',
+                          return_value=jenv_mock)
+        self.patch_object(lc_deploy, 'get_template', return_value=None)
+        self.patch_object(lc_deploy, 'render_template')
+        self.assertEqual(
+            lc_deploy.render_local_overlay('/target'),
+            '/target/local-charm-overlay.yaml')
+        jenv_mock.from_string.assert_called_once_with(mock.ANY)
+        self.render_template.assert_called_once_with(
+            'atemplate',
+            '/target/local-charm-overlay.yaml')
+
     def test_render_overlays(self):
         RESP = {
             'mybundles/mybundle.yaml': '/tmp/mybundle.yaml'}

--- a/zaza/charm_lifecycle/deploy.py
+++ b/zaza/charm_lifecycle/deploy.py
@@ -24,6 +24,7 @@ applications:
   {{ charm_name }}:
     charm: {{ charm_location }}
 """
+LOCAL_OVERLAY_TEMPLATE_NAME = 'local-charm-overlay.yaml'
 
 
 def is_valid_env_key(key):
@@ -169,11 +170,13 @@ def render_local_overlay(target_dir):
     :returns: Path to rendered overlay
     :rtype: str
     """
-    template = jinja2.Environment(loader=jinja2.BaseLoader).from_string(
-        LOCAL_OVERLAY_TEMPLATE)
+    template = get_template(LOCAL_OVERLAY_TEMPLATE_NAME)
+    if not template:
+        template = jinja2.Environment(loader=jinja2.BaseLoader).from_string(
+            LOCAL_OVERLAY_TEMPLATE)
     rendered_template_file = os.path.join(
         target_dir,
-        os.path.basename('local-charm-overlay.yaml'))
+        os.path.basename(LOCAL_OVERLAY_TEMPLATE_NAME))
     render_template(template, rendered_template_file)
     return rendered_template_file
 


### PR DESCRIPTION
The local overlay ('local-charm-overlay.yaml') is generated on the
fly during deploy time and it assumes that the application name
will match the charm name. However this is not always the case so
allow charms to override the deploy time generated template with
one from the local tests/bundle/overlay directory.

This is really another stop-gap until the whole bundle generation
piece is rewritten.