### PR TITLE
Changes to enable testing creating a guest

### DIFF
--- a/unit_tests/utilities/test_zaza_utilities_cert.py
+++ b/unit_tests/utilities/test_zaza_utilities_cert.py
@@ -3,6 +3,38 @@ import mock
 import unit_tests.utils as ut_utils
 import zaza.utilities.cert as cert
 
+TEST_SSH_PRIVATE_KEY = """
+-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEAvWNz+tJAVyudNsDYrFK4CnJV+/nBmjYJXC3Zf42RFmzJ/Sff
+bMSXM/OBPOPtpJg/FawzsTgoHQRMQ/oEcKRSJ0ZGQINlwlrfHdyJcdyH4ifad2oT
+42cYRW0yMJggQGe7ttruCvY0mZugwrCjHoX3bqKjSg7YaMpyUKBa2cwCWJu/GUlp
+sT1jjY89QYvzb/Auj5lMfk8Qmc4fIcC7EZ+lf+1iuwg7OJjRKbsBqVhUgTKisTxD
+kzvo6SLy49j+mWUjfWlCI74D6QhW8OH9sN6MxI1sYiomPrCo+eBc1fkr0dUT8xd6
+t1UL6HHx8XkO16BMbLc+lIVNiifZtAK3SL1BnwIDAQABAoIBABZYxtWgu3DNt6Y/
+SRHETO0GorixtrNwjtgunMxdMvJ3cboKW2WlKMY7hFNf/al/QWpYQF036BvMZwda
+V+3Gpd72ftGb74ToXg1S+XDS+cGovDF89c3OW2HNya9MM/oFg3PHD3GBraE2aNiw
+KP8wBYsra6MQb16mDKkQ0seCOACmY/4jYlZ/7YbFtZPBPeZpnlxg4hgFIkiJmuPf
+pmHpLFBhpmyo0yf3DGf/rsL9ti6LPBo8vCH6anM9ljn/BW2a3JA/ap4uUGb+FuoV
+lwa1by1L6uLNYQb3fSEtmEEIy1mn89SjlEPfHnooXdadTM+9zT9xIc1ArNOSZagU
+UHibUXECgYEA5C3h8d1MU5tKppoIM8aOC+OQFZbFd+bF8z+t7RdX9P6br5J0Ugtj
+GcykUz6IRQWGZRCsyM9zshK2gQRCul0byNcFjzIHhR62Va6h1u7iwN1F4qc8a5WS
+bb/1TEVprTSu9guW8OO/EmUgWkBgej4/j31F8PZG4+m1defLZXNo7skCgYEA1HrN
+UOaBMzaFujGRZjlF54v7flCa1YYcv51Dfk8LEScs/jJvTY664ofj6AfQQN37Akmh
+6B6jBfP8K7RxcJvAXE00oNliDvwo9TxoTc/F59HbgsEcR739fMjwvpOBWJg0zJy8
+28/29dy9e0Fcy6ay55l050+0CBdzkvTWNHBVWScCgYEAhsTi0qvWTPtHmCcZ+Rqp
+AzShAV9PuoW/HPDblVFYTgejhIuH0H2RRserts8URVACFOdIZkLBHsgWqxUNJG2h
+33nAetcdwe5l2y2NwRjPLQKEKF6GPTTWi6P5CddllzuqqwAlYpnhXMgF18h2Mz1Y
+5TMkgDG1pR+AYedKJt2HeKECgYAKR+LVTkHkG3g++RUC8DR8rp49j2Lef/22G8Lf
+Qq3TZ6Taq9AM3aIXQeH6IR6ndNYnVy65T3ot2I9UAggXHcIh9S5dtgbzmKnWq9SU
+J0B5JgNMAVH/+qZgOkzDu9lfUwYC/HZ64EYfwU19wDzgMbGoWRl587ZPSesyqhwP
+L3xBswKBgQDc3WnWDP/KFjzWKY8KG4XZYKvvOy1en4hytbWrFssu5HlYoQeRgAog
+K8ZAFLW2Mn0QebwL/gXSDYlZHmu6EbnO4v1kzRMi6aQxYOgKJWLEwj3r3hzJh6YU
+QEGH15IncVqMch6HIir4oTF7RY2BsikDDY/GB/l0pRfZrGl9mnrY6Q==
+-----END RSA PRIVATE KEY-----
+"""
+TEST_SSH_PUB_KEY = """ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC9Y3P60kBXK502wNisUrgKclX7+cGaNglcLdl/jZEWbMn9J99sxJcz84E84+2kmD8VrDOxOCgdBExD+gRwpFInRkZAg2XCWt8d3Ilx3IfiJ9p3ahPjZxhFbTIwmCBAZ7u22u4K9jSZm6DCsKMehfduoqNKDthoynJQoFrZzAJYm78ZSWmxPWONjz1Bi/Nv8C6PmUx+TxCZzh8hwLsRn6V/7WK7CDs4mNEpuwGpWFSBMqKxPEOTO+jpIvLj2P6ZZSN9aUIjvgPpCFbw4f2w3ozEjWxiKiY+sKj54FzV+SvR1RPzF3q3VQvocfHxeQ7XoExstz6UhU2KJ9m0ArdIvUGf ubuntu@gnuoy-bastion """  # noqa
+TEST_SSH_PUB_KEY_INVALID = """ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDMz6U88GVhwAjjhzSrcyKKWe3LfB4pK4Ap6XpIfSmiVDPTBiBU3wzj1YAIBo26OMHDkfUnmtBgtzOfcb64QPaUmMfCkzadxrd8inYlpz+0AoahCTTONkElMxj+wa7SYVF4GphrDKDvlPi83bcLmO39veNVcLYHcDa+9mWBP3AlI3TdKqJpgOtCzLu9qbhlpmYa7YD6ijQrTJI3wOOw0uZeEARVCCKU44BVUFnWrNx5ioihETj9rAxRFrm1dx8mKDP0fCf53/Xn+LKLcYBPVovT6BpBHkaLuG6mTYU7puHN607wRhRwYhc3Y9y0sd6rHykYKL3G27w08s597paFtXg5 ubuntu@gnuoy-bastion"""  # noqa
+
 
 class TestUtilitiesCert(ut_utils.BaseTestCase):
 
