### PR TITLE
Make initial deployment timeout configurable

### DIFF
--- a/doc/source/runningcharmtests.rst
+++ b/doc/source/runningcharmtests.rst
@@ -70,6 +70,10 @@ of environment variables as context. Currently these are:
  * NET\_ID
  * OS\_\*
  * VIP\_RANGE
+ * JUJU\_\*
+ * CHARM\_\*
+ * MODEL\_\*
+ * TEST\_\*
 
 The rendered overlay will be used on top of the specified bundle at deploy time.
 

--- a/unit_tests/test_zaza_charm_lifecycle_deploy.py
+++ b/unit_tests/test_zaza_charm_lifecycle_deploy.py
@@ -268,7 +268,7 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
         self.wait_for_application_states.assert_called_once_with(
             'newmodel',
             {},
-            self.TIMEOUT)
+            5400)
         self.get_deployment_context.return_value = {
             'TEST_DEPLOYMENT_TIMEOUT': 42
         }
@@ -288,7 +288,6 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
                     'workload-status': 'blocked',
                     'workload-status-message': 'Vault needs to be inited'}}}
         self.patch_object(lc_deploy, 'deploy_bundle')
-        self.patch_object(lc_deploy.zaza.model, 'TIMEOUT')
         lc_deploy.deploy('bun.yaml', 'newmodel')
         self.deploy_bundle.assert_called_once_with('bun.yaml', 'newmodel')
         self.wait_for_application_states.assert_called_once_with(
@@ -296,7 +295,7 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
             {'vault': {
                 'workload-status': 'blocked',
                 'workload-status-message': 'Vault needs to be inited'}},
-            self.TIMEOUT)
+            5400)
 
     def test_deploy_nowait(self):
         self.patch_object(lc_deploy.zaza.model, 'wait_for_application_states')

--- a/zaza/charm_lifecycle/deploy.py
+++ b/zaza/charm_lifecycle/deploy.py
@@ -268,7 +268,7 @@ def deploy(bundle, model, wait=True):
             model,
             test_config.get('target_deploy_status', {}),
             deployment_context.get('TEST_DEPLOYMENT_TIMEOUT',
-                                   zaza.model.TIMEOUT),
+                                   5400),
         )
         run_report.register_event_finish('Wait for Deployment')
 

--- a/zaza/charm_lifecycle/deploy.py
+++ b/zaza/charm_lifecycle/deploy.py
@@ -261,11 +261,15 @@ def deploy(bundle, model, wait=True):
     if wait:
         run_report.register_event_start('Wait for Deployment')
         test_config = utils.get_charm_config()
+        deployment_context = deployment_env.get_deployment_context()
         logging.info("Waiting for environment to settle")
         zaza.model.set_juju_model(model)
         zaza.model.wait_for_application_states(
             model,
-            test_config.get('target_deploy_status', {}))
+            test_config.get('target_deploy_status', {}),
+            deployment_context.get('TEST_DEPLOYMENT_TIMEOUT',
+                                   zaza.model.TIMEOUT),
+        )
         run_report.register_event_finish('Wait for Deployment')
 
 

--- a/zaza/model.py
+++ b/zaza/model.py
@@ -35,6 +35,7 @@ from juju.model import Model
 from zaza import sync_wrapper
 
 CURRENT_MODEL = None
+TIMEOUT = 2700
 
 
 class ModelTimeout(Exception):
@@ -795,7 +796,7 @@ wait_for_agent_status = sync_wrapper(async_wait_for_agent_status)
 
 
 async def async_wait_for_application_states(model_name=None, states=None,
-                                            timeout=2700):
+                                            timeout=TIMEOUT):
     """Wait for model to achieve the desired state.
 
     Check the workload status and workload status message for every unit of
@@ -881,7 +882,7 @@ async def async_wait_for_application_states(model_name=None, states=None,
 wait_for_application_states = sync_wrapper(async_wait_for_application_states)
 
 
-async def async_block_until_all_units_idle(model_name=None, timeout=2700):
+async def async_block_until_all_units_idle(model_name=None, timeout=TIMEOUT):
     """Block until all units in the given model are idle.
 
     An example accessing this function via its sync wrapper::
@@ -906,7 +907,7 @@ block_until_all_units_idle = sync_wrapper(async_block_until_all_units_idle)
 
 
 async def async_block_until_service_status(unit_name, services, target_status,
-                                           model_name=None, timeout=2700,
+                                           model_name=None, timeout=TIMEOUT,
                                            pgrep_full=False):
     """Block until all services on the unit are in the desired state.
 
@@ -1024,7 +1025,7 @@ async def async_block_until(*conditions, timeout=None, wait_period=0.5,
 
 async def async_block_until_file_ready(application_name, remote_file,
                                        check_function, model_name=None,
-                                       timeout=2700):
+                                       timeout=TIMEOUT):
     """Block until the check_function passes against.
 
     Block until the check_function passes against the provided file. It is
@@ -1066,7 +1067,8 @@ async def async_block_until_file_ready(application_name, remote_file,
 
 async def async_block_until_file_has_contents(application_name, remote_file,
                                               expected_contents,
-                                              model_name=None, timeout=2700):
+                                              model_name=None,
+                                              timeout=TIMEOUT):
     """Block until the expected_contents are present on all units.
 
     Block until the given string (expected_contents) is present in the file
@@ -1109,7 +1111,7 @@ async def async_block_until_oslo_config_entries_match(application_name,
                                                       remote_file,
                                                       expected_contents,
                                                       model_name=None,
-                                                      timeout=2700):
+                                                      timeout=TIMEOUT):
     """Block until dict is represented in the file using oslo.config parser.
 
     Block until the expected_contents are in the given file on all units of
@@ -1177,7 +1179,8 @@ block_until_oslo_config_entries_match = sync_wrapper(
 
 async def async_block_until_services_restarted(application_name, mtime,
                                                services, model_name=None,
-                                               timeout=2700, pgrep_full=False):
+                                               timeout=TIMEOUT,
+                                               pgrep_full=False):
     """Block until the given services have a start time later then mtime.
 
     For example to check that the glance-api service has been restarted::
@@ -1227,7 +1230,8 @@ block_until_services_restarted = sync_wrapper(
 
 
 async def async_block_until_unit_wl_status(unit_name, status, model_name=None,
-                                           negate_match=False, timeout=2700):
+                                           negate_match=False,
+                                           timeout=TIMEOUT):
     """Block until the given unit has the desired workload status.
 
     A units workload status may change during a given action. This function

--- a/zaza/utilities/deployment_env.py
+++ b/zaza/utilities/deployment_env.py
@@ -44,6 +44,7 @@ VALID_ENVIRONMENT_KEY_PREFIXES = [
     'JUJU_',
     'CHARM_',
     'MODEL_',
+    'TEST_',
 ]
 
 MODEL_DEFAULTS = {


### PR DESCRIPTION
The environment tests are run in may influnence the execution time
for the initial deployment.  Allow the timeout to be configured
through deployment environment settings.