### PR TITLE
libjuju issue 267 is fixed so remove workaround

### DIFF
--- a/unit_tests/test_zaza_controller.py
+++ b/unit_tests/test_zaza_controller.py
@@ -70,20 +70,17 @@ class TestController(ut_utils.BaseTestCase):
         self.Controller.return_value = self.Controller_mock
 
     def test_add_model(self):
-        self.patch_object(controller, 'go_list_models')
         controller.add_model(self.model1.info.name)
         self.Controller_mock.add_model.assert_called_once_with(
             self.model1.info.name,
             config=None)
 
     def test_add_model_config(self):
-        self.patch_object(controller, 'go_list_models')
         controller.add_model(self.model1.info.name,
                              {'run-faster': 'true'})
         self.Controller_mock.add_model.assert_called_once_with(
             self.model1.info.name,
             config={'run-faster': 'true'})
-        self.go_list_models.assert_called_once()
 
     def test_destroy_model(self):
         controller.destroy_model(self.model1.info.name)

--- a/zaza/controller.py
+++ b/zaza/controller.py
@@ -34,9 +34,6 @@ async def async_add_model(model_name, config=None):
     model = await controller.add_model(model_name, config=config)
     await model.disconnect()
     await controller.disconnect()
-    # NOTE: This is necessary to guarantee juju is aware of the newly created
-    # model.
-    go_list_models()
 
 add_model = sync_wrapper(async_add_model)
 


### PR DESCRIPTION
A libjuju issue *1 that required a subprocess juju switch for a new
model to be accessible is no longer needed.

*1 https://github.com/juju/python-libjuju/issues/267