### PR TITLE
Fixes related to guest creation tests.

### DIFF
--- a/unit_tests/utilities/test_zaza_utilities_openstack.py
+++ b/unit_tests/utilities/test_zaza_utilities_openstack.py
@@ -302,6 +302,20 @@ class TestOpenStackUtils(ut_utils.BaseTestCase):
         self.build_opener.assert_called_once_with(ProxyHandler_mock)
         self.ProxyHandler.assert_called_once_with({'http': 'http://squidy'})
 
+    def test_get_images_by_name(self):
+        image_mock1 = mock.MagicMock()
+        image_mock1.name = 'bob'
+        image_mock2 = mock.MagicMock()
+        image_mock2.name = 'bill'
+        glance_client = mock.MagicMock()
+        glance_client.images.list.return_value = [image_mock1, image_mock2]
+        self.assertEqual(
+            openstack_utils.get_images_by_name(glance_client, 'bob'),
+            [image_mock1])
+        self.assertEqual(
+            openstack_utils.get_images_by_name(glance_client, 'frank'),
+            [])
+
     def test_find_cirros_image(self):
         urllib_opener_mock = mock.MagicMock()
         self.patch_object(openstack_utils, "get_urllib_opener")

--- a/zaza/charm_tests/glance/setup.py
+++ b/zaza/charm_tests/glance/setup.py
@@ -14,6 +14,7 @@
 
 """Code for configuring glance."""
 
+import logging
 import zaza.utilities.openstack as openstack_utils
 
 
@@ -35,11 +36,14 @@ def add_cirros_image(glance_client=None):
         keystone_session = openstack_utils.get_overcloud_keystone_session()
         glance_client = openstack_utils.get_glance_session_client(
             keystone_session)
-    image_url = openstack_utils.find_cirros_image(arch='x86_64')
-    openstack_utils.create_image(
-        glance_client,
-        image_url,
-        'cirros')
+    if openstack_utils.get_images_by_name(glance_client, 'cirros'):
+        logging.warning('Using existing glance image')
+    else:
+        image_url = openstack_utils.find_cirros_image(arch='x86_64')
+        openstack_utils.create_image(
+            glance_client,
+            image_url,
+            'cirros')
 
 
 def add_lts_image(glance_client=None):
@@ -52,11 +56,13 @@ def add_lts_image(glance_client=None):
         keystone_session = openstack_utils.get_overcloud_keystone_session()
         glance_client = openstack_utils.get_glance_session_client(
             keystone_session)
-    image_url = openstack_utils.find_ubuntu_image(
-        release='bionic',
-        arch='amd64')
-    print(image_url)
-    openstack_utils.create_image(
-        glance_client,
-        image_url,
-        'bionic')
+    if openstack_utils.get_images_by_name(glance_client, 'bionic'):
+        logging.warning('Using existing glance image')
+    else:
+        image_url = openstack_utils.find_ubuntu_image(
+            release='bionic',
+            arch='amd64')
+        openstack_utils.create_image(
+            glance_client,
+            image_url,
+            'bionic')

--- a/zaza/charm_tests/glance/setup.py
+++ b/zaza/charm_tests/glance/setup.py
@@ -17,6 +17,10 @@
 import logging
 import zaza.utilities.openstack as openstack_utils
 
+CIRROS_IMAGE_NAME = "cirros"
+LTS_RELEASE = "bionic"
+LTS_IMAGE_NAME = "bionic"
+
 
 def basic_setup():
     """Run setup for testing glance.
@@ -26,43 +30,52 @@ def basic_setup():
     """
 
 
-def add_cirros_image(glance_client=None):
+def add_cirros_image(glance_client=None, image_name=None):
     """Add a cirros image to the current deployment.
 
     :param glance: Authenticated glanceclient
     :type glance: glanceclient.Client
+    :param image_name: Label for the image in glance
+    :type image_name: str
     """
+    image_name = image_name or CIRROS_IMAGE_NAME
     if not glance_client:
         keystone_session = openstack_utils.get_overcloud_keystone_session()
         glance_client = openstack_utils.get_glance_session_client(
             keystone_session)
