### PR TITLE
travis: Switch to ``xenial`` dist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: true
+dist: xenial
 language: python
 python:
   - "3.6"
@@ -12,13 +13,11 @@ comment: |
   sudo back to ourself to activate lxd group membership executable search path
 script:
   - if [ $ENV = 'func-travis' ]; then
-       sudo apt-get -qq update;
-       sudo apt-get -y install snapd;
+       sudo apt remove -y --purge lxd lxd-client;
        sudo snap install lxd;
        sudo snap install juju --classic;
        sudo sh -c 'echo PATH=/snap/bin:$PATH >> /etc/environment';
        sudo lxd waitready;
-       sudo journalctl --no-pager -xe;
        sudo lxd init --auto;
        sudo usermod -a -G lxd travis;
        sudo su travis -c 'juju bootstrap --debug --no-gui localhost';


### PR DESCRIPTION
Update installation sequence to fit the Travis Xenial environment.

This should save us some time on binary deps as we no longer need
to install snapd and kernel packages mandated by spectre/meltdown
in the Travis ``trusty`` image.