### PR TITLE
Add helpers to get test bundles, tests and config

### DIFF
--- a/unit_tests/test_zaza_charm_lifecycle_utils.py
+++ b/unit_tests/test_zaza_charm_lifecycle_utils.py
@@ -22,6 +22,95 @@ import unit_tests.utils as ut_utils
 
 class TestCharmLifecycleUtils(ut_utils.BaseTestCase):
 
+    def test_model_alias_str_fmt(self):
+        self.assertEqual(
+            lc_utils._model_alias_str_fmt('bundle1'),
+            {'default_alias': 'bundle1'})
+        self.assertEqual(
+            lc_utils._model_alias_str_fmt(
+                {'model_alias1': 'bundle1'}),
+            {'model_alias1': 'bundle1'})
+
+    def test__concat_model_alias_maps(self):
+        # - test1
+        self.assertEqual(
+            lc_utils._concat_model_alias_maps(['test1']),
+            {'default_alias': ['test1']})
+        # - test1
+        # - test2
+        self.assertEqual(
+            lc_utils._concat_model_alias_maps(['test1', 'test2']),
+            {'default_alias': ['test1', 'test2']})
+        # - default_alias1:
+        #   - test1
+        self.assertEqual(
+            lc_utils._concat_model_alias_maps([{'default_alias': ['test1']}]),
+            {'default_alias': ['test1']})
+        # - test1
+        # - test2
+        # - model_alias1:
+        #   - test3
+        # - model_alias2:
+        #   - test4
+        self.assertEqual(
+            lc_utils._concat_model_alias_maps(
+                [
+                    'test1',
+                    'test2',
+                    {
+                        'model_alias1': ['test3']},
+                    {
+                        'model_alias2': ['test4']}]),
+            {
+                'default_alias': ['test1', 'test2'],
+                'model_alias1': ['test3'],
+                'model_alias2': ['test4']})
+
+    def test_get_test_bundles(self):
+        self.patch_object(lc_utils, "get_charm_config")
+        self.get_charm_config.return_value = {
+            'gate_bundles': ['bundle1']}
+        self.assertEqual(lc_utils.get_test_bundles(
+            'gate_bundles'),
+            [{'default_alias': 'bundle1'}])
+        self.get_charm_config.return_value = {
+            'gate_bundles': [
+                'bundle1',
+                'bundle2',
+                {
+                    'model_alias1': 'bundle_3',
+                    'model_alias2': 'bundle_4'}]}
+        self.assertEqual(lc_utils.get_test_bundles(
+            'gate_bundles'),
+            [
+                {'default_alias': 'bundle1'},
+                {'default_alias': 'bundle2'},
+                {'model_alias1': 'bundle_3', 'model_alias2': 'bundle_4'}])
+
+    def test_get_config_steps(self):
+        self.patch_object(lc_utils, "get_charm_config")
+        self.get_charm_config.return_value = {
+            'configure': [
+                'conf.class1',
+                'conf.class2',
+                {'model_alias1': ['conf.class3']}]}
+        self.assertEqual(
+            lc_utils.get_config_steps(),
+            {'default_alias': ['conf.class1', 'conf.class2'],
+             'model_alias1': ['conf.class3']})
+
+    def test_get_test_steps(self):
+        self.patch_object(lc_utils, "get_charm_config")
+        self.get_charm_config.return_value = {
+            'tests': [
+                'test.class1',
+                'test.class2',
+                {'model_alias1': ['test.class3']}]}
+        self.assertEqual(
+            lc_utils.get_test_steps(),
+            {'default_alias': ['test.class1', 'test.class2'],
+             'model_alias1': ['test.class3']})
+
     def test_generate_model_name(self):
         self.patch_object(lc_utils.uuid, "uuid4")
         self.uuid4.return_value = "longer-than-12characters"

--- a/zaza/charm_lifecycle/utils.py
+++ b/zaza/charm_lifecycle/utils.py
@@ -33,9 +33,9 @@ def _model_alias_str_fmt(data):
     DEFAULT_MODEL_ALIAS. If a dict is passed then this is a noop.
 
     :param data: String or Model Alias to data map
