### PR TITLE
Setup logging on all cli entry points

### DIFF
--- a/unit_tests/test_zaza_charm_lifecycle_func_test_runner.py
+++ b/unit_tests/test_zaza_charm_lifecycle_func_test_runner.py
@@ -165,38 +165,9 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
             mock.call('./tests/bundles/maveric-filebeat.yaml', 'newmodel')]
         self.deploy.assert_has_calls(deploy_calls)
 
-    def test_main_loglevel(self):
-        self.patch_object(lc_func_test_runner, 'parse_args')
-        self.patch_object(lc_func_test_runner, 'logging')
-        self.patch_object(lc_func_test_runner, 'func_test_runner')
-        self.patch_object(lc_func_test_runner, 'asyncio')
-        _args = mock.Mock()
-        _args.loglevel = 'DeBuG'
-        _args.dev = False
-        _args.smoke = False
-        self.parse_args.return_value = _args
-        self.logging.DEBUG = 10
-        lc_func_test_runner.main()
-        self.logging.basicConfig.assert_called_with(level=10)
-
-    def test_main_loglevel_invalid(self):
-        self.patch_object(lc_func_test_runner, 'parse_args')
-        self.patch_object(lc_func_test_runner, 'logging')
-        self.patch_object(lc_func_test_runner, 'func_test_runner')
-        self.patch_object(lc_func_test_runner, 'asyncio')
-        _args = mock.Mock()
-        _args.loglevel = 'invalid'
-        self.parse_args.return_value = _args
-        with self.assertRaises(ValueError) as context:
-            lc_func_test_runner.main()
-        self.assertEqual(
-            'Invalid log level: "invalid"',
-            str(context.exception))
-        self.assertFalse(self.logging.basicConfig.called)
-
     def test_main_smoke_dev_ambiguous(self):
         self.patch_object(lc_func_test_runner, 'parse_args')
-        self.patch_object(lc_func_test_runner, 'logging')
+        self.patch_object(lc_func_test_runner, 'cli_utils')
         self.patch_object(lc_func_test_runner, 'func_test_runner')
         self.patch_object(lc_func_test_runner, 'asyncio')
         _args = mock.Mock()
@@ -204,7 +175,6 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
         _args.dev = True
         _args.smoke = True
         self.parse_args.return_value = _args
