### PR TITLE
Move guest creation code.

### DIFF
--- a/zaza/charm_tests/nova/tests.py
+++ b/zaza/charm_tests/nova/tests.py
@@ -16,6 +16,7 @@
 
 """Encapsulate nova testing."""
 
+import logging
 import unittest
 
 import zaza.charm_tests.glance.setup as glance_setup
@@ -27,6 +28,8 @@ class BaseGuestCreateTest(unittest.TestCase):
 
     def launch_instance(self, instance_key):
         """Deprecated: Use zaza.configure.guest.launch_instance."""
+        logging.info('BaseGuestCreateTest.launch_instance is deprecated '
+                     'please use zaza.configure.guest.launch_instance')
         zaza.configure.guest.launch_instance(instance_key)
 
 

--- a/zaza/charm_tests/nova/tests.py
+++ b/zaza/charm_tests/nova/tests.py
@@ -16,97 +16,18 @@
 
 """Encapsulate nova testing."""
 
-import logging
-import time
 import unittest
 
-import zaza.model as model
-import zaza.utilities.openstack as openstack_utils
-import zaza.charm_tests.nova.utils as nova_utils
 import zaza.charm_tests.glance.setup as glance_setup
+import zaza.configure.guest
 
 
 class BaseGuestCreateTest(unittest.TestCase):
-    """Base for tests to launch a guest."""
-
-    boot_tests = {
-        'cirros': {
-            'image_name': 'cirros',
-            'flavor_name': 'm1.tiny',
-            'username': 'cirros',
-            'bootstring': 'gocubsgo',
-            'password': 'gocubsgo'},
-        'bionic': {
-            'image_name': 'bionic',
-            'flavor_name': 'm1.small',
-            'username': 'ubuntu',
-            'bootstring': 'finished at'}}
-
-    @classmethod
-    def setUpClass(cls):
-        """Run class setup for running glance tests."""
-        cls.keystone_session = openstack_utils.get_overcloud_keystone_session()
-        cls.model_name = model.get_juju_model()
-        cls.nova_client = openstack_utils.get_nova_session_client(
-            cls.keystone_session)
-        cls.neutron_client = openstack_utils.get_neutron_session_client(
-            cls.keystone_session)
+    """Deprecated: Use zaza.configure.guest.launch_instance."""
 
     def launch_instance(self, instance_key):
-        """Launch an instance.
-
-        :param instance_key: Key to collect associated config data with.
-        :type instance_key: str
-        """
-        # Collect resource information.
-        vm_name = time.strftime("%Y%m%d%H%M%S")
-        image = self.nova_client.glance.find_image(
-            self.boot_tests[instance_key]['image_name'])
-        flavor = self.nova_client.flavors.find(
-            name=self.boot_tests[instance_key]['flavor_name'])
-        net = self.neutron_client.find_resource("network", "private")
-        nics = [{'net-id': net.get('id')}]
-
-        # Launch instance.
-        logging.info('Launching instance {}'.format(vm_name))
-        instance = self.nova_client.servers.create(
-            name=vm_name,
-            image=image,
-            flavor=flavor,
-            key_name=nova_utils.KEYPAIR_NAME,
-            nics=nics)
-
-        # Test Instance is ready.
-        logging.info('Checking instance is active')
-        openstack_utils.resource_reaches_status(
-            self.nova_client.servers,
-            instance.id,
-            expected_status='ACTIVE')
-
-        logging.info('Checking cloud init is complete')
-        openstack_utils.cloud_init_complete(
-            self.nova_client,
-            instance.id,
-            self.boot_tests[instance_key]['bootstring'])
-        port = openstack_utils.get_ports_from_device_id(
-            self.neutron_client,
-            instance.id)[0]
-        logging.info('Assigning floating ip.')
-        ip = openstack_utils.create_floating_ip(
-            self.neutron_client,
-            "ext_net",
-            port=port)['floating_ip_address']
-        logging.info('Assigned floating IP {} to {}'.format(ip, vm_name))
-        openstack_utils.ping_response(ip)
-
-        # Check ssh'ing to instance.
-        logging.info('Testing ssh access.')
-        openstack_utils.ssh_test(
-            username=self.boot_tests[instance_key]['username'],
-            ip=ip,
-            vm_name=vm_name,
-            password=self.boot_tests[instance_key].get('password'),
-            privkey=openstack_utils.get_private_key(nova_utils.KEYPAIR_NAME))
+        """Deprecated: Use zaza.configure.guest.launch_instance."""
+        zaza.configure.guest.launch_instance(instance_key)
 
 
 class CirrosGuestCreateTest(BaseGuestCreateTest):
