### PR TITLE
Always disconnect from model in run_in_model.

### DIFF
--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -217,6 +217,18 @@ class TestModel(ut_utils.BaseTestCase):
         self.Model_mock.connect_model.assert_called_once_with('modelname')
         self.Model_mock.disconnect.assert_called_once_with()
 
+    def test_run_in_model_exception(self):
+        self.patch_object(model, 'Model')
+        self.Model.return_value = self.Model_mock
+
+        async def _wrapper():
+            async with model.run_in_model('modelname'):
+                raise Exception
+        with self.assertRaises(Exception):
+            loop.run(_wrapper())
+        self.Model_mock.connect_model.assert_called_once_with('modelname')
+        self.Model_mock.disconnect.assert_called_once_with()
+
     def test_scp_to_unit(self):
         self.patch_object(model, 'get_juju_model', return_value='mname')
         self.patch_object(model, 'Model')

--- a/zaza/model.py
+++ b/zaza/model.py
@@ -153,8 +153,10 @@ async def run_in_model(model_name):
     if not model_name:
         model_name = await async_get_juju_model()
     await model.connect_model(model_name)
-    await yield_(model)
-    await model.disconnect()
+    try:
+        await yield_(model)
+    finally:
+        await model.disconnect()
 
 
 async def async_scp_to_unit(unit_name, source, destination, model_name=None,


### PR DESCRIPTION
If a function raises an exception from within a run_in_model
context, run_in_model should still ensure the context is
closed cleanly be disconnecting from the model.