### PR TITLE
Send deployment output to logger

### DIFF
--- a/unit_tests/test_zaza_charm_lifecycle_deploy.py
+++ b/unit_tests/test_zaza_charm_lifecycle_deploy.py
@@ -208,10 +208,10 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
         self.patch_object(lc_deploy.utils, 'get_charm_config')
         self.get_charm_config.return_value = {}
         self.patch_object(lc_deploy, 'render_overlays')
-        self.patch_object(lc_deploy.subprocess, 'check_call')
+        self.patch_object(lc_deploy.utils, 'check_output_logging')
         self.render_overlays.return_value = []
         lc_deploy.deploy_bundle('bun.yaml', 'newmodel')
-        self.check_call.assert_called_once_with(
+        self.check_output_logging.assert_called_once_with(
             ['juju', 'deploy', '-m', 'newmodel', 'bun.yaml'])
 
     def test_deploy(self):

--- a/unit_tests/test_zaza_charm_lifecycle_utils.py
+++ b/unit_tests/test_zaza_charm_lifecycle_utils.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import io
 import mock
+import subprocess
 
 import zaza.charm_lifecycle.utils as lc_utils
 import unit_tests.utils as ut_utils
@@ -50,3 +52,27 @@ class TestCharmLifecycleUtils(ut_utils.BaseTestCase):
                                     'test_zaza_charm_lifecycle_utils.'
                                     'TestCharmLifecycleUtils')()),
             type(self))
+
+    def test_check_output_logging(self):
+        self.patch_object(lc_utils.logging, 'info')
+        self.patch_object(lc_utils.subprocess, 'Popen')
+        popen_mock = mock.MagicMock()
+        popen_mock.stdout = io.StringIO("logline1\nlogline2\nlogline3\n")
+        popen_mock.wait.return_value = 0
+        self.Popen.return_value = popen_mock
+        lc_utils.check_output_logging(['cmd', 'arg1', 'arg2'])
+        log_calls = [
+            mock.call('logline1'),
+            mock.call('logline2'),
+            mock.call('logline3')]
+        self.info.assert_has_calls(log_calls)
+
+    def test_check_output_logging_process_error(self):
+        with self.assertRaises(subprocess.CalledProcessError):
+            self.patch_object(lc_utils.logging, 'info')
+            self.patch_object(lc_utils.subprocess, 'Popen')
+            popen_mock = mock.MagicMock()
+            popen_mock.stdout = io.StringIO("logline1\n")
+            popen_mock.wait.return_value = 1
+            self.Popen.return_value = popen_mock
+            lc_utils.check_output_logging(['cmd', 'arg1', 'arg2'])

--- a/zaza/charm_lifecycle/deploy.py
+++ b/zaza/charm_lifecycle/deploy.py
@@ -17,7 +17,6 @@ import argparse
 import jinja2
 import logging
 import os
-import subprocess
 import sys
 import tempfile
 
@@ -248,7 +247,7 @@ def deploy_bundle(bundle, model):
             logging.info("Deploying overlay '{}' on to '{}' model"
                          .format(overlay, model))
             cmd.extend(['--overlay', overlay])
-        subprocess.check_call(cmd)
+        utils.check_output_logging(cmd)
 
 
 def deploy(bundle, model, wait=True):

--- a/zaza/charm_lifecycle/utils.py
+++ b/zaza/charm_lifecycle/utils.py
@@ -14,6 +14,8 @@
 
 """Utilities to support running lifecycle phases."""
 import importlib
+import logging
+import subprocess
 import uuid
 import sys
 import yaml
@@ -63,3 +65,22 @@ def generate_model_name():
     :rtype: str
     """
     return 'zaza-{}'.format(str(uuid.uuid4())[-12:])
+
+
+def check_output_logging(cmd):
+    """Run command and log output.
+
+    :param cmd: Shell command to run
+    :type cmd: List
+    """
+    popen = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        universal_newlines=True)
+    for line in iter(popen.stdout.readline, ""):
+        logging.info(line.strip())
+    popen.stdout.close()
+    return_code = popen.wait()
+    if return_code:
+        raise subprocess.CalledProcessError(return_code, cmd)

--- a/zaza/charm_lifecycle/utils.py
+++ b/zaza/charm_lifecycle/utils.py
@@ -72,6 +72,7 @@ def check_output_logging(cmd):
 
     :param cmd: Shell command to run
     :type cmd: List
+    :raises: subprocess.CalledProcessError
     """
     popen = subprocess.Popen(
         cmd,

--- a/zaza/charm_lifecycle/utils.py
+++ b/zaza/charm_lifecycle/utils.py
@@ -79,8 +79,12 @@ def check_output_logging(cmd):
         stderr=subprocess.STDOUT,
         universal_newlines=True)
     for line in iter(popen.stdout.readline, ""):
+        # popen.poll checks if child process has terminated. If it has it
+        # returns the returncode. If it has not it returns None.
+        if popen.poll() is not None:
+            break
         logging.info(line.strip())
     popen.stdout.close()
-    return_code = popen.wait()
+    return_code = popen.poll()
     if return_code:
         raise subprocess.CalledProcessError(return_code, cmd)


### PR DESCRIPTION
The juju deployment is done via a subprocess call and the resulting
output goes to stdout rather than to the logger. This change
captures the output and uses the python logging to log it.