### PR TITLE
Use UTC when calculating certificate validity

### DIFF
--- a/zaza/utilities/cert.py
+++ b/zaza/utilities/cert.py
@@ -94,10 +94,10 @@ def generate_cert(common_name,
             cryptography.x509.oid.NameOID.COMMON_NAME, issuer_name),
     ]))
     builder = builder.not_valid_before(
-        datetime.datetime.today() - datetime.timedelta(0, 1, 0),
+        datetime.datetime.utcnow() - datetime.timedelta(0, 1, 0),
     )
     builder = builder.not_valid_after(
-        datetime.datetime.today() + datetime.timedelta(30, 0, 0),
+        datetime.datetime.utcnow() + datetime.timedelta(30, 0, 0),
     )
     builder = builder.serial_number(cryptography.x509.random_serial_number())
     builder = builder.public_key(public_key)


### PR DESCRIPTION
The current usage of ``datetime.today()`` is at the grace of the
locale settings of the test executor and the instances spun up.

The ``cryptography.x509.CertificateBuilder`` ``not_valud_before``
and ``not_valid_after`` attributes do expect [0] a UTC datetime.

0: https://cryptography.io/en/latest/x509/reference/#cryptography.x509.CertificateBuilder