### PR TITLE
Add new deployment_env library

### DIFF
--- a/unit_tests/test_zaza_charm_lifecycle_deploy.py
+++ b/unit_tests/test_zaza_charm_lifecycle_deploy.py
@@ -21,29 +21,20 @@ import unit_tests.utils as ut_utils
 
 class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
 
-    def test_is_valid_env_key(self):
-        self.assertTrue(lc_deploy.is_valid_env_key('OS_VIP04'))
-        self.assertTrue(lc_deploy.is_valid_env_key('FIP_RANGE'))
-        self.assertTrue(lc_deploy.is_valid_env_key('GATEWAY'))
-        self.assertTrue(lc_deploy.is_valid_env_key('NAME_SERVER'))
-        self.assertTrue(lc_deploy.is_valid_env_key('NET_ID'))
-        self.assertTrue(lc_deploy.is_valid_env_key('VIP_RANGE'))
-        self.assertTrue(lc_deploy.is_valid_env_key('AMULET_OS_VIP'))
-        self.assertFalse(lc_deploy.is_valid_env_key('ZAZA_TEMPLATE_VIP00'))
-        self.assertFalse(lc_deploy.is_valid_env_key('PATH'))
-
-    def test_get_template_context_from_env(self):
-        self.patch_object(lc_deploy.os, 'environ')
-        self.environ.items.return_value = [
-            ('AMULET_OS_VIP', '10.10.0.2'),
-            ('OS_VIP04', '10.10.0.2'),
-            ('ZAZA_TEMPLATE_VIP00', '20.3.4.5'),
-            ('PATH', 'aa')]
+    def test_get_template_overlay_context(self):
+        self.patch_object(lc_deploy.deployment_env, 'get_deployment_context')
+        self.patch_object(lc_deploy, 'get_charm_config_context')
+        self.get_deployment_context.return_value = {
+            'OS_VIP04': '10.10.0.2'}
+        self.get_charm_config_context.return_value = {
+            'charm_location': '../../../mycharm',
+            'charm_name': 'mycharm'}
         self.assertEqual(
-            lc_deploy.get_template_context_from_env(),
-            {'OS_VIP04': '10.10.0.2',
-             'AMULET_OS_VIP': '10.10.0.2'}
-        )
+            lc_deploy.get_template_overlay_context(),
+            {
+                'OS_VIP04': '10.10.0.2',
+                'charm_location': '../../../mycharm',
+                'charm_name': 'mycharm'})
 
     def test_get_charm_config_context(self):
         self.patch_object(lc_deploy.utils, 'get_charm_config')
@@ -55,21 +46,6 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
             lc_deploy.get_charm_config_context(),
             {'charm_location': '/some/absolute/path/../../../mycharm',
              'charm_name': 'mycharm'})
