### PR TITLE
Add a way to compare OS release pair

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ dist/
 .local
 zaza.egg-info/
 .coverage
+.vscode/
 # Sphinx
 doc/build

--- a/unit_tests/utilities/test_zaza_utilities_juju.py
+++ b/unit_tests/utilities/test_zaza_utilities_juju.py
@@ -227,3 +227,18 @@ class TestJujuUtils(ut_utils.BaseTestCase):
         self.model.run_on_leader.assert_called_with(
             'application', 'leader-get --format=yaml ')
         self.assertFalse(self.yaml.load.called)
+
+    def test_get_machine_series(self):
+        self.patch(
+            'zaza.utilities.juju.get_machine_status',
+            new_callable=mock.MagicMock(),
+            name='_get_machine_status'
+        )
+        self._get_machine_status.return_value = 'xenial'
+        expected = 'xenial'
+        actual = juju_utils.get_machine_series('6')
+        self._get_machine_status.assert_called_with(
+            machine='6',
+            key='series'
+        )
+        self.assertEqual(expected, actual)

--- a/unit_tests/utilities/test_zaza_utilities_openstack.py
+++ b/unit_tests/utilities/test_zaza_utilities_openstack.py
@@ -680,7 +680,13 @@ class TestOpenStackUtils(ut_utils.BaseTestCase):
         with self.assertRaises(exceptions.OSVersionNotFound):
             openstack_utils.get_current_os_release_pair()
 
-        # Normal scenario
+        # Normal scenario, argument passed
+        self._get_os_version.return_value = {'keystone': 'mitaka'}
+        expected = 'xenial_mitaka'
+        result = openstack_utils.get_current_os_release_pair('keystone')
+        self.assertEqual(expected, result)
+
+        # Normal scenario, default value used
         self._get_os_version.return_value = {'keystone': 'mitaka'}
         expected = 'xenial_mitaka'
         result = openstack_utils.get_current_os_release_pair()

--- a/unit_tests/utilities/test_zaza_utilities_openstack.py
+++ b/unit_tests/utilities/test_zaza_utilities_openstack.py
@@ -658,9 +658,9 @@ class TestOpenStackUtils(ut_utils.BaseTestCase):
             name='_get_machines'
         )
         self.patch(
-            'zaza.utilities.juju.get_machine_status',
+            'zaza.utilities.juju.get_machine_series',
             new_callable=mock.MagicMock(),
-            name='_get_machine_status'
+            name='_get_machine_series'
         )
 
         # No machine returned
@@ -670,12 +670,12 @@ class TestOpenStackUtils(ut_utils.BaseTestCase):
 
         # No series returned
         self._get_machines.return_value = ['6']
-        self._get_machine_status.return_value = None
+        self._get_machine_series.return_value = None
         with self.assertRaises(exceptions.SeriesNotFound):
             openstack_utils.get_current_os_release_pair()
 
         # No OS Version returned
-        self._get_machine_status.return_value = 'xenial'
+        self._get_machine_series.return_value = 'xenial'
         self._get_os_version.return_value = {}
         with self.assertRaises(exceptions.OSVersionNotFound):
             openstack_utils.get_current_os_release_pair()

--- a/unit_tests/utilities/test_zaza_utilities_openstack.py
+++ b/unit_tests/utilities/test_zaza_utilities_openstack.py
@@ -665,7 +665,7 @@ class TestOpenStackUtils(ut_utils.BaseTestCase):
 
         # No machine returned
         self._get_machines.return_value = []
-        with self.assertRaises(exceptions.NoKeystoneFound):
+        with self.assertRaises(exceptions.ApplicationNotFound):
             openstack_utils.get_current_os_release_pair()
 
         # No series returned

--- a/zaza/utilities/exceptions.py
+++ b/zaza/utilities/exceptions.py
@@ -29,3 +29,27 @@ class NeutronBGPSpeakerMissing(Exception):
     """No BGP speaker appeared on agent."""
 
     pass
+
+
+class NoKeystoneFound(Exception):
+    """No Keystone found in machines."""
+
+    pass
+
+
+class SeriesNotFound(Exception):
+    """Series not found in status."""
+
+    pass
+
+
+class OSVersionNotFound(Exception):
+    """OS Version not found."""
+
+    pass
+
+
+class ReleasePairNotFound(Exception):
+    """Release pair was not found in OPENSTACK_RELEASES_PAIRS."""
+
+    pass

--- a/zaza/utilities/exceptions.py
+++ b/zaza/utilities/exceptions.py
@@ -31,10 +31,19 @@ class NeutronBGPSpeakerMissing(Exception):
     pass
 
 
-class NoKeystoneFound(Exception):
-    """No Keystone found in machines."""
+class ApplicationNotFound(Exception):
+    """Application not found in machines."""
 
