### PR TITLE
Allow a charm test to configure before_deploy scripts

### DIFF
--- a/doc/source/runningcharmtests.rst
+++ b/doc/source/runningcharmtests.rst
@@ -79,7 +79,25 @@ To run manually::
                             Name of new model
       --log LOGLEVEL        Loglevel [DEBUG|INFO|WARN|ERROR|CRITICAL]
 
-2) Deploy
+2) Before Deploy
+~~~~~~~~~~~~~~~~
+
+Perform pre-deployment tasks, for example: setup a default model configuration
+that is necessary to deploy a bundle.
+
+To run manually::
+
+    $ functest-before-deploy --help
+    usage: functest-before-deploy [-h] [-c BEFOREFUNCS [BEFOREFUNCS ...]] [--log LOGLEVEL]
+
+    optional arguments:
+      -h, --help
+                            show this help message and exit
+      -c BEFOREFUNCS, --beforefuncs BEFOREFUNCS
+                            Space separated list of config functions
+      --log LOGLEVEL        Loglevel [DEBUG|INFO|WARN|ERROR|CRITICAL]
+
+3) Deploy
 ~~~~~~~~~
 
 Deploy the target bundle and wait for it to complete. **functest-run-suite** 
@@ -115,7 +133,7 @@ To run manually::
       --log LOGLEVEL        Loglevel [DEBUG|INFO|WARN|ERROR|CRITICAL]
 
 
-3) Configure
+4) Configure
 ~~~~~~~~~~~~
 
 Post-deployment configuration, for example create network, tenant, image, etc.
@@ -136,7 +154,7 @@ To run manually::
       --log LOGLEVEL        Loglevel [DEBUG|INFO|WARN|ERROR|CRITICAL]
 
 
-4) Test
+5) Test
 ~~~~~~~
 
 Run tests. These maybe tests in zaza or a wrapper around another testing
@@ -155,14 +173,14 @@ To run manually::
       --log LOGLEVEL        Loglevel [DEBUG|INFO|WARN|ERROR|CRITICAL]
 
 
-5) Collect
+6) Collect
 ~~~~~~~~~~
 
 Collect artifacts useful for debugging any failures or useful for trend
 analysis like deprecation warning or deployment time.
 
 