-
-    def test_get_template_overlay_context(self):
-        self.patch_object(lc_deploy, 'get_template_context_from_env')
-        self.patch_object(lc_deploy, 'get_charm_config_context')
-        self.get_template_context_from_env.return_value = {
-            'OS_VIP04': '10.10.0.2'}
-        self.get_charm_config_context.return_value = {
-            'charm_location': '../../../mycharm',
-            'charm_name': 'mycharm'}
-        self.assertEqual(
-            lc_deploy.get_template_overlay_context(),
-            {
-                'OS_VIP04': '10.10.0.2',
-                'charm_location': '../../../mycharm',
-                'charm_name': 'mycharm'})
 
     def test_get_overlay_template_dir(self):
         self.assertEqual(

--- a/unit_tests/test_zaza_charm_lifecycle_prepare.py
+++ b/unit_tests/test_zaza_charm_lifecycle_prepare.py
@@ -12,76 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
-import mock
-
 import zaza.charm_lifecycle.prepare as lc_prepare
 import unit_tests.utils as ut_utils
 
 
 class TestCharmLifecyclePrepare(ut_utils.BaseTestCase):
 
-    MODEL_CONFIG_DEFAULTS = lc_prepare.MODEL_DEFAULTS
-
-    def base_parse_option_list_string(self, env, expect):
-        with mock.patch.dict(lc_prepare.os.environ, env):
-            self.assertEqual(lc_prepare.get_model_settings(), expect)
-
-    def test_parse_option_list_string_empty_config(self):
-        self.assertEqual(
-            lc_prepare.parse_option_list_string(option_list=""),
-            {})
-
-    def test_parse_option_list_string_single_value(self):
-        self.assertEqual(
-            lc_prepare.parse_option_list_string(
-                option_list='image-stream=released'),
-            {'image-stream': 'released'})
-
-    def test_parse_option_list_string_multiple_values(self):
-        self.assertEqual(
-            lc_prepare.parse_option_list_string(
-                option_list='image-stream=released;no-proxy=jujucharms.com'),
-            {
-                'image-stream': 'released',
-                'no-proxy': 'jujucharms.com'})
-
-    def test_parse_option_list_string_whitespace(self):
-        self.assertEqual(
-            lc_prepare.parse_option_list_string(
-                option_list=' test-mode= false ; image-stream=  released'),
-            {
-                'test-mode': 'false',
-                'image-stream': 'released'})
-
-    def test_get_model_settings_no_config(self):
-        self.base_parse_option_list_string({}, self.MODEL_CONFIG_DEFAULTS)
-
-    def test_get_model_settings_multiple_values_override(self):
-        expect_config = copy.deepcopy(self.MODEL_CONFIG_DEFAULTS)
-        expect_config.update({'test-mode': 'false'})
-        self.base_parse_option_list_string(
-            {'MODEL_SETTINGS': 'test-mode=false'},
-            expect_config)
-
     def test_prepare(self):
         self.patch_object(lc_prepare.zaza.controller, 'add_model')
-        self.patch_object(lc_prepare, 'get_model_settings')
-        self.patch_object(lc_prepare, 'get_model_constraints')
+        self.patch_object(lc_prepare.deployment_env, 'get_model_settings')
+        self.patch_object(lc_prepare.deployment_env, 'get_model_constraints')
         self.patch_object(lc_prepare.zaza.model, 'set_model_constraints')
-        self.get_model_settings.return_value = lc_prepare.MODEL_DEFAULTS
+        self.get_model_settings.return_value = {'default-series': 'hardy'}
         self.get_model_constraints.return_value = {'image-stream': 'released'}
         lc_prepare.prepare('newmodel')
         self.add_model.assert_called_once_with(
             'newmodel',
             config={
-                'default-series': 'xenial',
-                'image-stream': 'daily',
-                'test-mode': 'true',
-                'transmit-vendor-metrics': 'false',
-                'enable-os-upgrade': 'false',
-                'automatically-retry-hooks': 'false',
-                'use-default-secgroup': 'true'})
+                'default-series': 'hardy'})
         self.set_model_constraints.assert_called_once_with(
             constraints={'image-stream': 'released'},
             model_name='newmodel')