-    pass
+    def __init__(self, application):
+        """Create Application not found exception.
+
+        :param application: Name of the application
+        :type application: string
+        :returns: ApplicationNotFound Exception
+        """
+        msg = ("{} application was not found in machines.".
+               format(application))
+        super(ApplicationNotFound, self).__init__(msg)
 
 
 class SeriesNotFound(Exception):

--- a/zaza/utilities/juju.py
+++ b/zaza/utilities/juju.py
@@ -115,6 +115,20 @@ def get_machine_status(machine, key=None):
     return status
 
 
+def get_machine_series(machine):
+    """Return the juju series for a machine.
+
+    :param machine: Machine number
+    :type machine: string
+    :returns: Juju series
+    :rtype: string
+    """
+    return get_machine_status(
+        machine=machine,
+        key='series'
+    )
+
+
 def get_machine_uuids_for_application(application):
     """Return machine uuids for a given application.
 

--- a/zaza/utilities/openstack.py
+++ b/zaza/utilities/openstack.py
@@ -1131,7 +1131,7 @@ def get_current_os_release_pair(application='keystone'):
     :type application: string
     :returns: Name of the OpenStack release pair
     :rtype: str
-    :raises: exceptions.NoKeystoneFound
+    :raises: exceptions.ApplicationNotFound
     :raises: exceptions.SeriesNotFound
     :raises: exceptions.OSVersionNotFound
     """
@@ -1139,7 +1139,7 @@ def get_current_os_release_pair(application='keystone'):
     if len(machines) >= 1:
         machine = machines[0]
     else:
-        raise exceptions.NoKeystoneFound()
+        raise exceptions.ApplicationNotFound(application)
 
     series = juju_utils.get_machine_series(machine)
     if not series:

--- a/zaza/utilities/openstack.py
+++ b/zaza/utilities/openstack.py
@@ -1124,26 +1124,28 @@ def get_application_config_keys(application):
     return list(application_config.keys())
 
 
-def get_current_os_release_pair():
+def get_current_os_release_pair(application='keystone'):
     """Return OpenStack Release pair name.
 
+    :param application: Name of application
+    :type application: string
     :returns: Name of the OpenStack release pair
     :rtype: str
     :raises: exceptions.NoKeystoneFound
     :raises: exceptions.SeriesNotFound
     :raises: exceptions.OSVersionNotFound
     """
-    keystone = juju_utils.get_machines_for_application('keystone')
-    if len(keystone) >= 1:
-        keystone = keystone[0]
+    machines = juju_utils.get_machines_for_application(application)
+    if len(machines) >= 1:
+        machine = machines[0]
     else:
         raise exceptions.NoKeystoneFound()
 
-    series = juju_utils.get_machine_status(keystone, key='series')
+    series = juju_utils.get_machine_status(machine, key='series')
     if not series:
         raise exceptions.SeriesNotFound()
 
-    os_version = get_current_os_versions(['keystone']).get('keystone')
+    os_version = get_current_os_versions([application]).get(application)
     if not os_version:
         raise exceptions.OSVersionNotFound()
 

--- a/zaza/utilities/openstack.py
+++ b/zaza/utilities/openstack.py
@@ -1141,7 +1141,7 @@ def get_current_os_release_pair(application='keystone'):
     else:
         raise exceptions.NoKeystoneFound()
 
-    series = juju_utils.get_machine_status(machine, key='series')
+    series = juju_utils.get_machine_series(machine)
     if not series:
         raise exceptions.SeriesNotFound()
 

--- a/zaza/utilities/os_versions.py
+++ b/zaza/utilities/os_versions.py
@@ -37,6 +37,12 @@ OPENSTACK_CODENAMES = OrderedDict([
     ('2018.1', 'queens'),
 ])
 
+OPENSTACK_RELEASES_PAIRS = [
+    'trusty_icehouse', 'trusty_kilo', 'trusty_liberty',
+    'trusty_mitaka', 'xenial_mitaka', 'xenial_newton',
+    'yakkety_newton', 'xenial_ocata', 'zesty_ocata',
+    'xenial_pike', 'artful_pike', 'xenial_queens',
+    'bionic_queens', 'bionic_rocky', 'cosmic_rocky']
 
 # The ugly duckling - must list releases oldest to newest
 SWIFT_CODENAMES = OrderedDict([


### PR DESCRIPTION
It was a functionality available in charm helpers. It is implemented in
a similar way:
* Get the current series from the `keystone` machine
* Get the OS version from `get_current_os_versions`
* Try to find the built string in `OPENSTACK_RELEASES_PAIRS`
It is thus possible to compare release pairs as it returns integers.