### PR TITLE
Fix call to async_get_unit_service_start_time

### DIFF
--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -935,7 +935,8 @@ disk_formats = ami,ari,aki,vhd,vmdk,raw,qcow2,vdi,iso,root-tar
         self.patch_object(model, 'async_block_until')
         self.async_block_until.side_effect = _block_until
 
-        async def _async_get_unit_service_start_time(model_name, unit, svc):
+        async def _async_get_unit_service_start_time(unit, svc, timeout=None,
+                                                     model_name=None):
             if gu_raise_exception:
                 raise model.ServiceNotRunning('sv1')
             else:

--- a/zaza/model.py
+++ b/zaza/model.py
@@ -1123,9 +1123,10 @@ async def async_block_until_services_restarted(application_name, mtime,
             for service in services:
                 try:
                     svc_mtime = await async_get_unit_service_start_time(
-                        model_name,
                         unit.entity_id,
-                        service)
+                        service,
+                        timeout=timeout,
+                        model_name=model_name)
                 except ServiceNotRunning:
                     return False
                 if svc_mtime < mtime:


### PR DESCRIPTION
The call to async_get_unit_service_start_time was wrong causing the
model_name to be used as the service to look for.