@@ -235,3 +267,11 @@ class TestUtilitiesCert(ut_utils.BaseTestCase):
         self.builder_mock.add_extension.assert_called_once_with(
             self.bcons_mock(),
             critical=True)
+
+    def test_is_keys_valid(self):
+        self.assertTrue(
+            cert.is_keys_valid(TEST_SSH_PUB_KEY, TEST_SSH_PRIVATE_KEY))
+
+    def test_is_keys_valid_invalid(self):
+        self.assertFalse(
+            cert.is_keys_valid(TEST_SSH_PUB_KEY_INVALID, TEST_SSH_PRIVATE_KEY))

--- a/zaza/charm_tests/glance/setup.py
+++ b/zaza/charm_tests/glance/setup.py
@@ -3,6 +3,14 @@
 import zaza.utilities.openstack as openstack_utils
 
 
+def basic_setup():
+    """Run setup for testing glance.
+
+    Glance setup for testing glance is currently part of glance functional
+    tests. Image setup for other tests to use should go here.
+    """
+
+
 def add_cirros_image(glance_client=None):
     """Add a cirros image to the current deployment.
 
@@ -17,13 +25,24 @@ def add_cirros_image(glance_client=None):
     openstack_utils.create_image(
         glance_client,
         image_url,
-        'cirrosimage')
+        'cirros')
 
 
-def basic_setup():
-    """Run setup for testing glance.
+def add_lts_image(glance_client=None):
+    """Add an Ubuntu LTS image to the current deployment.
 
-    Glance setup for testing glance is currently part of glance functional
-    tests. Image setup for other tests to use should go here.
+    :param glance: Authenticated glanceclient
+    :type glance: glanceclient.Client
     """
