### PR TITLE
Fix race in `test_utils.config_change()`

### DIFF
--- a/zaza/charm_tests/test_utils.py
+++ b/zaza/charm_tests/test_utils.py
@@ -78,6 +78,10 @@ class OpenStackBaseTest(unittest.TestCase):
             model_name=self.model_name)
 
         logging.debug(
+            'Waiting for units to execute config-changed hook')
+        model.wait_for_agent_status(model_name=self.model_name)
+
+        logging.debug(
             'Waiting for units to reach target states')
         model.wait_for_application_states(
             model_name=self.model_name,


### PR DESCRIPTION
When changing config we have a race that make the idle/ready
check run *before* the `config-changed` hook has started executing
on units.  Subsequently tests are sometimes executed before or while
configuration change is in progress, leading to intermittent false
negative test failures.

Fixes #113