--- a/unit_tests/utilities/test_deployment_env.py
+++ b/unit_tests/utilities/test_deployment_env.py
@@ -1,0 +1,223 @@
+# Copyright 2019 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+import mock
+import yaml
+
+import zaza.utilities.deployment_env as deployment_env
+import unit_tests.utils as ut_utils
+
+
+class TestUtilitiesDeploymentEnv(ut_utils.BaseTestCase):
+
+    MODEL_CONFIG_DEFAULTS = deployment_env.MODEL_DEFAULTS
+    MODEL_DEFAULT_CONSTRAINTS = deployment_env.MODEL_DEFAULT_CONSTRAINTS
+
+    def test_parse_option_list_string_empty_config(self):
+        self.assertEqual(
+            deployment_env.parse_option_list_string(option_list=""),
+            {})
+
+    def test_parse_option_list_string_single_value(self):
+        self.assertEqual(
+            deployment_env.parse_option_list_string(
+                option_list='image-stream=released'),
+            {'image-stream': 'released'})
+
+    def test_parse_option_list_string_multiple_values(self):
+        self.assertEqual(
+            deployment_env.parse_option_list_string(
+                option_list='image-stream=released;no-proxy=jujucharms.com'),
+            {
+                'image-stream': 'released',
+                'no-proxy': 'jujucharms.com'})
+
+    def test_parse_option_list_string_whitespace(self):
+        self.assertEqual(
+            deployment_env.parse_option_list_string(
+                option_list=' test-mode= false ; image-stream=  released'),
+            {
+                'test-mode': 'false',
+                'image-stream': 'released'})
+
+    def base_get_model_settings(self, env, expect):
+        with mock.patch.dict(deployment_env.os.environ, env):
+            self.assertEqual(deployment_env.get_model_settings(), expect)
+
+    def test_get_model_settings_no_config(self):
+        self.base_get_model_settings({}, self.MODEL_CONFIG_DEFAULTS)
+
+    def test_get_model_settings_multiple_values_override(self):
+        expect_config = copy.deepcopy(self.MODEL_CONFIG_DEFAULTS)
+        expect_config.update({'test-mode': 'false'})
+        self.base_get_model_settings(
+            {'MODEL_SETTINGS': 'test-mode=false'},
+            expect_config)
+
+    def test_get_model_settings_file_override(self):
+        expect_config = copy.deepcopy(self.MODEL_CONFIG_DEFAULTS)
+        expect_config.update({'default-series': 'file-setting'})
+        self.patch_object(
+            deployment_env,
+            'get_setup_file_section',
+            return_value={'default-series': 'file-setting'})
+        self.base_get_model_settings({}, expect_config)
+
+    def test_get_model_settings_file_override_env_override(self):
+        # Check that env variables override defaults and file
+        expect_config = copy.deepcopy(self.MODEL_CONFIG_DEFAULTS)
+        expect_config.update({'default-series': 'env-setting'})
+        self.patch_object(
+            deployment_env,
+            'get_setup_file_section',
+            return_value={'default-series': 'file-setting'})
+        self.base_get_model_settings(
+            {'MODEL_SETTINGS': 'default-series=env-setting'},
+            expect_config)
+
+    def base_get_model_constraints(self, env, expect):
+        with mock.patch.dict(deployment_env.os.environ, env):
+            self.assertEqual(deployment_env.get_model_constraints(), expect)
+
+    def test_get_model_constraints_no_config(self):
+        self.base_get_model_constraints({}, self.MODEL_DEFAULT_CONSTRAINTS)
+
+    def test_get_model_constraints_multiple_values_override(self):
+        expect_config = copy.deepcopy(self.MODEL_DEFAULT_CONSTRAINTS)
+        expect_config.update({'mem': 'from-env'})
+        self.base_get_model_constraints(
+            {'MODEL_CONSTRAINTS': 'mem=from-env'},
+            expect_config)
+
+    def test_get_model_constraints_file_override(self):
+        expect_config = copy.deepcopy(self.MODEL_DEFAULT_CONSTRAINTS)
+        expect_config.update({'mem': 'from-file'})
+        self.patch_object(
+            deployment_env,
+            'get_setup_file_section',
+            return_value={'mem': 'from-file'})
+        self.base_get_model_constraints({}, expect_config)
+
+    def test_get_model_constraints_file_override_env_override(self):
+        # Check that env variables override defaults and file
+        expect_config = copy.deepcopy(self.MODEL_DEFAULT_CONSTRAINTS)
+        expect_config.update({'mem': 'from-env'})
+        self.patch_object(
+            deployment_env,
+            'get_setup_file_section',
+            return_value={'mem': 'from-file'})
+        self.base_get_model_constraints(
+            {'MODEL_CONSTRAINTS': 'mem=from-env'},
+            expect_config)
+
+    def test_is_valid_env_key(self):
+        self.assertTrue(deployment_env.is_valid_env_key('OS_VIP04'))
+        self.assertTrue(deployment_env.is_valid_env_key('FIP_RANGE'))
+        self.assertTrue(deployment_env.is_valid_env_key('GATEWAY'))
+        self.assertTrue(deployment_env.is_valid_env_key('NAME_SERVER'))
+        self.assertTrue(deployment_env.is_valid_env_key('NET_ID'))
+        self.assertTrue(deployment_env.is_valid_env_key('VIP_RANGE'))
+        self.assertTrue(deployment_env.is_valid_env_key('AMULET_OS_VIP'))
+        self.assertFalse(
+            deployment_env.is_valid_env_key('ZAZA_TEMPLATE_VIP00'))
+        self.assertFalse(deployment_env.is_valid_env_key('PATH'))
+
+    def test_find_setup_file(self):
+        self.patch_object(
+            deployment_env.os.path,
+            'isfile',
+            return_value=True)
+        with mock.patch.dict(deployment_env.os.environ,
+                             {'HOME': '/home/testuser'}):
+            self.assertEqual(
+                deployment_env.find_setup_file(),
+                '/home/testuser/.zaza.yaml')
+
+    def test_get_setup_file_contents(self):
+        self.patch_object(
+            deployment_env,
+            'find_setup_file',
+            return_value='/home/testuser/.zaza.yaml')
+        self.patch("builtins.open",
+                   new_callable=mock.mock_open(),
+                   name="_open")
+        self.patch_object(deployment_env, 'yaml')
+        _yaml = "testconfig: someconfig"
+        _yaml_dict = {'test_config': 'someconfig'}
+        self.yaml.safe_load.return_value = _yaml_dict
+        _fileobj = mock.MagicMock()
+        _fileobj.__enter__.return_value = _yaml
+        self._open.return_value = _fileobj
+
+        self.assertEqual(
+            deployment_env.get_setup_file_contents(),
+            _yaml_dict)
+        self._open.assert_called_once_with('/home/testuser/.zaza.yaml', "r")
+        self.yaml.safe_load.assert_called_once_with(_yaml)
+
+    def test_get_setup_file_contents_yaml_error(self):
+        self.patch_object(deployment_env, 'logging')
+        self.patch_object(
+            deployment_env,
+            'find_setup_file',
+            return_value='/home/testuser/.zaza.yaml')
+        self.patch("builtins.open",
+                   new_callable=mock.mock_open(),
+                   name="_open")
+        self.patch_object(deployment_env.yaml, 'safe_load')
+        self.safe_load.side_effect = yaml.YAMLError
+
+        _fileobj = mock.MagicMock()
+        _fileobj.__enter__.return_value = ''
+        self._open.return_value = _fileobj
+
+        self.assertEqual(
+            deployment_env.get_setup_file_contents(),
+            {})
+
+    def test_get_setup_file_section(self):
+        self.patch_object(
+            deployment_env,
+            'get_setup_file_contents',
+            return_value={
+                'secrets': {'setting1': 'value1'}})
+        self.assertEqual(
+            deployment_env.get_setup_file_section('secrets'),
+            {'setting1': 'value1'})
+        self.assertEqual(
+            deployment_env.get_setup_file_section('absent-section'),
+            {})
+
+    def test_get_deployment_context(self):
+        self.patch_object(deployment_env.os, 'environ')
+        self.patch_object(
+            deployment_env,
+            'get_setup_file_contents',
+            return_value={'runtime_config': {
+                'OS_SETTING1': 'from-file',
+                'OS_SETTING2': 'from-file'}})
+        self.environ.items.return_value = [
+            ('AMULET_OS_VIP', '10.10.0.2'),
+            ('OS_SETTING2', 'from-env'),
+            ('OS_VIP04', '10.10.0.2'),
+            ('ZAZA_TEMPLATE_VIP00', '20.3.4.5'),
+            ('PATH', 'aa')]
+        self.assertEqual(
+            deployment_env.get_deployment_context(),
+            {'OS_VIP04': '10.10.0.2',
+             'AMULET_OS_VIP': '10.10.0.2',
+             'OS_SETTING1': 'from-file',
+             'OS_SETTING2': 'from-env'}
+        )