-    add_cirros_image()
+    if not glance_client:
+        keystone_session = openstack_utils.get_overcloud_keystone_session()
+        glance_client = openstack_utils.get_glance_session_client(
+            keystone_session)
+    image_url = openstack_utils.find_ubuntu_image(
+        release='bionic',
+        arch='amd64')
+    print(image_url)
+    openstack_utils.create_image(
+        glance_client,
+        image_url,
+        'bionic')

--- a/zaza/charm_tests/neutron/__init__.py
+++ b/zaza/charm_tests/neutron/__init__.py
@@ -1,0 +1,1 @@
+"""Collection of code for setting up and testing neutron."""

--- a/zaza/charm_tests/neutron/setup.py
+++ b/zaza/charm_tests/neutron/setup.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Setup for Neutron deployments."""
+
+from zaza.configure import (
+    network,
+)
+from zaza.utilities import (
+    cli as cli_utils,
+    generic as generic_utils,
+    juju as juju_utils,
+    openstack as openstack_utils,
+)
+
+# The overcloud network configuration settings are declared.
+# These are the network configuration settings under test.
+OVERCLOUD_NETWORK_CONFIG = {
+    "network_type": "gre",
+    "router_name": "provider-router",
+    "ip_version": "4",
+    "address_scope": "public",
+    "external_net_name": "ext_net",
+    "external_subnet_name": "ext_net_subnet",
+    "prefix_len": "24",
+    "subnetpool_name": "pooled_subnets",
+    "subnetpool_prefix": "192.168.0.0/16",
+}
+
+# The undercloud network configuration settings are substrate specific to
+# the environment where the tests are being executed. These settings may be
+# overridden by environment variables. See the doc string documentation for
+# zaza.utilities.generic_utils.get_undercloud_env_vars for the environment
+# variables required to be exported and available to zaza.
+# These are default settings provided as an example.
+DEFAULT_UNDERCLOUD_NETWORK_CONFIG = {
+    "start_floating_ip": "10.5.150.0",
+    "end_floating_ip": "10.5.150.254",
+    "external_dns": "10.5.0.2",
+    "external_net_cidr": "10.5.0.0/16",
+    "default_gateway": "10.5.0.1",
+}
+
+
+def basic_overcloud_network():
+    """Run setup for neutron networking.
+
+    Configure the following:
+        The overcloud network using subnet pools
+
+    """
+    cli_utils.setup_logging()
+
+    # Get network configuration settings
+    network_config = {}
+    # Declared overcloud settings
+    network_config.update(OVERCLOUD_NETWORK_CONFIG)
+    # Default undercloud settings
+    network_config.update(DEFAULT_UNDERCLOUD_NETWORK_CONFIG)
+    # Environment specific settings
+    network_config.update(generic_utils.get_undercloud_env_vars())
+
+    # Get keystone session
+    keystone_session = openstack_utils.get_overcloud_keystone_session()
+
+    # Handle network for Openstack-on-Openstack scenarios
+    if juju_utils.get_provider_type() == "openstack":
+        undercloud_ks_sess = openstack_utils.get_undercloud_keystone_session()
+        network.setup_gateway_ext_port(network_config,
+                                       keystone_session=undercloud_ks_sess)
+
+    # Confugre the overcloud network
+    network.setup_sdn(network_config, keystone_session=keystone_session)

--- a/zaza/charm_tests/nova/__init__.py
+++ b/zaza/charm_tests/nova/__init__.py
@@ -1,0 +1,1 @@
+"""Collection of code for setting up and testing nova."""

--- a/zaza/charm_tests/nova/setup.py
+++ b/zaza/charm_tests/nova/setup.py
@@ -1,0 +1,51 @@
+"""Code for configureing nova."""
+
+import zaza.utilities.openstack as openstack_utils
+from zaza.utilities import (
+    cli as cli_utils,
+)
+import zaza.charm_tests.nova.utils as nova_utils
+
+
+def create_flavors(nova_client=None):
+    """Create basic flavors.
+
+    :param nova_client: Authenticated nova client
+    :type nova_client: novaclient.v2.client.Client
+    """
+    if not nova_client:
+        keystone_session = openstack_utils.get_overcloud_keystone_session()
+        nova_client = openstack_utils.get_nova_session_client(
+            keystone_session)
+    cli_utils.setup_logging()
+    names = [flavor.name for flavor in nova_client.flavors.list()]
+    for flavor in nova_utils.FLAVORS.keys():
+        if flavor not in names:
+            nova_client.flavors.create(
+                name=flavor,
+                ram=nova_utils.FLAVORS[flavor]['ram'],
+                vcpus=nova_utils.FLAVORS[flavor]['vcpus'],
+                disk=nova_utils.FLAVORS[flavor]['disk'],
+                flavorid=nova_utils.FLAVORS[flavor]['flavorid'])
+
+
+def manage_ssh_key(nova_client=None):
+    """Create basic flavors.
+
+    :param nova_client: Authenticated nova client
+    :type nova_client: novaclient.v2.client.Client
+    """
+    if not nova_client:
+        keystone_session = openstack_utils.get_overcloud_keystone_session()
+        nova_client = openstack_utils.get_nova_session_client(
+            keystone_session)
+    cli_utils.setup_logging()
+    if not openstack_utils.valid_key_exists(nova_client,
+                                            nova_utils.KEYPAIR_NAME):
+        key = openstack_utils.create_ssh_key(
+            nova_client,
+            nova_utils.KEYPAIR_NAME,
+            replace=True)
+        openstack_utils.write_private_key(
+            nova_utils.KEYPAIR_NAME,
+            key.private_key)

--- a/zaza/charm_tests/nova/tests.py
+++ b/zaza/charm_tests/nova/tests.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Encapsulate nova testing."""
+
+import logging
+import time
+import unittest
+
+import zaza.model as model
+import zaza.utilities.openstack as openstack_utils
+import zaza.charm_tests.nova.utils as nova_utils
+
+
+class BaseGuestCreateTest(unittest.TestCase):
+    """Base for tests to launch a guest."""
+
+    boot_tests = {
+        'cirros': {
+            'image_name': 'cirrosimage',
+            'flavor_name': 'm1.tiny',
+            'username': 'cirros',
+            'bootstring': 'gocubsgo',
+            'password': 'gocubsgo'},
+        'bionic': {
+            'image_name': 'bionic',
+            'flavor_name': 'm1.small',
+            'username': 'ubuntu',
+            'bootstring': 'finished at'}}
+
+    @classmethod
+    def setUpClass(cls):
+        """Run class setup for running glance tests."""
+        cls.keystone_session = openstack_utils.get_overcloud_keystone_session()
+        cls.model_name = model.get_juju_model()
+        cls.nova_client = openstack_utils.get_nova_session_client(
+            cls.keystone_session)
+        cls.neutron_client = openstack_utils.get_neutron_session_client(
+            cls.keystone_session)
+
+    def launch_instance(self, instance_key):
+        """Launch an instance.
+
+        :param instance_key: Key to collect associated config data with.
+        :type instance_key: str
+        """
+        # Collect resource information.
+        vm_name = time.strftime("%Y%m%d%H%M%S")
+        image = self.nova_client.glance.find_image(
+            self.boot_tests[instance_key]['image_name'])
+        flavor = self.nova_client.flavors.find(
+            name=self.boot_tests[instance_key]['flavor_name'])
+        net = self.neutron_client.find_resource("network", "private")
+        nics = [{'net-id': net.get('id')}]
+
+        # Launch instance.
+        logging.info('Launching instance {}'.format(vm_name))
+        instance = self.nova_client.servers.create(
+            name=vm_name,
+            image=image,
+            flavor=flavor,
+            key_name=nova_utils.KEYPAIR_NAME,
+            nics=nics)
+
+        # Test Instance is ready.
+        logging.info('Checking instance is active')
+        openstack_utils.resource_reaches_status(
+            self.nova_client.servers,
+            instance.id,
+            expected_status='ACTIVE')
+
+        logging.info('Checking cloud init is complete')
+        openstack_utils.cloud_init_complete(
+            self.nova_client,
+            instance.id,
+            self.boot_tests[instance_key]['bootstring'])
+        port = openstack_utils.get_ports_from_device_id(
+            self.neutron_client,
+            instance.id)[0]
+        logging.info('Assigning floating ip.')
+        ip = openstack_utils.create_floating_ip(
+            self.neutron_client,
+            "ext_net",
+            port=port)['floating_ip_address']
+        logging.info('Assigned floating IP {} to {}'.format(ip, vm_name))
+        openstack_utils.ping_response(ip)
+
+        # Check ssh'ing to instance.
+        logging.info('Testing ssh access.')
+        openstack_utils.ssh_test(
+            username=self.boot_tests[instance_key]['username'],
+            ip=ip,
+            vm_name=vm_name,
+            password=self.boot_tests[instance_key].get('password'),
+            privkey=openstack_utils.get_private_key(nova_utils.KEYPAIR_NAME))
+
+
+class CirrosGuestCreateTest(BaseGuestCreateTest):
+    """Tests to launch a cirros image."""
+
+    def test_launch_small_cirros_instance(self):
+        """Launch a cirros instance and test connectivity."""
+        self.launch_instance('cirros')
+
+
+class LTSGuestCreateTest(BaseGuestCreateTest):
+    """Tests to launch a LTS image."""
+
+    def test_launch_small_cirros_instance(self):
+        """Launch a cirros instance and test connectivity."""
+        self.launch_instance('bionic')

