### PR TITLE
Modify the venv tox environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,9 @@ deps = -r{toxinidir}/requirements.txt
 commands = flake8 {posargs} zaza unit_tests
 
 [testenv:venv]
-commands = {posargs}
+basepython = python3
+deps = -r{toxinidir}/requirements.txt
+commands = /bin/true
 
 [flake8]
 ignore = E402,E226


### PR DESCRIPTION
* Make it target python3
* Install the necessary dependencies
* Use /bin/true to not raise error when using it via `tox -e venv`