--- a/zaza/charm_lifecycle/deploy.py
+++ b/zaza/charm_lifecycle/deploy.py
@@ -25,20 +25,9 @@ import zaza.model
 import zaza.charm_lifecycle.utils as utils
 import zaza.utilities.cli as cli_utils
 import zaza.utilities.run_report as run_report
+import zaza.utilities.deployment_env as deployment_env
 
 DEFAULT_OVERLAY_TEMPLATE_DIR = 'tests/bundles/overlays'
-VALID_ENVIRONMENT_KEY_PREFIXES = [
-    'FIP_RANGE',
-    'GATEWAY',
-    'NAME_SERVER',
-    'NET_ID',
-    'OS_',
-    'VIP_RANGE',
-    'AMULET_',
-    'MOJO_',
-    'JUJU_',
-    'CHARM_',
-]
 LOCAL_OVERLAY_TEMPLATE = """
 applications:
   {{ charm_name }}:
@@ -46,31 +35,6 @@ applications:
 """
 LOCAL_OVERLAY_TEMPLATE_NAME = 'local-charm-overlay.yaml'
 LOCAL_OVERLAY_ENABLED_KEY = 'local_overlay_enabled'
-
-
-def is_valid_env_key(key):
-    """Check if key is a valid environment variable name for use with template.
-
-    :param key: List of configure functions functions
-    :type key: str
-    :returns: Whether key is a valid environment variable name
-    :rtype: bool
-    """
-    valid = False
-    for _k in VALID_ENVIRONMENT_KEY_PREFIXES:
-        if key.startswith(_k):
-            valid = True
-            break
-    return valid
-
-
-def get_template_context_from_env():
-    """Return environment vars from the current env for template rendering.
-
-    :returns: Environment variable key values for use with template rendering
-    :rtype: dict
-    """
-    return {k: v for k, v in os.environ.items() if is_valid_env_key(k)}
 
 
 def get_charm_config_context():
