### PR TITLE
We should pass token hashing check

### DIFF
--- a/zaza/charm_tests/keystone/tests.py
+++ b/zaza/charm_tests/keystone/tests.py
@@ -351,12 +351,12 @@ class SecurityTests(BaseKeystoneTest):
         # to each one and resolved independently where possible.
         expected_failures = [
             'disable-admin-token',
-            'uses-sha256-for-hashing-tokens',
             'validate-file-ownership',
             'validate-file-permissions',
         ]
         expected_passes = [
             'check-max-request-body-size',
+            'uses-sha256-for-hashing-tokens',
             'uses-fernet-token-after-default',
             'insecure-debug-is-false',
         ]


### PR DESCRIPTION
The token hashing algorithm is only relevant for PKI tokens. There is
a change up to [charm-keystone][1] that updates this check to validate
hashing algorithm when the PKI token backend is in use.

The charms, themselves, have removed support for the PKI backend
in the 18.08 release of the charms, rendering this check somewhat
moot. I'm keeping this check as it is practically validating the on-disk
configuration of Keystone.

[1]: https://review.openstack.org/#/c/644513/