### PR TITLE
Check for the VIP in the identity catalog entry

### DIFF
--- a/zaza/charm_tests/keystone/__init__.py
+++ b/zaza/charm_tests/keystone/__init__.py
@@ -39,3 +39,9 @@ class BaseKeystoneTest(test_utils.OpenStackBaseTest):
             cls.default_api_version = '2'
         else:
             cls.default_api_version = '3'
+        cls.admin_keystone_session = (
+            openstack_utils.get_overcloud_keystone_session())
+        cls.admin_keystone_client = (
+            openstack_utils.get_keystone_session_client(
+                cls.admin_keystone_session,
+                client_api_version=cls.default_api_version))

--- a/zaza/charm_tests/keystone/tests.py
+++ b/zaza/charm_tests/keystone/tests.py
@@ -45,6 +45,24 @@ class CharmOperationTest(BaseKeystoneTest):
         """Run class setup for running Keystone charm operation tests."""
         super(CharmOperationTest, cls).setUpClass()
 
+    def test_001_vip_in_catalog(self):
+        """Verify the VIP is in the identity catalog entry.
+
+        This test should run early. It validates that if a VIP is set it is in
+        the catalog entry for kesytone.
+        """
+        vip = (zaza.model.get_application_config('keystone')
+               .get('vip').get('value'))
+        if not vip:
+            # If the vip is not set skip this test.
+            return
+        endpoint_filter = {'service_type': 'identity',
+                           'interface': 'public',
+                           'region_name': 'RegionOne'}
+        ep = self.admin_keystone_client.session.get_endpoint(**endpoint_filter)
+        assert vip in ep, (
+            "VIP: {} not found in catalog entry: {}".format(vip, ep))
+
     def test_pause_resume(self):
         """Run pause and resume tests.
 


### PR DESCRIPTION
Add an early test to check that the catalog entry for the identity
service uses the VIP.