### PR TITLE
Add support for Ceph RGW multisite testing

### DIFF
--- a/zaza/utilities/openstack.py
+++ b/zaza/utilities/openstack.py
@@ -211,15 +211,19 @@ def get_neutron_session_client(session):
     return neutronclient.Client(session=session)
 
 
-def get_swift_session_client(session):
+def get_swift_session_client(session,
+                             region_name='RegionOne'):
     """Return swiftclient authenticated by keystone session.
 
     :param session: Keystone session object
     :type session: keystoneauth1.session.Session object
+    :param region_name: Optional region name to use
+    :type region_name: str
     :returns: Authenticated swiftclient
     :rtype: swiftclient.Client object
     """
-    return swiftclient.Connection(session=session)
+    return swiftclient.Connection(session=session,
+                                  os_options={'region_name': region_name})
 
 
 def get_octavia_session_client(session, service_type='load-balancer',


### PR DESCRIPTION
Adapt existing CephRGW test case to deal with multisite
deployment testing.

Validate services across both standard ceph-radosgw and
slave-ceph-radosgw applications if discovered.

Upload test data to source site, validate replication and
delete on target site.

Test promotion of slave, ability to create new container and
then failback to original master.