### PR TITLE
Allow application_name parameter to config_change

### DIFF
--- a/zaza/charm_tests/keystone/setup.py
+++ b/zaza/charm_tests/keystone/setup.py
@@ -106,9 +106,11 @@ def add_demo_user():
 
         _singleton = BaseKeystoneTest()
         _singleton.setUpClass()
+        # Explicitly set application name in case setup is called by a charm
+        # under test other than keystone.
         with _singleton.config_change(
                 {'preferred-api-version': _singleton.default_api_version},
-                {'preferred-api-version': '3'}):
+                {'preferred-api-version': '3'}, application_name="keystone"):
             _v3()
     else:
         # create only V3 user

--- a/zaza/charm_tests/test_utils.py
+++ b/zaza/charm_tests/test_utils.py
@@ -54,7 +54,8 @@ class OpenStackBaseTest(unittest.TestCase):
         logging.debug('Leader unit is {}'.format(cls.lead_unit))
 
     @contextlib.contextmanager
-    def config_change(self, default_config, alternate_config):
+    def config_change(self, default_config, alternate_config,
+                      application_name=None):
         """Run change config tests.
 
         Change config to `alternate_config`, wait for idle workload status,
@@ -70,11 +71,17 @@ class OpenStackBaseTest(unittest.TestCase):
         :type default_config: dict
         :param alternate_config: Dict of charm settings to change to
         :type alternate_config: dict
+        :param application_name: String application name for use when called
+                                 by a charm under test other than the object's
+                                 application.
+        :type application_name: str
         """
+        if not application_name:
+            application_name = self.application_name
         # we need to compare config values to what is already applied before
         # attempting to set them.  otherwise the model will behave differently
         # than we would expect while waiting for completion of the change
-        _app_config = model.get_application_config(self.application_name)
+        _app_config = model.get_application_config(application_name)
         app_config = {}
         # convert the more elaborate config structure from libjuju to something
         # we can compare to what the caller supplies to this function
@@ -97,7 +104,7 @@ class OpenStackBaseTest(unittest.TestCase):
             logging.debug('Changing charm setting to {}'
                           .format(alternate_config))
             model.set_application_config(
-                self.application_name,
+                application_name,
                 alternate_config,
                 model_name=self.model_name)
 
@@ -117,7 +124,7 @@ class OpenStackBaseTest(unittest.TestCase):
 
         logging.debug('Restoring charm setting to {}'.format(default_config))
         model.set_application_config(
-            self.application_name,
+            application_name,
             default_config,
             model_name=self.model_name)
 


### PR DESCRIPTION
When the charm under test is not the self.application_name of the object
of the setup/test class zaza.test_charms.test_utils.config_change would
try to make a configuration change to the wrong charm. This lead to
https://github.com/openstack-charmers/zaza/issues/168.

This change allows passing application_name to config_change for when
the charm under test is not the same as the object's
self.application_name.

Closes-Issue: https://github.com/openstack-charmers/zaza/issues/168