--- a/zaza/charm_tests/nova/utils.py
+++ b/zaza/charm_tests/nova/utils.py
@@ -1,0 +1,25 @@
+"""Data for nova tests."""
+
+FLAVORS = {
+    'm1.tiny': {
+        'flavorid': 1,
+        'ram': 512,
+        'disk': 1,
+        'vcpus': 1},
+    'm1.small': {
+        'flavorid': 2,
+        'ram': 2048,
+        'disk': 20,
+        'vcpus': 1},
+    'm1.medium': {
+        'flavorid': 3,
+        'ram': 4096,
+        'disk': 40,
+        'vcpus': 2},
+    'm1.large': {
+        'flavorid': 4,
+        'ram': 8192,
+        'disk': 40,
+        'vcpus': 4},
+}
+KEYPAIR_NAME = 'zaza'

--- a/zaza/charm_tests/test_utils.py
+++ b/zaza/charm_tests/test_utils.py
@@ -35,8 +35,8 @@ class OpenStackBaseTest(unittest.TestCase):
         cls.test_config = lifecycle_utils.get_charm_config()
         cls.application_name = cls.test_config['charm_name']
         cls.first_unit = model.get_first_unit_name(
-            cls.model_name,
-            cls.application_name)
+            cls.application_name,
+            model_name=cls.model_name)
         logging.debug('First unit is {}'.format(cls.first_unit))
 
     def restart_on_changed(self, config_file, default_config, alternate_config,
@@ -65,58 +65,60 @@ class OpenStackBaseTest(unittest.TestCase):
         # first_unit is only useed to grab a timestamp, the assumption being
         # that all the units times are in sync.
 
-        mtime = model.get_unit_time(self.model_name, self.first_unit)
+        mtime = model.get_unit_time(
+            self.first_unit,
+            model_name=self.model_name)
         logging.debug('Remote unit timestamp {}'.format(mtime))
 
         logging.debug('Changing charm setting to {}'.format(alternate_config))
         model.set_application_config(
-            self.model_name,
             self.application_name,
-            alternate_config)
+            alternate_config,
+            model_name=self.model_name)
 
         logging.debug(
             'Waiting for updates to propagate to {}'.format(config_file))
         model.block_until_oslo_config_entries_match(
-            self.model_name,
             self.application_name,
             config_file,
-            alternate_entry)
+            alternate_entry,
+            model_name=self.model_name)
 
         logging.debug(
             'Waiting for units to reach target states'.format(config_file))
         model.wait_for_application_states(
-            self.model_name,
-            self.test_config.get('target_deploy_status', {}))
+            self.test_config.get('target_deploy_status', {}),
+            model_name=self.model_name)
 
         # Config update has occured and hooks are idle. Any services should
         # have been restarted by now:
         logging.debug(
             'Waiting for services ({}) to be restarted'.format(services))
         model.block_until_services_restarted(
-            self.model_name,
             self.application_name,
             mtime,
-            services)
+            services,
+            model_name=self.model_name)
 
         logging.debug('Restoring charm setting to {}'.format(default_config))
         model.set_application_config(
-            self.model_name,
             self.application_name,
-            default_config)
+            default_config,
+            model_name=self.model_name)
 
         logging.debug(
             'Waiting for updates to propagate to '.format(config_file))
         model.block_until_oslo_config_entries_match(
-            self.model_name,
             self.application_name,
             config_file,
-            default_entry)
+            default_entry,
+            model_name=self.model_name)
 
         logging.debug(
             'Waiting for units to reach target states'.format(config_file))
         model.wait_for_application_states(
-            self.model_name,
-            self.test_config.get('target_deploy_status', {}))
+            self.test_config.get('target_deploy_status', {}),
+            model_name=self.model_name)
 
     def pause_resume(self, services):
         """Run Pause and resume tests.
@@ -129,33 +131,41 @@ class OpenStackBaseTest(unittest.TestCase):
         :type services: list
         """
         model.block_until_service_status(
-            self.model_name,
             self.first_unit,
             services,
-            'running')
+            'running',
+            model_name=self.model_name)
         model.block_until_unit_wl_status(
-            self.model_name,
             self.first_unit,
-            'active')
-        model.run_action(self.model_name, self.first_unit, 'pause', {})
+            'active',
+            model_name=self.model_name)
+        model.run_action(
+            self.first_unit,
+            'pause',
+            {},
+            model_name=self.model_name)
         model.block_until_unit_wl_status(
-            self.model_name,
             self.first_unit,
-            'maintenance')
-        model.block_until_all_units_idle(self.model_name)
+            'maintenance',
+            model_name=self.model_name)
+        model.block_until_all_units_idle(model_name=self.model_name)
         model.block_until_service_status(
-            self.model_name,
             self.first_unit,
             services,
-            'stopped')
-        model.run_action(self.model_name, self.first_unit, 'resume', {})
+            'stopped',
+            model_name=self.model_name)
+        model.run_action(
+            self.first_unit,
+            'resume',
+            {},
+            model_name=self.model_name)
         model.block_until_unit_wl_status(
-            self.model_name,
             self.first_unit,
-            'active')
-        model.block_until_all_units_idle(self.model_name)
+            'active',
+            model_name=self.model_name)
+        model.block_until_all_units_idle(model_name=self.model_name)
         model.block_until_service_status(
-            self.model_name,
             self.first_unit,
             services,
-            'running')
+            'running',
+            model_name=self.model_name)

--- a/zaza/utilities/exceptions.py
+++ b/zaza/utilities/exceptions.py
@@ -5,3 +5,15 @@ class MissingOSAthenticationException(Exception):
     """Exception when some data needed to authenticate is missing."""
 
     pass
+
+
+class CloudInitIncomplete(Exception):
+    """Cloud init has not completed properly."""
+
+    pass
+
+
+class SSHFailed(Exception):
+    """SSH failed."""
+
+    pass


### PR DESCRIPTION
This is a bundle of disparate changes that enable testing the
creating of a guest instance. At a high level these are:

* Add helpers for downloading ubuntu images.
* Add method for setting up a basic overcloud network. This is very
  similar to zaza.configure.network.run_from_cli
* Add nova setup module that includes create_flavors and
  manage_ssh_key
* Add nova test base class for launching an instance and two
  derived classes for launching a cirros and lts image respectively.
* Fixes to zaza.charm_tests.test_utils after the refactor of the model
  argument in zaza.models
* New certs.is_keys_valid function to check if a public and private
  key are a pair.
* Methods in utilities.openstack for managing ssh keys. On creation of
  a new key the private key is stored locally and the public key is
  retrieved from Openstack
* Methods in utilities.openstack for testing guests at various points
  of the creation process.