@@ -102,7 +66,7 @@ def get_template_overlay_context():
     """
     context = {}
     contexts = [
-        get_template_context_from_env(),
+        deployment_env.get_deployment_context(),
     ]
     try:
         contexts.append(get_charm_config_context())

--- a/zaza/charm_lifecycle/prepare.py
+++ b/zaza/charm_lifecycle/prepare.py
@@ -14,9 +14,7 @@
 
 """Run prepare phase."""
 import argparse
-import copy
 import logging
-import os
 import sys
 
 import zaza.controller
@@ -25,65 +23,7 @@ import zaza.model
 import zaza.charm_lifecycle.utils as utils
 import zaza.utilities.cli as cli_utils
 import zaza.utilities.run_report as run_report
-
-MODEL_DEFAULTS = {
-    # Model defaults from charm-test-infra
-    #   https://jujucharms.com/docs/2.1/models-config
-    'default-series': 'xenial',
-    'image-stream': 'daily',
-    'test-mode': 'true',
-    'transmit-vendor-metrics': 'false',
-    # https://bugs.launchpad.net/juju/+bug/1685351
-    # enable-os-refresh-update: false
-    'enable-os-upgrade': 'false',
-    'automatically-retry-hooks': 'false',
-    'use-default-secgroup': 'true',
-}
-
-
-def parse_option_list_string(option_list, delimiter=None):
-    """Convert the given string to a dictionary of options.
-
-    Each pair must be of the form 'k=v', the delimiter seperates the
-    pairs from each other not the key from the value.
-
-    :param option_list: A string representation of key value pairs.
-    :type option_list: str
-    :param delimiter: Delimiter to use to seperate each pair.
-    :type delimiter: str
-    :returns: A dictionary of settings.
-    :rtype: Dict
-    """
-    settings = {}
-    if delimiter is None:
-        delimiter = ';'
-    for setting in option_list.split(delimiter):
-        if not setting:
-            continue
-        key, value = setting.split('=')
-        settings[key.strip()] = value.strip()
-    return settings
-
-
-def get_model_settings():
-    """Construct settings for model from defaults and env variables.
-
-    :returns: Settings to use for model
-    :rtype: Dict
-    """
-    model_settings = copy.deepcopy(MODEL_DEFAULTS)
-    model_settings.update(
-        parse_option_list_string(os.environ.get('MODEL_SETTINGS', '')))
-    return model_settings
-
-
-def get_model_constraints():
-    """Construct constraints for model.
-
-    :returns: Constraints to apply to model
-    :rtype: Dict
-    """
-    return parse_option_list_string(os.environ.get('MODEL_CONSTRAINTS', ''))
+import zaza.utilities.deployment_env as deployment_env
 
 
 @run_report.register_event_wrapper('Prepare Environment')
@@ -93,10 +33,12 @@ def prepare(model_name):
     :param model: Name of model to add
     :type bundle: str
     """