-6) Destroy
+7) Destroy
 ~~~~~~~~~~
 
 Destroy the model::

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2018 Canonical Ltd.
+# Copyright 2020 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -88,6 +88,7 @@ setup(
     entry_points={
         'console_scripts': [
             'functest-run-suite = zaza.charm_lifecycle.func_test_runner:main',
+            'functest-before-deploy = zaza.charm_lifecycle.before_deploy:main',
             'functest-deploy = zaza.charm_lifecycle.deploy:main',
             'functest-configure = zaza.charm_lifecycle.configure:main',
             'functest-destroy = zaza.charm_lifecycle.destroy:main',

--- a/unit_tests/test_zaza_charm_lifecycle_before_deploy.py
+++ b/unit_tests/test_zaza_charm_lifecycle_before_deploy.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Canonical Ltd.
+# Copyright 2020 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unit_tests/test_zaza_charm_lifecycle_before_deploy.py
+++ b/unit_tests/test_zaza_charm_lifecycle_before_deploy.py
@@ -1,0 +1,51 @@
+# Copyright 2018 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mock
+
+import zaza.charm_lifecycle.before_deploy as lc_before_deploy
+import unit_tests.utils as ut_utils
+
+
+class TestCharmLifecycleBeforeDeploy(ut_utils.BaseTestCase):
+
+    def test_run_before_deploy_list(self):
+        self.patch_object(lc_before_deploy.utils, 'get_class')
+        self.get_class.side_effect = lambda x: x
+        mock1 = mock.MagicMock()
+        mock2 = mock.MagicMock()
+        lc_before_deploy.run_before_deploy_list([mock1, mock2])
+        self.assertTrue(mock1.called)
+        self.assertTrue(mock2.called)
+
+    def test_before_deploy(self):
+        self.patch_object(lc_before_deploy, 'run_before_deploy_list')
+        mock1 = mock.MagicMock()
+        mock2 = mock.MagicMock()
+        lc_before_deploy.before_deploy('modelname', [mock1, mock2])
+        self.run_before_deploy_list.assert_called_once_with([mock1, mock2])
+
+    def test_parser(self):
+        args = lc_before_deploy.parse_args(
+            ['-m', 'modelname', '-c', 'my.func1', 'my.func2'])
+        self.assertEqual(args.beforefuncs, ['my.func1', 'my.func2'])
+        self.assertEqual(args.model_name, 'modelname')
+
+    def test_parser_logging(self):
+        # Using defaults
+        args = lc_before_deploy.parse_args(['-m', 'model'])
+        self.assertEqual(args.loglevel, 'INFO')
+        # Using args
+        args = lc_before_deploy.parse_args(['-m', 'model', '--log', 'DEBUG'])
+        self.assertEqual(args.loglevel, 'DEBUG')

--- a/unit_tests/test_zaza_charm_lifecycle_func_test_runner.py
+++ b/unit_tests/test_zaza_charm_lifecycle_func_test_runner.py
@@ -48,6 +48,7 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
         self.patch_object(lc_func_test_runner.utils, 'get_charm_config')
         self.patch_object(lc_func_test_runner.utils, 'generate_model_name')
         self.patch_object(lc_func_test_runner.prepare, 'prepare')
+        self.patch_object(lc_func_test_runner.before_deploy, 'before_deploy')
         self.patch_object(lc_func_test_runner.deploy, 'deploy')
         self.patch_object(lc_func_test_runner.configure, 'configure')
         self.patch_object(lc_func_test_runner.test, 'test')
@@ -105,6 +106,7 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
         self.patch_object(lc_func_test_runner.utils, 'get_charm_config')
         self.patch_object(lc_func_test_runner.utils, 'generate_model_name')
         self.patch_object(lc_func_test_runner.prepare, 'prepare')
+        self.patch_object(lc_func_test_runner.before_deploy, 'before_deploy')
         self.patch_object(lc_func_test_runner.deploy, 'deploy')
         self.patch_object(lc_func_test_runner.configure, 'configure')
         self.patch_object(lc_func_test_runner.test, 'test')
@@ -193,10 +195,67 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
         self.test.assert_has_calls(test_calls)
         self.destroy.assert_has_calls(destroy_calls)
 
+    def test_func_test_runner_with_before_script(self):
+        self.patch_object(lc_func_test_runner.utils, 'get_charm_config')
+        self.patch_object(lc_func_test_runner.utils, 'generate_model_name')
+        self.patch_object(lc_func_test_runner.prepare, 'prepare')
+        self.patch_object(lc_func_test_runner.before_deploy, 'before_deploy')
+        self.patch_object(lc_func_test_runner.deploy, 'deploy')
+        self.patch_object(lc_func_test_runner.configure, 'configure')
+        self.patch_object(lc_func_test_runner.test, 'test')
+        self.patch_object(lc_func_test_runner.destroy, 'destroy')
+        self.patch_object(
+            lc_func_test_runner.zaza.model,
+            'block_until_all_units_idle')
+        self.generate_model_name.return_value = 'newmodel'
+        self.get_charm_config.return_value = {
+            'charm_name': 'mycharm',
+            'gate_bundles': ['bundle1', 'bundle2'],
+            'smoke_bundles': ['bundle2'],
+            'dev_bundles': ['bundle3', 'bundle4'],
+            'before_deploy': [
+                'zaza.charm_tests.prepare.first',
+                'zaza.charm_tests.prepare.second'],
+            'tests': [
+                'zaza.charm_tests.mycharm.tests.SmokeTest',
+                'zaza.charm_tests.mycharm.tests.ComplexTest']}
+        lc_func_test_runner.func_test_runner()
+        prepare_calls = [
+            mock.call('newmodel'),
+            mock.call('newmodel')]
+        deploy_calls = [
+            mock.call('./tests/bundles/bundle1.yaml', 'newmodel',
+                      model_ctxt={'default_alias': 'newmodel'}),
+            mock.call('./tests/bundles/bundle2.yaml', 'newmodel',
+                      model_ctxt={'default_alias': 'newmodel'})]
+        before_deploy_calls = [
+            mock.call('newmodel', [
+                'zaza.charm_tests.prepare.first',
+                'zaza.charm_tests.prepare.second']),
+            mock.call('newmodel', [
+                'zaza.charm_tests.prepare.first',
+                'zaza.charm_tests.prepare.second'])]
+        test_calls = [
+            mock.call('newmodel', [
+                'zaza.charm_tests.mycharm.tests.SmokeTest',
+                'zaza.charm_tests.mycharm.tests.ComplexTest']),
+            mock.call('newmodel', [
+                'zaza.charm_tests.mycharm.tests.SmokeTest',
+                'zaza.charm_tests.mycharm.tests.ComplexTest'])]
+        destroy_calls = [
+            mock.call('newmodel'),
+            mock.call('newmodel')]
+        self.prepare.assert_has_calls(prepare_calls)
+        self.deploy.assert_has_calls(deploy_calls)
+        self.before_deploy.assert_has_calls(before_deploy_calls)
+        self.test.assert_has_calls(test_calls)
+        self.destroy.assert_has_calls(destroy_calls)
+
     def test_func_test_runner_smoke(self):
         self.patch_object(lc_func_test_runner.utils, 'get_charm_config')
         self.patch_object(lc_func_test_runner.utils, 'generate_model_name')
         self.patch_object(lc_func_test_runner.prepare, 'prepare')
+        self.patch_object(lc_func_test_runner.before_deploy, 'before_deploy')
         self.patch_object(lc_func_test_runner.deploy, 'deploy')
         self.patch_object(lc_func_test_runner.configure, 'configure')
         self.patch_object(lc_func_test_runner.test, 'test')
@@ -227,6 +286,7 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
         self.patch_object(lc_func_test_runner.utils, 'get_charm_config')
         self.patch_object(lc_func_test_runner.utils, 'generate_model_name')
         self.patch_object(lc_func_test_runner.prepare, 'prepare')
+        self.patch_object(lc_func_test_runner.before_deploy, 'before_deploy')
         self.patch_object(lc_func_test_runner.deploy, 'deploy')
         self.patch_object(lc_func_test_runner.configure, 'configure')
         self.patch_object(lc_func_test_runner.test, 'test')
@@ -258,6 +318,7 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
         self.patch_object(lc_func_test_runner.utils, 'get_charm_config')
         self.patch_object(lc_func_test_runner.utils, 'generate_model_name')
         self.patch_object(lc_func_test_runner.prepare, 'prepare')
+        self.patch_object(lc_func_test_runner.before_deploy, 'before_deploy')
         self.patch_object(lc_func_test_runner.deploy, 'deploy')
         self.patch_object(lc_func_test_runner.configure, 'configure')
         self.patch_object(lc_func_test_runner.test, 'test')

--- a/unit_tests/test_zaza_charm_lifecycle_func_test_runner.py
+++ b/unit_tests/test_zaza_charm_lifecycle_func_test_runner.py
@@ -225,9 +225,9 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
             mock.call('newmodel')]
         deploy_calls = [
             mock.call('./tests/bundles/bundle1.yaml', 'newmodel',
-                      model_ctxt={'default_alias': 'newmodel'}),
+                      model_ctxt={'default_alias': 'newmodel'}, force=False),
             mock.call('./tests/bundles/bundle2.yaml', 'newmodel',
-                      model_ctxt={'default_alias': 'newmodel'})]
+                      model_ctxt={'default_alias': 'newmodel'}, force=False)]
         before_deploy_calls = [
             mock.call('newmodel', [
                 'zaza.charm_tests.prepare.first',

--- a/zaza/charm_lifecycle/before_deploy.py
+++ b/zaza/charm_lifecycle/before_deploy.py
@@ -1,0 +1,83 @@
+# Copyright 2018 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Run configuration phase."""
+import asyncio
+import argparse
+import sys
+
+import zaza.model
+import zaza.charm_lifecycle.utils as utils
+import zaza.utilities.cli as cli_utils
+import zaza.utilities.run_report as run_report
+
+
+def run_before_deploy_list(functions):
+    """Run the pre-deploy scripts.
+
+    Run the pre-deploy scripts as defined in the list of test classes in
+    series.
+
+    :param functions: List of pre-deploy functions functions
+    :type tests: ['zaza.charms_tests.svc.setup', ...]
+    """
+    for func in functions:
+        run_report.register_event_start('BBefore Deploy {}'.format(func))
+        utils.get_class(func)()
+        run_report.register_event_finish('BBefore Deploy {}'.format(func))
+
+
+def before_deploy(model_name, functions):
+    """Run all post-deployment configuration steps.
+
+    :param functions: List of pre-deploy functions functions
+    :type tests: ['zaza.charms_tests.svc.setup', ...]
+    """
+    zaza.model.set_juju_model(model_name)
+    run_before_deploy_list(functions)
+
+
+def parse_args(args):
+    """Parse command line arguments.
+
+    :param args: List of before_deploy functions functions
+    :type list: [str1, str2,...] List of command line arguments
+    :returns: Parsed arguments
+    :rtype: Namespace
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-c', '--beforefuncs', nargs='+',
+                        help='Space separated list of config functions',
+                        required=False)
+    parser.add_argument('-m', '--model-name', help='Name of model to remove',
+                        required=True)
+    parser.add_argument('--log', dest='loglevel',
+                        help='Loglevel [DEBUG|INFO|WARN|ERROR|CRITICAL]')
+    parser.set_defaults(loglevel='INFO')
+    return parser.parse_args(args)
+
+
+def main():
+    """Run the configuration defined by the command line args.
+
+    Run the configuration defined by the command line args or if none were
+    provided read the configuration functions  from the charms tests.yaml
+    config file
+    """
+    args = parse_args(sys.argv[1:])
+    cli_utils.setup_logging(log_level=args.loglevel.upper())
+    funcs = args.configfuncs or utils.get_charm_config()['before_deploy']
+    before_deploy(args.model_name, funcs)
+    run_report.output_event_report()
+    asyncio.get_event_loop().close()

--- a/zaza/charm_lifecycle/before_deploy.py
+++ b/zaza/charm_lifecycle/before_deploy.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Canonical Ltd.
+# Copyright 2020 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -33,9 +33,9 @@ def run_before_deploy_list(functions):
     :type tests: ['zaza.charms_tests.svc.setup', ...]
     """
     for func in functions:
-        run_report.register_event_start('BBefore Deploy {}'.format(func))
+        run_report.register_event_start('Before Deploy {}'.format(func))
         utils.get_class(func)()
-        run_report.register_event_finish('BBefore Deploy {}'.format(func))
+        run_report.register_event_finish('Before Deploy {}'.format(func))
 
 
 def before_deploy(model_name, functions):

--- a/zaza/charm_lifecycle/func_test_runner.py
+++ b/zaza/charm_lifecycle/func_test_runner.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Canonical Ltd.
+# Copyright 2020 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/zaza/charm_lifecycle/func_test_runner.py
+++ b/zaza/charm_lifecycle/func_test_runner.py
@@ -19,6 +19,7 @@ import logging
 import os
 import sys
 
+import zaza.charm_lifecycle.before_deploy as before_deploy
 import zaza.charm_lifecycle.configure as configure
 import zaza.charm_lifecycle.destroy as destroy
 import zaza.charm_lifecycle.utils as utils
@@ -42,6 +43,7 @@ def run_env_deployment(env_deployment, keep_model=False, force=False):
     """
     config_steps = utils.get_config_steps()
     test_steps = utils.get_test_steps()
+    before_deploy_steps = utils.get_before_deploy_steps()
 
     model_aliases = {model_deploy.model_alias: model_deploy.model_name
                      for model_deploy in env_deployment.model_deploys}
@@ -52,6 +54,13 @@ def run_env_deployment(env_deployment, keep_model=False, force=False):
 
     force = force or utils.is_config_deploy_forced_for_bundle(
         deployment.bundle)
+
+    for deployment in env_deployment.model_deploys:
+        # Before deploy
+        before_deploy.before_deploy(
+            deployment.model_name,
+            before_deploy_steps.get(deployment.model_alias, [])
+        )
 
     for deployment in env_deployment.model_deploys:
         deploy.deploy(

--- a/zaza/charm_lifecycle/utils.py
+++ b/zaza/charm_lifecycle/utils.py
@@ -288,6 +288,34 @@ def get_test_steps():
     return _concat_model_alias_maps(get_charm_config().get('tests', []))
 
 
+def get_before_deploy_steps():
+    """Get pre-deploy steps and their associated model aliases.
+
+    Get a map of configuration steps to model aliases. If there are
+    configuration steps which are not mapped to a model alias then these are
+    associated with the the DEFAULT_MODEL_ALIAS.
+
+    eg if test.yaml contained:
+
+        before_deploy:
+        - conf.class1
+        - conf.class2
+        - model_alias1:
+          - conf.class3
+
+       then get_before_deploy_steps() would return:
+
+        {
+            'default_alias': ['conf.class1', 'conf.class2'],
+            'model_alias1': ['conf.class3']}
+
+    :returns: A dict mapping config steps to model aliases
+    :rtype: Dict[str, List[str]]
+    """
+    return _concat_model_alias_maps(
+        get_charm_config().get('before_deploy', []))
+
+
 def get_charm_config(yaml_file=None, fatal=True):
     """Read the yaml test config file and return the resulting config.
 


### PR DESCRIPTION
It is necessary to customize the model parameters before
deploying a bundle for some Juju substrates (ex: k8s) so
Zaza should support running additional pre-deploy scripts