### PR TITLE
Handle set origin

### DIFF
--- a/zaza/charm_tests/series_upgrade/tests.py
+++ b/zaza/charm_tests/series_upgrade/tests.py
@@ -50,7 +50,7 @@ class SeriesUpgradeTest(unittest.TestCase):
             # Defaults
             origin = "openstack-origin"
             pause_non_leader_subordinate = True
-            pause_non_leader_primary = False
+            pause_non_leader_primary = True
             # Skip subordinates
             if applications[application]["subordinate-to"]:
                 continue

--- a/zaza/utilities/generic.py
+++ b/zaza/utilities/generic.py
@@ -298,15 +298,15 @@ def series_upgrade(unit_name, machine_num,
     model.block_until_unit_wl_status(unit_name, "blocked")
     logging.info("Watiing for model idleness")
     model.block_until_all_units_idle()
+    logging.info("Set origin on {}".format(application))
+    set_origin(application, origin)
+    model.block_until_all_units_idle()
     logging.info("Complete series upgrade on {}".format(machine_num))
     model.complete_series_upgrade(machine_num)
     model.block_until_all_units_idle()
     logging.info("Watiing for workload status 'active' on {}"
                  .format(unit_name))
     model.block_until_unit_wl_status(unit_name, "active")
-    model.block_until_all_units_idle()
-    logging.info("Set origin on {}".format(application))
-    set_origin(application, origin)
     model.block_until_all_units_idle()
     # This step may be performed by juju in the future
     logging.info("Set series on {} to {}".format(application, to_series))


### PR DESCRIPTION
After the series upgrade a config changed hook will fire with openstack
origin or source still set to ubuntu series n-1 which will Traceback.

It is necessary to pause all primary charms which will then allow the
setting of openstack-origin or source to distro after the first unit is
in progress with the series upgrade.