### PR TITLE
Add timeout for juju controllers refresh

### DIFF
--- a/zaza/controller.py
+++ b/zaza/controller.py
@@ -33,7 +33,13 @@ async def async_add_model(model_name, config=None):
     """
     # Tactical fix until https://github.com/juju/python-libjuju/issues/333
     # is resolved
-    subprocess.check_call(['juju', 'list-controllers', '--refresh'])
+
+    # if you have a dead controller, this cmd will wait forever.
+    # add timeout to avoid waiting.
+    # use `juju unregister` to remove your dead controller and try again
+    # related bug: https://bugs.launchpad.net/juju-core/+bug/1593506
+    subprocess.check_call(['juju', 'list-controllers', '--refresh'],
+                          timeout=60)
     model_cmd = ['juju', 'add-model', '--no-switch']
     if config:
         with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml') as fp:


### PR DESCRIPTION
If you have a dead controller, which is already deleted but still has a
local record in juju, it will cause a few problems without hints:

1. juju destroy-model will freeze forever
2. juju kill-model will fail with unuseful message
3. juju controllers --refresh will freeze forever

The only way to fix so far is `juju unregister`.

A related bug has been reported:

    https://bugs.launchpad.net/juju-core/+bug/1593506

`functest-prepare` will also freeze forever because of 3, without any
message. To avoid wasting time on waiting, add timeout and help message
for people to find the problem earlier.

Signed-off-by: Joe Guo <guoqiao@gmail.com>