### PR TITLE
Avoid adding duplicate handler

### DIFF
--- a/unit_tests/utilities/test_zaza_utilities_cli.py
+++ b/unit_tests/utilities/test_zaza_utilities_cli.py
@@ -49,6 +49,7 @@ class TestCLIUtils(ut_utils.BaseTestCase):
         self.patch_object(cli_utils, "logging")
         _logformatter = mock.MagicMock()
         _logger = mock.MagicMock()
+        _logger.hasHandlers.return_value = False
         _consolehandler = mock.MagicMock()
         self.logging.Formatter.return_value = _logformatter
         self.logging.getLogger.return_value = _logger
@@ -61,3 +62,15 @@ class TestCLIUtils(ut_utils.BaseTestCase):
         _logger.setLevel.assert_called_with("INFO")
         _consolehandler.setFormatter.assert_called_with(_logformatter)
         _logger.addHandler.assert_called_with(_consolehandler)
+
+    def test_setup_logging_existing_handler(self):
+        self.patch_object(cli_utils, "logging")
+        _logformatter = mock.MagicMock()
+        _logger = mock.MagicMock()
+        _logger.hasHandlers.return_value = True
+        _consolehandler = mock.MagicMock()
+        self.logging.Formatter.return_value = _logformatter
+        self.logging.getLogger.return_value = _logger
+        self.logging.StreamHandler.return_value = _consolehandler
+        cli_utils.setup_logging()
+        self.assertFalse(_logger.addHandler.called)

--- a/zaza/utilities/cli.py
+++ b/zaza/utilities/cli.py
@@ -50,6 +50,7 @@ def setup_logging():
         datefmt="%Y-%m-%d %H:%M:%S")
     rootLogger = logging.getLogger()
     rootLogger.setLevel('INFO')
-    consoleHandler = logging.StreamHandler()
-    consoleHandler.setFormatter(logFormatter)
-    rootLogger.addHandler(consoleHandler)
+    if not rootLogger.hasHandlers():
+        consoleHandler = logging.StreamHandler()
+        consoleHandler.setFormatter(logFormatter)
+        rootLogger.addHandler(consoleHandler)


### PR DESCRIPTION
If a logging handler has already been added don't add it again.
(Picked from zaza.openstack)