@@ -114,7 +35,8 @@ class CirrosGuestCreateTest(BaseGuestCreateTest):
 
     def test_launch_small_instance(self):
         """Launch a cirros instance and test connectivity."""
-        self.launch_instance(glance_setup.CIRROS_IMAGE_NAME)
+        zaza.configure.guest.launch_instance(
+            glance_setup.CIRROS_IMAGE_NAME)
 
 
 class LTSGuestCreateTest(BaseGuestCreateTest):
@@ -122,4 +44,5 @@ class LTSGuestCreateTest(BaseGuestCreateTest):
 
     def test_launch_small_instance(self):
         """Launch a Bionic instance and test connectivity."""
-        self.launch_instance(glance_setup.LTS_IMAGE_NAME)
+        zaza.configure.guest.launch_instance(
+            glance_setup.LTS_IMAGE_NAME)

--- a/zaza/configure/guest.py
+++ b/zaza/configure/guest.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+
+# Copyright 2018 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Encapsulate nova testing."""
+
+import logging
+import time
+
+import zaza.utilities.openstack as openstack_utils
+import zaza.charm_tests.nova.utils as nova_utils
+
+boot_tests = {
+    'cirros': {
+        'image_name': 'cirros',
+        'flavor_name': 'm1.tiny',
+        'username': 'cirros',
+        'bootstring': 'gocubsgo',
+        'password': 'gocubsgo'},
+    'bionic': {
+        'image_name': 'bionic',
+        'flavor_name': 'm1.small',
+        'username': 'ubuntu',
+        'bootstring': 'finished at'}}
+
+
+def launch_instance(instance_key):
+    """Launch an instance.
+
+    :param instance_key: Key to collect associated config data with.
+    :type instance_key: str
+    """
+    keystone_session = openstack_utils.get_overcloud_keystone_session()
+    nova_client = openstack_utils.get_nova_session_client(keystone_session)
+    neutron_client = openstack_utils.get_neutron_session_client(
+        keystone_session)
+
+    # Collect resource information.
+    vm_name = time.strftime("%Y%m%d%H%M%S")
+    image = nova_client.glance.find_image(
+        boot_tests[instance_key]['image_name'])
+    flavor = nova_client.flavors.find(
+        name=boot_tests[instance_key]['flavor_name'])
+    net = neutron_client.find_resource("network", "private")
+    nics = [{'net-id': net.get('id')}]
+
+    # Launch instance.
+    logging.info('Launching instance {}'.format(vm_name))
+    instance = nova_client.servers.create(
+        name=vm_name,
+        image=image,
+        flavor=flavor,
+        key_name=nova_utils.KEYPAIR_NAME,
+        nics=nics)
+
+    # Test Instance is ready.
+    logging.info('Checking instance is active')
+    openstack_utils.resource_reaches_status(
+        nova_client.servers,
+        instance.id,
+        expected_status='ACTIVE')
+
+    logging.info('Checking cloud init is complete')
+    openstack_utils.cloud_init_complete(
+        nova_client,
+        instance.id,
+        boot_tests[instance_key]['bootstring'])
+    port = openstack_utils.get_ports_from_device_id(
+        neutron_client,
+        instance.id)[0]
+    logging.info('Assigning floating ip.')
+    ip = openstack_utils.create_floating_ip(
+        neutron_client,
+        "ext_net",
+        port=port)['floating_ip_address']
+    logging.info('Assigned floating IP {} to {}'.format(ip, vm_name))
+    openstack_utils.ping_response(ip)
+
+    # Check ssh'ing to instance.
+    logging.info('Testing ssh access.')
+    openstack_utils.ssh_test(
+        username=boot_tests[instance_key]['username'],
+        ip=ip,
+        vm_name=vm_name,
+        password=boot_tests[instance_key].get('password'),
+        privkey=openstack_utils.get_private_key(nova_utils.KEYPAIR_NAME))


### PR DESCRIPTION
The code to create a guest is currently in the nova tests area but
many other tests need to reuse this code. So, move the guest
creation code to the configuration area to be consistent with
network setup.