-        self.logging.DEBUG = 10
         with self.assertRaises(ValueError) as context:
             lc_func_test_runner.main()
         self.assertEqual(
@@ -213,7 +183,7 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
 
     def test_main_bundle_dev_ambiguous(self):
         self.patch_object(lc_func_test_runner, 'parse_args')
-        self.patch_object(lc_func_test_runner, 'logging')
+        self.patch_object(lc_func_test_runner, 'cli_utils')
         self.patch_object(lc_func_test_runner, 'func_test_runner')
         self.patch_object(lc_func_test_runner, 'asyncio')
         _args = mock.Mock()
@@ -222,7 +192,6 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
         _args.smoke = False
         _args.bundle = 'foo.yaml'
         self.parse_args.return_value = _args
-        self.logging.DEBUG = 10
         with self.assertRaises(ValueError) as context:
             lc_func_test_runner.main()
         self.assertEqual(
@@ -232,7 +201,7 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
 
     def test_main_bundle_smoke_ambiguous(self):
         self.patch_object(lc_func_test_runner, 'parse_args')
-        self.patch_object(lc_func_test_runner, 'logging')
+        self.patch_object(lc_func_test_runner, 'cli_utils')
         self.patch_object(lc_func_test_runner, 'func_test_runner')
         self.patch_object(lc_func_test_runner, 'asyncio')
         _args = mock.Mock()
@@ -241,7 +210,6 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
         _args.smoke = True
         _args.bundle = 'foo.yaml'
         self.parse_args.return_value = _args
-        self.logging.DEBUG = 10
         with self.assertRaises(ValueError) as context:
             lc_func_test_runner.main()
         self.assertEqual(

--- a/zaza/charm_lifecycle/configure.py
+++ b/zaza/charm_lifecycle/configure.py
@@ -15,11 +15,11 @@
 """Run configuration phase."""
 import asyncio
 import argparse
-import logging
 import sys
 
 import zaza.model
 import zaza.charm_lifecycle.utils as utils
+import zaza.utilities.cli as cli_utils
 
 
 def run_configure_list(functions):
@@ -73,10 +73,7 @@ def main():
     config file
     """
     args = parse_args(sys.argv[1:])
-    level = getattr(logging, args.loglevel.upper(), None)
-    if not isinstance(level, int):
-        raise ValueError('Invalid log level: "{}"'.format(args.loglevel))
-    logging.basicConfig(level=level)
+    cli_utils.setup_logging(log_level=args.loglevel.upper())
     funcs = args.configfuncs or utils.get_charm_config()['configure']
     configure(args.model_name, funcs)
     asyncio.get_event_loop().close()

--- a/zaza/charm_lifecycle/deploy.py
+++ b/zaza/charm_lifecycle/deploy.py
@@ -23,6 +23,7 @@ import tempfile
 
 import zaza.model
 import zaza.charm_lifecycle.utils as utils
+import zaza.utilities.cli as cli_utils
 
 DEFAULT_OVERLAY_TEMPLATE_DIR = 'tests/bundles/overlays'
 VALID_ENVIRONMENT_KEY_PREFIXES = [
@@ -297,8 +298,5 @@ def parse_args(args):
 def main():
     """Deploy bundle."""
     args = parse_args(sys.argv[1:])
-    level = getattr(logging, args.loglevel.upper(), None)
-    if not isinstance(level, int):
-        raise ValueError('Invalid log level: "{}"'.format(args.loglevel))
-    logging.basicConfig(level=level)
+    cli_utils.setup_logging(log_level=args.loglevel.upper())
     deploy(args.bundle, args.model, wait=args.wait)

--- a/zaza/charm_lifecycle/destroy.py
+++ b/zaza/charm_lifecycle/destroy.py
@@ -14,10 +14,10 @@
 
 """Run destroy phase."""
 import argparse
-import logging
 import sys
 
 import zaza.controller
+import zaza.utilities.cli as cli_utils
 
 
 def destroy(model_name):
@@ -49,8 +49,5 @@ def parse_args(args):
 def main():
     """Cleanup after test run."""
     args = parse_args(sys.argv[1:])
-    level = getattr(logging, args.loglevel.upper(), None)
-    if not isinstance(level, int):
-        raise ValueError('Invalid log level: "{}"'.format(args.loglevel))
-    logging.basicConfig(level=level)
+    cli_utils.setup_logging(log_level=args.loglevel.upper())
     destroy(args.model_name)

--- a/zaza/charm_lifecycle/func_test_runner.py
+++ b/zaza/charm_lifecycle/func_test_runner.py
@@ -15,7 +15,6 @@
 """Run full test lifecycle."""
 import argparse
 import asyncio
-import logging
 import os
 import sys
 
@@ -25,6 +24,7 @@ import zaza.charm_lifecycle.utils as utils
 import zaza.charm_lifecycle.prepare as prepare
 import zaza.charm_lifecycle.deploy as deploy
 import zaza.charm_lifecycle.test as test
+import zaza.utilities.cli as cli_utils
 
 
 def func_test_runner(keep_model=False, smoke=False, dev=False, bundle=None):
@@ -106,10 +106,7 @@ def main():
     """Execute full test run."""
     args = parse_args(sys.argv[1:])
 
-    level = getattr(logging, args.loglevel.upper(), None)
-    if not isinstance(level, int):
-        raise ValueError('Invalid log level: "{}"'.format(args.loglevel))
-    logging.basicConfig(level=level)
+    cli_utils.setup_logging(log_level=args.loglevel.upper())
 
     if args.dev and args.smoke:
         raise ValueError('Ambiguous arguments: --smoke and '

--- a/zaza/charm_lifecycle/prepare.py
+++ b/zaza/charm_lifecycle/prepare.py
@@ -23,6 +23,7 @@ import zaza.controller
 import zaza.model
 
 import zaza.charm_lifecycle.utils as utils
+import zaza.utilities.cli as cli_utils
 
 MODEL_DEFAULTS = {
     # Model defaults from charm-test-infra
@@ -116,9 +117,6 @@ def parse_args(args):
 def main():
     """Add a new model."""
     args = parse_args(sys.argv[1:])
-    level = getattr(logging, args.loglevel.upper(), None)
-    if not isinstance(level, int):
-        raise ValueError('Invalid log level: "{}"'.format(args.loglevel))
-    logging.basicConfig(level=level)
-    print('model_name: {}'.format(args.model_name))
+    cli_utils.setup_logging(log_level=args.loglevel.upper())
+    logging.info('model_name: {}'.format(args.model_name))
     prepare(args.model_name)

--- a/zaza/charm_lifecycle/test.py
+++ b/zaza/charm_lifecycle/test.py
@@ -21,6 +21,7 @@ import sys
 
 import zaza.model
 import zaza.charm_lifecycle.utils as utils
+import zaza.utilities.cli as cli_utils
 
 
 def run_test_list(tests):
@@ -71,10 +72,7 @@ def main():
     read the tests from the charms tests.yaml config file
     """
     args = parse_args(sys.argv[1:])
-    level = getattr(logging, args.loglevel.upper(), None)
-    if not isinstance(level, int):
-        raise ValueError('Invalid log level: "{}"'.format(args.loglevel))
-    logging.basicConfig(level=level)
+    cli_utils.setup_logging(log_level=args.loglevel.upper())
     tests = args.tests or utils.get_charm_config()['tests']
     test(args.model_name, tests)
     asyncio.get_event_loop().close()

--- a/zaza/utilities/cli.py
+++ b/zaza/utilities/cli.py
@@ -39,17 +39,20 @@ def parse_arg(options, arg, multiargs=False):
         return getattr(options, arg)
 
 
-def setup_logging():
+def setup_logging(log_level='INFO'):
     """Do setup for logging.
 
     :returns: Nothing: This fucntion is executed for its sideffect
     :rtype: None
     """
+    level = getattr(logging, log_level.upper(), None)
+    if not isinstance(level, int):
+        raise ValueError('Invalid log level: "{}"'.format(log_level))
     logFormatter = logging.Formatter(
         fmt="%(asctime)s [%(levelname)s] %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S")
     rootLogger = logging.getLogger()
-    rootLogger.setLevel('INFO')
+    rootLogger.setLevel(level)
     if not rootLogger.hasHandlers():
         consoleHandler = logging.StreamHandler()
         consoleHandler.setFormatter(logFormatter)


### PR DESCRIPTION
Call the setup_logging method on all the zaza cli entry points
to setup logging consistently.