### PR TITLE
stein: Add swift 2.21.0

### DIFF
--- a/zaza/utilities/os_versions.py
+++ b/zaza/utilities/os_versions.py
@@ -96,7 +96,7 @@ SWIFT_CODENAMES = OrderedDict([
     ('rocky',
         ['2.18.0', '2.19.0']),
     ('stein',
-        ['2.20.0', '2.20.0'])
+        ['2.20.0', '2.21.0'])
 ])
 
 # >= Liberty version->codename mapping


### PR DESCRIPTION
Add the latest swift release to the list of versions for stein.