### PR TITLE
Remove double call to sync_wrapper

### DIFF
--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -195,13 +195,16 @@ class TestModel(ut_utils.BaseTestCase):
 
     def test_get_juju_model_noenv(self):
         self.patch_object(model.os, 'environ')
-        self.patch_object(model, 'get_current_model')
-        self.get_current_model.return_value = 'modelsmodel'
+        self.patch_object(model, 'async_get_current_model')
+
+        async def _async_get_current_model():
+            return 'modelsmodel'
+        self.async_get_current_model.side_effect = _async_get_current_model
 
         # No envirnment variable
         self.environ.__getitem__.side_effect = KeyError
         self.assertEqual(model.get_juju_model(), 'modelsmodel')
-        self.get_current_model.assert_called_once()
+        self.async_get_current_model.assert_called_once()
 
     def test_run_in_model(self):
         self.patch_object(model, 'Model')

--- a/zaza/model.py
+++ b/zaza/model.py
@@ -54,7 +54,7 @@ def set_juju_model(model_name):
     CURRENT_MODEL = model_name
 
 
-def get_juju_model():
+async def async_get_juju_model():
     """Retrieve current model.
 
     First check the environment for JUJU_MODEL. If this is not set, get the
@@ -78,8 +78,10 @@ def get_juju_model():
             CURRENT_MODEL = os.environ["MODEL_NAME"]
         except KeyError:
             # If unset connect get the current active model
-            CURRENT_MODEL = get_current_model()
+            CURRENT_MODEL = await async_get_current_model()
     return CURRENT_MODEL
+
+get_juju_model = sync_wrapper(async_get_juju_model)
 
 
 async def deployed():
@@ -149,7 +151,7 @@ async def run_in_model(model_name):
     """
     model = Model()
     if not model_name:
-        model_name = get_juju_model()
+        model_name = await async_get_juju_model()
     await model.connect_model(model_name)
     await yield_(model)
     await model.disconnect()


### PR DESCRIPTION
Calling a function via the sync_wrapper should never result in
another function being called via the sync_wrapper. If this happens
then a "RuntimeError: This event loop is already running" exception
is raised. In the example below no model is set via environment
variables. This leads to the following sequence:

1) Call run_action_on_leader which is a call to
   async_run_action_on_leader using thw sync_wrapper.
2) async_run_action_on_leader calls the async function run_in_model
3) run_in_model calls get_juju_model
4) get_juju_model then calls get_current_model which is a call to
   async_get_current_model using thw sync_wrapper.
5) A second call to run_until_complete is issued against the
  existing loop.