### PR TITLE
Use absolute path to charm in default local overlay

### DIFF
--- a/unit_tests/test_zaza_charm_lifecycle_deploy.py
+++ b/unit_tests/test_zaza_charm_lifecycle_deploy.py
@@ -47,11 +47,14 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
 
     def test_get_charm_config_context(self):
         self.patch_object(lc_deploy.utils, 'get_charm_config')
+        self.patch_object(lc_deploy.os.path, 'abspath')
         self.get_charm_config.return_value = {
             'charm_name': 'mycharm'}
+        self.abspath.return_value = '/some/absolute/path'
         self.assertEqual(
             lc_deploy.get_charm_config_context(),
-            {'charm_location': '../../../mycharm', 'charm_name': 'mycharm'})
+            {'charm_location': '/some/absolute/path/../../../mycharm',
+             'charm_name': 'mycharm'})
 
     def test_get_template_overlay_context(self):
         self.patch_object(lc_deploy, 'get_template_context_from_env')

--- a/zaza/charm_lifecycle/deploy.py
+++ b/zaza/charm_lifecycle/deploy.py
@@ -77,10 +77,18 @@ def get_charm_config_context():
     :returns: Context for template rendering
     :rtype: dict
     """
+    # NOTE(fnordahl): Starting with Juju version 2.7, relative charm paths will
+    # be interpreted in relation to the location of the overlay file.  Previous
+    # versions would interpret paths relative to the location of the main
+    # bundle file.  Build an absolute path so we can work with both paradigms.
+    bundle_dir_abspath = os.path.abspath(utils.BUNDLE_DIR)
     test_config = utils.get_charm_config()
     ctxt = {
         'charm_name': test_config['charm_name'],
-        'charm_location': '../../../{}'.format(test_config['charm_name'])}
+        'charm_location': '{}/../../../{}'
+                          .format(bundle_dir_abspath,
+                                  test_config['charm_name']),
+    }
     return ctxt
 
 


### PR DESCRIPTION
Starting with Juju version 2.7, relative charm paths will be
interpreted in relation to the location of the overlay file. [0]

Previous versions would interpret paths relative to the location
of the main bundle file.

Build an absolute path for use in the default local overlay so we
can work with both paradigms.

0: https://github.com/juju/juju/pull/10487