### PR TITLE
Undercloud keystone scope

### DIFF
--- a/unit_tests/utilities/test_zaza_utilities_openstack.py
+++ b/unit_tests/utilities/test_zaza_utilities_openstack.py
@@ -271,16 +271,12 @@ class TestOpenStackUtils(ut_utils.BaseTestCase):
 
     def test_get_undercloud_keystone_session(self):
         self.patch_object(openstack_utils, "get_keystone_session")
-        self.patch_object(openstack_utils, "get_keystone_scope")
         self.patch_object(openstack_utils, "get_undercloud_auth")
         _auth = "FAKE_AUTH"
-        _scope = "PROJECT"
-        self.get_keystone_scope.return_value = _scope
         self.get_undercloud_auth.return_value = _auth
 
         openstack_utils.get_undercloud_keystone_session()
-        self.get_keystone_session.assert_called_once_with(_auth, scope=_scope,
-                                                          verify=None)
+        self.get_keystone_session.assert_called_once_with(_auth, verify=None)
 
     def test_get_urllib_opener(self):
         self.patch_object(openstack_utils.urllib.request, "ProxyHandler")

--- a/zaza/utilities/openstack.py
+++ b/zaza/utilities/openstack.py
@@ -199,7 +199,7 @@ def get_neutron_session_client(session):
 
 
 def get_keystone_scope():
-    """Return Keystone scope based on OpenStack release.
+    """Return Keystone scope based on OpenStack release of the overcloud.
 
     :returns: String keystone scope
     :rtype: string
@@ -259,7 +259,6 @@ def get_undercloud_keystone_session(verify=None):
     :rtype: keystoneauth1.session.Session
     """
     return get_keystone_session(get_undercloud_auth(),
-                                scope=get_keystone_scope(),
                                 verify=verify)
 
 


### PR DESCRIPTION
The get_undercloud_keystone_session function was mistakenly using the
get_keystone_scope function. The get_keystone_scope function is only
for use with the overcloud.

Use of the get_keystone_scope function mistakenly caused undercloud
authentication to mix overcloud authentication.

We would only see this when the overcloud is Liberty because only
liberty uses scope=DOMAIN with keystone v3.