### PR TITLE
Update the juju models cache on model add

### DIFF
--- a/unit_tests/test_zaza_controller.py
+++ b/unit_tests/test_zaza_controller.py
@@ -70,23 +70,20 @@ class TestController(ut_utils.BaseTestCase):
         self.Controller.return_value = self.Controller_mock
 
     def test_add_model(self):
-        self.assertEqual(controller.add_model(self.model1.info.name),
-                         self.model1.info.name)
+        self.patch_object(controller, 'go_list_models')
+        controller.add_model(self.model1.info.name)
         self.Controller_mock.add_model.assert_called_once_with(
             self.model1.info.name,
             config=None)
-        self.model1.connect.assert_called_once()
 
     def test_add_model_config(self):
-        self.assertEqual(
-            controller.add_model(
-                self.model1.info.name,
-                {'run-faster': 'true'}),
-            self.model1.info.name)
+        self.patch_object(controller, 'go_list_models')
+        controller.add_model(self.model1.info.name,
+                             {'run-faster': 'true'})
         self.Controller_mock.add_model.assert_called_once_with(
             self.model1.info.name,
             config={'run-faster': 'true'})
-        self.model1.connect.assert_called_once()
+        self.go_list_models.assert_called_once()
 
     def test_destroy_model(self):
         controller.destroy_model(self.model1.info.name)
@@ -104,3 +101,9 @@ class TestController(ut_utils.BaseTestCase):
             controller.list_models(),
             self.models)
         self.Controller_mock.list_models.assert_called_once()
+
+    def test_go_list_models(self):
+        self.patch_object(controller, 'subprocess')
+        controller.go_list_models()
+        self.subprocess.check_call.assert_called_once_with([
+            "juju", "models"])

--- a/zaza/controller.py
+++ b/zaza/controller.py
@@ -88,7 +88,9 @@ list_models = sync_wrapper(async_list_models)
 def go_list_models():
     """Execute juju models.
 
-    NOTE: Eexcuting the juju models command updates the local cache of models.
+    NOTE: Excuting the juju models command updates the local cache of models.
+    Python-juju currently does not update the local cache on add model.
+    https://github.com/juju/python-libjuju/issues/267
 
     :returns: None
     :rtype: None

--- a/zaza/controller.py
+++ b/zaza/controller.py
@@ -16,6 +16,7 @@
 
 import logging
 from juju.controller import Controller
+import subprocess
 from zaza import sync_wrapper
 
 
@@ -30,12 +31,11 @@ async def async_add_model(model_name, config=None):
     controller = Controller()
     await controller.connect()
     logging.debug("Adding model {}".format(model_name))
-    model = await controller.add_model(model_name, config=config)
-    await model.connect()
-    model_name = model.info.name
-    await model.disconnect()
+    await controller.add_model(model_name, config=config)
     await controller.disconnect()
-    return model_name
+    # NOTE: This is necessary to guarantee juju is aware of the newly created
+    # model.
+    go_list_models()
 
 add_model = sync_wrapper(async_add_model)
 
@@ -83,3 +83,15 @@ async def async_list_models():
     return models
 
 list_models = sync_wrapper(async_list_models)
+
+
+def go_list_models():
+    """Execute juju models.
+
+    NOTE: Eexcuting the juju models command updates the local cache of models.
+
+    :returns: None
+    :rtype: None
+    """
+    cmd = ["juju", "models"]
+    subprocess.check_call(cmd)


### PR DESCRIPTION
Update the juju models cache on model add
    
Python-libjuju does not update the local cache of juju models on model
create. If no juju switch command or juju models command is run juju
will report model not found.
    
Issue is being tracked by
https://github.com/juju/python-libjuju/issues/267
    
Add a juju models command to update the local cache and make the new
model available to the juju binary.
