### PR TITLE
Declare swfitclient requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ install_require = [
     'python-neutronclient',
     'python-octaviaclient',
     'python-cinderclient',
+    'python-swiftclient',
 ]
 
 tests_require = [


### PR DESCRIPTION
When zaza is installed as a dependency it requires swiftclient.
Guarantee swiftclient is installed as a dependency of zaza.