### PR TITLE
Pass a version to the cinder client.

### DIFF
--- a/zaza/utilities/openstack.py
+++ b/zaza/utilities/openstack.py
@@ -226,15 +226,17 @@ def get_octavia_session_client(session, service_type='load-balancer',
                                     endpoint=endpoint.url)
 
 
-def get_cinder_session_client(session):
+def get_cinder_session_client(session, version=2):
     """Return cinderclient authenticated by keystone session.
 
     :param session: Keystone session object
     :type session: keystoneauth1.session.Session object
+    :param version: Cinder API version
+    :type version: int
     :returns: Authenticated cinderclient
     :rtype: cinderclient.Client object
     """
-    return cinderclient.Client(session=session)
+    return cinderclient.Client(session=session, version=version)
 
 
 def get_keystone_scope():


### PR DESCRIPTION
Passing a version to the cinder client is mandatory *1 so
supply a version and default to 2 as per existing amulet
helper.

*1 https://github.com/openstack/python-cinderclient/blob/master/cinderclient/client.py#L795