### PR TITLE
Explicit Model Timeout Exception

### DIFF
--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -394,7 +394,7 @@ class TestModel(ut_utils.BaseTestCase):
             timeout = timeout + self._block_until_calls
             self._block_until_calls += 1
             if timeout == -1:
-                raise concurrent.futures._base.TimeoutError
+                raise concurrent.futures._base.TimeoutError("Timeout", 1)
             result = f()
             if not result:
                 self.system_ready = False

--- a/zaza/model.py
+++ b/zaza/model.py
@@ -735,7 +735,7 @@ async def async_wait_for_application_states(model_name=None, states=None,
         try:
             await model.block_until(
                 lambda: model.all_units_idle(), timeout=timeout)
-        except concurrent.futures._base.TimeoutError as e:
+        except concurrent.futures._base.TimeoutError:
             raise ModelTimeout("Zaza has timed out waiting on the model to "
                                "reach idle state.")
         try:
@@ -763,7 +763,7 @@ async def async_wait_for_application_states(model_name=None, states=None,
                             unit,
                             prefixes=prefixes),
                         timeout=timeout)
-        except concurrent.futures._base.TimeoutError as e:
+        except concurrent.futures._base.TimeoutError:
             raise ModelTimeout("Zaza has timed out waiting on the model to "
                                "reach expected workload statuses.")
 

--- a/zaza/model.py
+++ b/zaza/model.py
@@ -739,9 +739,9 @@ async def async_wait_for_application_states(model_name=None, states=None,
             raise ModelTimeout("Zaza has timed out waiting on the model to "
                                "reach idle state.")
         try:
-            for application in model.applications:
+            for application, app_data in model.applications.items():
                 check_info = states.get(application, {})
-                for unit in model.applications[application].units:
+                for unit in app_data.units:
                     logging.info("Checking workload status of {}".format(
                         unit.entity_id))
                     await model.block_until(

--- a/zaza/model.py
+++ b/zaza/model.py
@@ -27,6 +27,7 @@ import subprocess
 import tempfile
 import yaml
 from oslo_config import cfg
+import concurrent
 
 from juju.errors import JujuError
 from juju.model import Model
@@ -34,6 +35,12 @@ from juju.model import Model
 from zaza import sync_wrapper
 
 CURRENT_MODEL = None
+
+
+class ModelTimeout(Exception):
+    """Model timeout exception."""
+
+    pass
 
 
 def set_juju_model(model_name):
@@ -725,32 +732,40 @@ async def async_wait_for_application_states(model_name=None, states=None,
             lambda: len(model.units) > 0
         )
         logging.info("Waiting for all units to be idle")
-        await model.block_until(
-            lambda: model.all_units_idle(), timeout=timeout)
-        for application in model.applications:
-            check_info = states.get(application, {})
-            for unit in model.applications[application].units:
-                logging.info("Checking workload status of {}".format(
-                    unit.entity_id))
-                await model.block_until(
-                    lambda: check_unit_workload_status(
-                        model,
-                        unit,
-                        check_info.get('workload-status', 'active')),
-                    timeout=timeout)
-                check_msg = check_info.get('workload-status-message')
-                logging.info("Checking workload status message of {}".format(
-                    unit.entity_id))
-                if check_msg is not None:
-                    prefixes = (check_msg)
-                else:
-                    prefixes = approved_message_prefixes
-                await model.block_until(
-                    lambda: check_unit_workload_status_message(
-                        model,
-                        unit,
-                        prefixes=prefixes),
-                    timeout=timeout)
+        try:
+            await model.block_until(
+                lambda: model.all_units_idle(), timeout=timeout)
+        except concurrent.futures._base.TimeoutError as e:
+            raise ModelTimeout("Zaza has timed out waiting on the model to "
+                               "reach idle state.")
+        try:
+            for application in model.applications:
+                check_info = states.get(application, {})
+                for unit in model.applications[application].units:
+                    logging.info("Checking workload status of {}".format(
+                        unit.entity_id))
+                    await model.block_until(
+                        lambda: check_unit_workload_status(
+                            model,
+                            unit,
+                            check_info.get('workload-status', 'active')),
+                        timeout=timeout)
+                    check_msg = check_info.get('workload-status-message')
+                    logging.info("Checking workload status message of {}"
+                                 .format(unit.entity_id))
+                    if check_msg is not None:
+                        prefixes = (check_msg)
+                    else:
+                        prefixes = approved_message_prefixes
+                    await model.block_until(
+                        lambda: check_unit_workload_status_message(
+                            model,
+                            unit,
+                            prefixes=prefixes),
+                        timeout=timeout)
+        except concurrent.futures._base.TimeoutError as e:
+            raise ModelTimeout("Zaza has timed out waiting on the model to "
+                               "reach expected workload statuses.")
 
 wait_for_application_states = sync_wrapper(async_wait_for_application_states)
 


### PR DESCRIPTION
When we timeout waiting for the model to be idle and have specific
workload statuses make that explicit.