### PR TITLE
Accept bespoke workload statuses and default

### DIFF
--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -450,7 +450,7 @@ class TestModel(ut_utils.BaseTestCase):
             'workload-status-message': 'Unit is ready'})
         self.assertTrue(
             model.check_unit_workload_status(self.Model_mock,
-                                             self.unit1, 'active'))
+                                             self.unit1, ['active']))
 
     def test_check_unit_workload_status_no_match(self):
         self.patch_object(model, 'check_model_for_hard_errors')
@@ -459,7 +459,17 @@ class TestModel(ut_utils.BaseTestCase):
             'workload-status-message': 'Unit is ready'})
         self.assertFalse(
             model.check_unit_workload_status(self.Model_mock,
-                                             self.unit1, 'active'))
+                                             self.unit1, ['active']))
+
+    def test_check_unit_workload_status_multi(self):
+        self.patch_object(model, 'check_model_for_hard_errors')
+        self._application_states_setup({
+            'workload-status': 'blocked',
+            'workload-status-message': 'Unit is ready'})
+        self.assertTrue(
+            model.check_unit_workload_status(
+                self.Model_mock,
+                self.unit1, ['active', 'blocked']))
 
     def test_check_unit_workload_status_message_message(self):
         self.patch_object(model, 'check_model_for_hard_errors')
@@ -490,7 +500,7 @@ class TestModel(ut_utils.BaseTestCase):
             model.check_unit_workload_status_message(
                 self.Model_mock,
                 self.unit1,
-                prefixes=('Readyish', 'Unit is ready')))
+                prefixes=['Readyish', 'Unit is ready']))
 
     def test_check_unit_workload_status_message_prefix_no_match(self):
         self.patch_object(model, 'check_model_for_hard_errors')
@@ -501,7 +511,7 @@ class TestModel(ut_utils.BaseTestCase):
             model.check_unit_workload_status_message(
                 self.Model_mock,
                 self.unit1,
-                prefixes=('Readyish', 'Unit is ready')))
+                prefixes=['Readyish', 'Unit is ready']))
 
     def test_wait_for_application_states(self):
         self._application_states_setup({

--- a/zaza/model.py
+++ b/zaza/model.py
@@ -608,7 +608,7 @@ def check_model_for_hard_errors(model):
         raise UnitError(errored_units)
 
 
-def check_unit_workload_status(model, unit, state):
+def check_unit_workload_status(model, unit, states):
     """Check that the units workload status matches the supplied state.
 
     This function has the side effect of also checking for *any* units
@@ -618,14 +618,14 @@ def check_unit_workload_status(model, unit, state):
     :type model: juju.Model
     :param unit: Unit to check wl status of
     :type unit: juju.Unit
-    :param state: Acceptable unit work load states
-    :type state: list
+    :param states: Acceptable unit work load states
+    :type states: list
     :raises: UnitError
     :returns: Whether units workload status matches desired state
     :rtype: bool
     """
     check_model_for_hard_errors(model)
-    return unit.workload_status in state
+    return unit.workload_status in states
 
 
 def check_unit_workload_status_message(model, unit, message=None,


### PR DESCRIPTION
When checking the readyness of an application check both the
bespoke status as defined in the tests.yaml and the default.
Closes issue #158 