-    :type data: str or {}
+    :type data: Union[str, Dict[str, str]]
     :returns: Model Alias to data map
-    :rtype: {}
+    :rtype: Dict[str, str]
     """
     if isinstance(data, collections.Mapping):
         return data
@@ -57,15 +57,14 @@ def _concat_model_alias_maps(data):
            'alias2': ['e4']}
 
     :param data: List comprised of str elements or dict elements.
-    :type data: []
+    :type data: List[Union[str, Dict[str, List[str]]]]
     :returns: Model Alias to data map
-    :rtype: {}
+    :rtype: Dict[str, List[str]]
     """
     new_data = {DEFAULT_MODEL_ALIAS: []}
     for item in data:
         if isinstance(item, collections.Mapping):
-            for key, value in item.items():
-                new_data[key] = value
+            new_data.update(item)
         else:
             new_data[DEFAULT_MODEL_ALIAS].append(item)
     return new_data
@@ -96,7 +95,7 @@ def get_test_bundles(bundle_key):
     :type bundle_key: str
     :returns: A list of dicts where the dict contain a model alias to bundle
               mapping.
-    :rtype: [{}, ...]
+    :rtype: List[Dict[str, str]]
     """
     return [_model_alias_str_fmt(b)
             for b in get_charm_config()[bundle_key]]
@@ -124,7 +123,7 @@ def get_config_steps():
             'model_alias1': ['conf.class3']}
 
     :returns: A dict mapping config steps to model aliases
-    :rtype: {str: [], ...}
+    :rtype: Dict[str, List[str]]
     """
     return _concat_model_alias_maps(get_charm_config().get('configure', []))
 
@@ -151,7 +150,7 @@ def get_test_steps():
             'model_alias1': ['test.class3']}
 
     :returns: A dict mapping test steps to model aliases
-    :rtype: {str: [], ...}
+    :rtype: Dict[str, List[str]]
     """
     return _concat_model_alias_maps(get_charm_config().get('tests', []))
 

--- a/zaza/charm_lifecycle/utils.py
+++ b/zaza/charm_lifecycle/utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Utilities to support running lifecycle phases."""
+import collections
 import importlib
 import logging
 import subprocess
@@ -22,6 +23,137 @@ import yaml
 
 BUNDLE_DIR = "./tests/bundles/"
 DEFAULT_TEST_CONFIG = "./tests/tests.yaml"
