### PR TITLE
More generic non leader first series upgrade

### DIFF
--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -983,7 +983,7 @@ disk_formats = ami,ari,aki,vhd,vmdk,raw,qcow2,vdi,iso,root-tar
         model.prepare_series_upgrade(_machine_num, to_series=_to_series)
         self.subprocess.check_call.assert_called_once_with(
             ["juju", "upgrade-series", "-m", self.model_name,
-             "prepare", _machine_num, _to_series, "--agree"])
+             "prepare", _machine_num, _to_series, "--yes"])
 
     def test_complete_series_upgrade(self):
         self.patch_object(model, 'get_juju_model',

--- a/zaza/charm_tests/series_upgrade/tests.py
+++ b/zaza/charm_tests/series_upgrade/tests.py
@@ -74,10 +74,11 @@ class SeriesUpgradeTest(unittest.TestCase):
                 origin = None
                 pause_non_leader_primary = False
                 pause_non_leader_subordinate = False
-            if "mongodb" in applications[application]["charm"]:
-                # Mongodb is sligthly different. It needs to run series upgrade
-                # on its secondaries first. It has its own function.
-                generic_utils.series_upgrade_mongodb(
+            if ("mongodb" in applications[application]["charm"] or
+                    "vault" in applications[application]["charm"]):
+                # Mongodb and vault need to run series upgrade
+                # on its secondaries first.
+                generic_utils.series_upgrade_non_leaders_first(
                     application,
                     from_series=self.from_series,
                     to_series=self.to_series,

--- a/zaza/model.py
+++ b/zaza/model.py
@@ -1206,7 +1206,7 @@ def prepare_series_upgrade(machine_num, to_series="xenial"):
     """
     juju_model = get_juju_model()
     cmd = ["juju", "upgrade-series", "-m", juju_model,
-           "prepare", machine_num, to_series, "--agree"]
+           "prepare", machine_num, to_series, "--yes"]
     subprocess.check_call(cmd)
 
 

--- a/zaza/utilities/generic.py
+++ b/zaza/utilities/generic.py
@@ -170,12 +170,13 @@ def get_yaml_config(config_file):
     return yaml.load(open(config_file, 'r').read())
 
 
-def series_upgrade_mongodb(application, from_series="trusty",
-                           to_series="xenial", completed_machines=[]):
-    """Series upgrade mongodb.
+def series_upgrade_non_leaders_first(application, from_series="trusty",
+                                     to_series="xenial",
+                                     completed_machines=[]):
+    """Series upgrade non leaders first.
 
-    Wrap all the functionality to handle series upgrade for mongodb.
-    Mongodb must have its secondaries upgraded first.
+    Wrap all the functionality to handle series upgrade for charms
+    which must have non leaders upgraded first.
 
     :param application: Name of application to upgrade series
     :type application: str
@@ -206,8 +207,6 @@ def series_upgrade_mongodb(application, from_series="trusty",
                          .format(unit))
             series_upgrade(unit, machine,
                            from_series=from_series, to_series=to_series,
-                           pause_non_leader_primary=False,
-                           pause_non_leader_subordinate=False,
                            origin=None)
             completed_machines.append(machine)
         else:
@@ -221,8 +220,6 @@ def series_upgrade_mongodb(application, from_series="trusty",
     if machine not in completed_machines:
         series_upgrade(leader, machine,
                        from_series=from_series, to_series=to_series,
-                       pause_non_leader_primary=False,
-                       pause_non_leader_subordinate=False,
                        origin=None)
         completed_machines.append(machine)
     else:


### PR DESCRIPTION
Make the series_upgrade_mongodb less specific to mongodb. We may
eventually use this to series upgrade vault.

Fix bug in the generalized series_upgrade_non_leaders_first.

Fix change in switch --agree to --yes.