### PR TITLE
only use v2 keystone user creation for trusty mitaka

### DIFF
--- a/zaza/charm_tests/keystone/setup.py
+++ b/zaza/charm_tests/keystone/setup.py
@@ -91,13 +91,13 @@ def add_demo_user():
             project_domain=domain,
             project=project)
 
-    if (openstack_utils.get_os_release() <
+    if (openstack_utils.get_os_release() <=
             openstack_utils.get_os_release('trusty_mitaka')):
         # create only V2 user
         _v2()
         return
 
-    if (openstack_utils.get_os_release() >=
+    if (openstack_utils.get_os_release() >
         openstack_utils.get_os_release('trusty_mitaka') and
         openstack_utils.get_os_release() <
             openstack_utils.get_os_release('xenial_queens')):


### PR DESCRIPTION
On Trusty Mitaka the preferred-api-version in not support. In this
commit we update the conditions to avoid using v3 creation when the
release used is trusty mitaka or older.

Signed-off-by: Sahid Orentino Ferdjaoui <sahid.ferdjaoui@canonical.com>