+DEFAULT_MODEL_ALIAS = "default_alias"
+
+
+def _model_alias_str_fmt(data):
+    """Convert to model_alias:str format if needed.
+
+    If a string is passed in then the string is mapped to the
+    DEFAULT_MODEL_ALIAS. If a dict is passed then this is a noop.
+
+    :param data: String or Model Alias to data map
+    :type data: str or {}
+    :returns: Model Alias to data map
+    :rtype: {}
+    """
+    if isinstance(data, collections.Mapping):
+        return data
+    else:
+        return {DEFAULT_MODEL_ALIAS: data}
+
+
+def _concat_model_alias_maps(data):
+    """Iterate over list and construct single dict of model alias maps.
+
+    Any elements in list which are not dicts are added to a list and assigned
+    to DEFAULT_MODEL_ALIAS.
+
+    eg If input is ['e1', 'e2', {'alias1': ['e3'], 'alias2': ['e4']}]
+       this function will return:
+       {
+           DEFAULT_MODEL_ALIAS: ['e1', 'e2'],
+           'alias1': ['e3'],
+           'alias2': ['e4']}
+
+    :param data: List comprised of str elements or dict elements.
+    :type data: []
+    :returns: Model Alias to data map
+    :rtype: {}
+    """
+    new_data = {DEFAULT_MODEL_ALIAS: []}
+    for item in data:
+        if isinstance(item, collections.Mapping):
+            for key, value in item.items():
+                new_data[key] = value
+        else:
+            new_data[DEFAULT_MODEL_ALIAS].append(item)
+    return new_data
+
+
+def get_test_bundles(bundle_key):
+    """Get test bundles with their model alias.
+
+    Get a list of test bundles with their model alias. If no model alias is
+    supplied then DEFAULT_MODEL_ALIAS is used.
+
+    eg if test.yaml contained:
+
+        gate_bundles:
+          - bundle1
+          - bundle2
+          - model_alias1: bundle_3
+            model_alias2: bundle_4
+
+       then get_test_bundles('gate_bundles') would return:
+
+            [
+                {'default_alias': 'bundle1'},
+                {'default_alias': 'bundle2'},
+                {'model_alias1': 'bundle1', 'model_alias2': 'bundle2'}])
+
+    :param bundle_key: Name of group of bundles eg gate_bundles
+    :type bundle_key: str
+    :returns: A list of dicts where the dict contain a model alias to bundle
+              mapping.
+    :rtype: [{}, ...]
+    """
+    return [_model_alias_str_fmt(b)
+            for b in get_charm_config()[bundle_key]]
+
+
+def get_config_steps():
+    """Get configuration steps and their associated model aliases.
+
+    Get a map of configuration steps to model aliases. If there are
+    configuration steps which are not mapped to a model alias then these are
+    associated with the the DEFAULT_MODEL_ALIAS.
+
+    eg if test.yaml contained:
+
+        configure:
+        - conf.class1
+        - conf.class2
+        - model_alias1:
+          - conf.class3
+
+       then get_config_steps() would return:
+
+        {
+            'default_alias': ['conf.class1', 'conf.class2'],
+            'model_alias1': ['conf.class3']}
+
+    :returns: A dict mapping config steps to model aliases
+    :rtype: {str: [], ...}
+    """
+    return _concat_model_alias_maps(get_charm_config().get('configure', []))
+
+
+def get_test_steps():
+    """Get test steps and their associated model aliases.
+
+    Get a map of test steps to model aliases. If there are test
+    steps which are not mapped to a model alias then these are associated with
+    the the DEFAULT_MODEL_ALIAS.
+
+    eg if test.yaml contained:
+
+        test:
+        - test.class1
+        - test.class2
+        - model_alias1:
+          - test.class3
+
+       then get_test_steps() would return:
+
+        {
+            'default_alias': ['test.class1', 'test.class2'],
+            'model_alias1': ['test.class3']}
+
+    :returns: A dict mapping test steps to model aliases
+    :rtype: {str: [], ...}
+    """
+    return _concat_model_alias_maps(get_charm_config().get('tests', []))
 
 
 def get_charm_config(yaml_file=None):


### PR DESCRIPTION
This change adds helpers to retrieve the model alias mappings for
bundles, configuration and tests as specified in the tests.yaml.
This includes handling configuration written with and without
explicit model alias maps. See below for background.

To support cross-model-relations test authors need the ability to
express which tests/config or bundles should be targetted at which
model. To do this zaza will support model aliases. This will allow
an author to associate a model alias with a bundle. Subsequent
configuration and test steps can then be targetted at that model
alias. This aslo supports multiple bundles to be deployed in a test
run and each associated with its own model alias.

Backward compatability with existing config which does not specify a
model alias is achieved by mapping objects which do not specify a
model alias to a default alias.

It is possible for an author to use both approaches in the same
tests.yaml eg:

    charm_name: vault
    configure:
    - zaza.openstack.charm_tests.vault.setup.basic_setup
    - vault_model:
      - zaza.openstack.charm_tests.vault.setup.basic_setup
    - keystone_model:
      - zaza.openstack.charm_tests.ks.setup.user_setup
    gate_bundles:
    - xenial-ha-mysql
    - vault_model: xenial-ha-mysql
      keystone_model: keystone-certs
    tests:
    - zaza.openstack.charm_tests.vault.tests.VaultTest
    - vault_model:
      - zaza.openstack.charm_tests.vault.tests.VaultTest
    - keystone_model:
      - zaza.openstack.charm_tests.keystone.tests.ProjTest