-    zaza.controller.add_model(model_name, config=get_model_settings())
+    zaza.controller.add_model(
+        model_name,
+        config=deployment_env.get_model_settings())
     zaza.model.set_model_constraints(
         model_name=model_name,
-        constraints=get_model_constraints())
+        constraints=deployment_env.get_model_constraints())
 
 
 def parse_args(args):

--- a/zaza/utilities/deployment_env.py
+++ b/zaza/utilities/deployment_env.py
@@ -1,0 +1,190 @@
+# Copyright 2019 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Module for working with zaza setup file."""
+
+import copy
+import logging
+import os
+import functools
+import yaml
+
+ZAZA_SETUP_FILE_LOCATIONS = [
+    '{home}/.zaza.yaml']
+
+SECRETS = 'secrets'
+RUNTIME_CONFIG = 'runtime_config'
+
+DEPLOYMENT_CONTEXT_SECTIONS = [
+    SECRETS,
+    RUNTIME_CONFIG]
+
+MODEL_SETTINGS_SECTION = 'model_settings'
+MODEL_CONSTRAINTS_SECTION = 'model_constraints'
+
+VALID_ENVIRONMENT_KEY_PREFIXES = [
+    'FIP_RANGE',
+    'GATEWAY',
+    'NAME_SERVER',
+    'NET_ID',
+    'OS_',
+    'VIP_RANGE',
+    'AMULET_',
+    'MOJO_',
+    'JUJU_',
+    'CHARM_',
+    'MODEL_',
+]
+
+MODEL_DEFAULTS = {
+    # Model defaults from charm-test-infra
+    #   https://jujucharms.com/docs/2.1/models-config
+    'default-series': 'xenial',
+    'image-stream': 'daily',
+    'test-mode': 'true',
+    'transmit-vendor-metrics': 'false',
+    # https://bugs.launchpad.net/juju/+bug/1685351
+    # enable-os-refresh-update: false
+    'enable-os-upgrade': 'false',
+    'automatically-retry-hooks': 'false',
+    'use-default-secgroup': 'true',
+}
+
+MODEL_DEFAULT_CONSTRAINTS = {}
+
+
+def parse_option_list_string(option_list, delimiter=None):
+    """Convert the given string to a dictionary of options.
+
+    Each pair must be of the form 'k=v', the delimiter seperates the
+    pairs from each other not the key from the value.
+
+    :param option_list: A string representation of key value pairs.
+    :type option_list: str
+    :param delimiter: Delimiter to use to seperate each pair.
+    :type delimiter: str
+    :returns: A dictionary of settings.
+    :rtype: Dict
+    """
+    settings = {}
+    if delimiter is None:
+        delimiter = ';'
+    for setting in option_list.split(delimiter):
+        if not setting:
+            continue
+        key, value = setting.split('=')
+        settings[key.strip()] = value.strip()
+    return settings
+
+
+def get_model_settings():
+    """Return model settings from defaults, config file and env variables.
+
+    :returns: Settings to use for model
+    :rtype: Dict
+    """
+    model_settings = copy.deepcopy(MODEL_DEFAULTS)
+    model_settings.update(get_setup_file_section(MODEL_SETTINGS_SECTION))
+    model_settings.update(
+        parse_option_list_string(os.environ.get('MODEL_SETTINGS', '')))
+    return model_settings
+
+
+def get_model_constraints():
+    """Return constraints for model from defaults, config file & env variables.
+
+    :returns: Constraints to apply to model
+    :rtype: Dict
+    """
+    model_constraints = copy.deepcopy(MODEL_DEFAULT_CONSTRAINTS)
+    model_constraints.update(get_setup_file_section(MODEL_CONSTRAINTS_SECTION))
+    model_constraints.update(
+        parse_option_list_string(os.environ.get('MODEL_CONSTRAINTS', '')))
+    return model_constraints
+
+
+def is_valid_env_key(key):
+    """Check if key is a valid environment variable name for use with template.
+
+    :param key: List of configure functions functions
+    :type key: str
+    :returns: Whether key is a valid environment variable name
+    :rtype: bool
+    """
+    valid = False
+    for _k in VALID_ENVIRONMENT_KEY_PREFIXES:
+        if key.startswith(_k):
+            valid = True
+            break
+    return valid
+
+
+def find_setup_file():
+    """Search for zaza config file.
+
+    :returns: Location of zaza config file or None if not found.
+    :rtype: str or None
+    """
+    ctxt = {
+        'home': os.environ.get('HOME')}
+    for setup_file in ZAZA_SETUP_FILE_LOCATIONS:
+        if os.path.isfile(setup_file.format(**ctxt)):
+            return setup_file.format(**ctxt)
+
+
+def get_setup_file_contents():
+    """Return a dictionary of tha zaza config files contents.
+
+    :returns: Return dict of tha zaza config files contents or an empty dict if
+              no file was found.
+    :rtype: dict
+    """
+    setup_file = find_setup_file()
+    setup_file_data = {}
+    if setup_file:
+        with open(setup_file, 'r') as stream:
+            try:
+                _file_data = yaml.safe_load(stream)
+                if _file_data:
+                    setup_file_data.update(_file_data)
+            except yaml.YAMLError:
+                logging.warn("Unable to load data from {}".format(setup_file))
+    return setup_file_data
+
+
+def get_setup_file_section(section_name):
+    """Return the contents of a section from the zaza config file."""
+    return get_setup_file_contents().get(section_name, {})
+
+
+get_secrets = functools.partial(get_setup_file_section, section_name=SECRETS)
+
+
+def get_deployment_context():
+    """Return the context used for rendering deployment config and bundles.
+
+    Extract key value pairs from zaza config file and environment. Environment
+    variables take presedent over config file values.
+
+    :returns: Context constructed from zaza config file and environment
+              variables.
+    :rtype: dict
+    """
+    runtime_config = {}
+    conf_file_ctxt = get_setup_file_contents()
+    for section in DEPLOYMENT_CONTEXT_SECTIONS:
+        runtime_config.update(conf_file_ctxt.get(section, {}))
+    for k, v in os.environ.items():
+        if is_valid_env_key(k):
+            runtime_config[k] = v
+    return runtime_config


### PR DESCRIPTION
Centralise getting data from the deployment environment into a new
library deployment_env. This centralises loading data from a
zaza config file and from environment variables.

Ultimately all calls to config files and environment variables
should go through this library.