-    if openstack_utils.get_images_by_name(glance_client, 'cirros'):
+    if openstack_utils.get_images_by_name(glance_client, image_name):
         logging.warning('Using existing glance image')
     else:
         image_url = openstack_utils.find_cirros_image(arch='x86_64')
         openstack_utils.create_image(
             glance_client,
             image_url,
-            'cirros')
+            image_name)
 
 
-def add_lts_image(glance_client=None):
+def add_lts_image(glance_client=None, image_name=None, release=None):
     """Add an Ubuntu LTS image to the current deployment.
 
     :param glance: Authenticated glanceclient
     :type glance: glanceclient.Client
+    :param image_name: Label for the image in glance
+    :type image_name: str
+    :param release: Name of ubuntu release.
+    :type release: str
     """
+    image_name = image_name or LTS_IMAGE_NAME
+    release = release or LTS_RELEASE
     if not glance_client:
         keystone_session = openstack_utils.get_overcloud_keystone_session()
         glance_client = openstack_utils.get_glance_session_client(
             keystone_session)
-    if openstack_utils.get_images_by_name(glance_client, 'bionic'):
+    if openstack_utils.get_images_by_name(glance_client, image_name):
         logging.warning('Using existing glance image')
     else:
         image_url = openstack_utils.find_ubuntu_image(
-            release='bionic',
+            release=release,
             arch='amd64')
         openstack_utils.create_image(
             glance_client,
             image_url,
-            'bionic')
+            image_name)

--- a/zaza/charm_tests/nova/tests.py
+++ b/zaza/charm_tests/nova/tests.py
@@ -30,7 +30,7 @@ class BaseGuestCreateTest(unittest.TestCase):
 
     boot_tests = {
         'cirros': {
-            'image_name': 'cirrosimage',
+            'image_name': 'cirros',
             'flavor_name': 'm1.tiny',
             'username': 'cirros',
             'bootstring': 'gocubsgo',

--- a/zaza/charm_tests/nova/tests.py
+++ b/zaza/charm_tests/nova/tests.py
@@ -23,6 +23,7 @@ import unittest
 import zaza.model as model
 import zaza.utilities.openstack as openstack_utils
 import zaza.charm_tests.nova.utils as nova_utils
+import zaza.charm_tests.glance.setup as glance_setup
 
 
 class BaseGuestCreateTest(unittest.TestCase):
@@ -113,7 +114,7 @@ class CirrosGuestCreateTest(BaseGuestCreateTest):
 
     def test_launch_small_cirros_instance(self):
         """Launch a cirros instance and test connectivity."""
-        self.launch_instance('cirros')
+        self.launch_instance(glance_setup.CIRROS_IMAGE_NAME)
 
 
 class LTSGuestCreateTest(BaseGuestCreateTest):
@@ -121,4 +122,4 @@ class LTSGuestCreateTest(BaseGuestCreateTest):
 
     def test_launch_small_cirros_instance(self):
         """Launch a cirros instance and test connectivity."""
-        self.launch_instance('bionic')
+        self.launch_instance(glance_setup.LTS_IMAGE_NAME)

--- a/zaza/configure/network.py
+++ b/zaza/configure/network.py
@@ -114,6 +114,7 @@ def setup_sdn(network_config, keystone_session=None):
     project_id = openstack_utils.get_project_id(
         keystone_client,
         "admin",
+        domain_name="admin_domain",
     )
     # Network Setup
     subnetpools = False

--- a/zaza/utilities/openstack.py
+++ b/zaza/utilities/openstack.py
@@ -1366,6 +1366,20 @@ def get_urllib_opener():
     return urllib.request.build_opener(handler)
 
 
+def get_images_by_name(glance, image_name):
+    """Get all glance image objects with the given name.
+
+    :param glance: Authenticated glanceclient
+    :type glance: glanceclient.Client
+    :param image_name: Name of image
+    :type image_name: str
+
+    :returns: List of glance images
+    :rtype: [glanceclient.v2.image, ...]
+    """
+    return [i for i in glance.images.list() if image_name == i.name]
+
+
 def find_cirros_image(arch):
     """Return the url for the latest cirros image for the given architecture.
 


### PR DESCRIPTION
* Make image creation a noop if image already exists
* Two admin projects are created, one in the default domain and
  one in the admin domain. To differentiate between them specify the
  admin domain when searching for the project id. This, in turn, ensures
  that the security group rules are applied to the correct 'default' security group.
* Fix cirros image name