### PR TITLE
Add cmr support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ aiounittest
 async_generator
 juju
 juju_wait
-PyYAML<=4.2,>=3.0 
+PyYAML>=3.0 
 flake8>=2.2.4,<=3.5.0
 flake8-docstrings
 flake8-per-file-ignores

--- a/unit_tests/test_zaza_charm_lifecycle_deploy.py
+++ b/unit_tests/test_zaza_charm_lifecycle_deploy.py
@@ -87,7 +87,8 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
         self.assertIsNone(lc_deploy.get_template('mybundle.yaml'))
 
     def test_render_template(self):
-        self.patch_object(lc_deploy, 'get_template_overlay_context')
+        self.patch_object(lc_deploy, 'get_template_overlay_context',
+                          return_value={})
         template_mock = mock.MagicMock()
         template_mock.render.return_value = 'Template contents'
         m = mock.mock_open()
@@ -105,7 +106,8 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
         lc_deploy.render_overlay('my_overlay.yaml', '/tmp/special-dir')
         self.render_template.assert_called_once_with(
             template_mock,
-            '/tmp/special-dir/my_overlay.yaml')
+            '/tmp/special-dir/my_overlay.yaml',
+            model_ctxt=None)
 
     def test_template_missing_required_variables(self):
         self.patch_object(lc_deploy, 'get_template_overlay_context')
@@ -142,7 +144,8 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
         self.assertFalse(self.Environment.called)
         self.render_template.assert_called_once_with(
             'atemplate',
-            '/target/local-charm-overlay.yaml')
+            '/target/local-charm-overlay.yaml',
+            model_ctxt=None)
 
     def test_render_local_overlay_default(self):
         jenv_mock = mock.MagicMock()
@@ -160,7 +163,8 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
         jenv_mock.from_string.assert_called_once_with(mock.ANY)
         self.render_template.assert_called_once_with(
             'atemplate',
-            '/target/local-charm-overlay.yaml')
+            '/target/local-charm-overlay.yaml',
+            model_ctxt=None)
 
     def yaml_read_patch(self, yaml, yaml_dict):
         self.patch("builtins.open",
@@ -211,7 +215,7 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
         self.patch_object(lc_deploy, 'render_local_overlay')
         self.render_local_overlay.return_value = '/tmp/local-overlay.yaml'
         self.patch_object(lc_deploy, 'render_overlay')
-        self.render_overlay.side_effect = lambda x, y: RESP[x]
+        self.render_overlay.side_effect = lambda x, y, model_ctxt: RESP[x]
         self.assertEqual(
             lc_deploy.render_overlays('mybundles/mybundle.yaml', '/tmp'),
             ['/tmp/local-overlay.yaml', '/tmp/mybundle.yaml'])
@@ -225,7 +229,7 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
         self.patch_object(lc_deploy, 'render_overlay')
         self.patch_object(lc_deploy, 'render_local_overlay')
         self.render_local_overlay.return_value = '/tmp/local.yaml'
-        self.render_overlay.side_effect = lambda x, y: RESP[x]
+        self.render_overlay.side_effect = lambda x, y, model_ctxt: RESP[x]
         self.assertEqual(
             lc_deploy.render_overlays('mybundles/mybundle.yaml', '/tmp'),
             ['/tmp/local.yaml'])
@@ -240,7 +244,7 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
         self.patch_object(lc_deploy, 'render_local_overlay')
         self.render_local_overlay.return_value = '/tmp/local-overlay.yaml'
         self.patch_object(lc_deploy, 'render_overlay')
-        self.render_overlay.side_effect = lambda x, y: RESP[x]
+        self.render_overlay.side_effect = lambda x, y, model_ctxt: RESP[x]
         self.assertEqual(
             lc_deploy.render_overlays('mybundles/mybundle.yaml', '/tmp'),
             ['/tmp/mybundle.yaml'])
@@ -261,7 +265,8 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
         self.get_charm_config.return_value = {}
         self.patch_object(lc_deploy, 'deploy_bundle')
         lc_deploy.deploy('bun.yaml', 'newmodel')
-        self.deploy_bundle.assert_called_once_with('bun.yaml', 'newmodel')
+        self.deploy_bundle.assert_called_once_with('bun.yaml', 'newmodel',
+                                                   model_ctxt=None)
         self.wait_for_application_states.assert_called_once_with(
             'newmodel',
             {})
@@ -276,7 +281,8 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
                     'workload-status-message': 'Vault needs to be inited'}}}
         self.patch_object(lc_deploy, 'deploy_bundle')
         lc_deploy.deploy('bun.yaml', 'newmodel')
-        self.deploy_bundle.assert_called_once_with('bun.yaml', 'newmodel')
+        self.deploy_bundle.assert_called_once_with('bun.yaml', 'newmodel',
+                                                   model_ctxt=None)
         self.wait_for_application_states.assert_called_once_with(
             'newmodel',
             {'vault': {
@@ -287,7 +293,8 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
         self.patch_object(lc_deploy.zaza.model, 'wait_for_application_states')
         self.patch_object(lc_deploy, 'deploy_bundle')
         lc_deploy.deploy('bun.yaml', 'newmodel', wait=False)
-        self.deploy_bundle.assert_called_once_with('bun.yaml', 'newmodel')
+        self.deploy_bundle.assert_called_once_with('bun.yaml', 'newmodel',
+                                                   model_ctxt=None)
         self.assertFalse(self.wait_for_application_states.called)
 
     def test_parser(self):

--- a/unit_tests/test_zaza_charm_lifecycle_func_test_runner.py
+++ b/unit_tests/test_zaza_charm_lifecycle_func_test_runner.py
@@ -64,8 +64,10 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
             mock.call('newmodel'),
             mock.call('newmodel')]
         deploy_calls = [
-            mock.call('./tests/bundles/bundle1.yaml', 'newmodel'),
-            mock.call('./tests/bundles/bundle2.yaml', 'newmodel')]
+            mock.call('./tests/bundles/bundle1.yaml', 'newmodel',
+                      model_ctxt={'default_alias': 'newmodel'}),
+            mock.call('./tests/bundles/bundle2.yaml', 'newmodel',
+                      model_ctxt={'default_alias': 'newmodel'})]
         configure_calls = [
             mock.call('newmodel', [
                 'zaza.charm_tests.mycharm.setup.basic_setup'
@@ -129,10 +131,18 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
             mock.call('m3'),
             mock.call('m4')]
         deploy_calls = [
-            mock.call('./tests/bundles/bundle1.yaml', 'm1'),
-            mock.call('./tests/bundles/bundle2.yaml', 'm2'),
-            mock.call('./tests/bundles/bundle5.yaml', 'm3'),
-            mock.call('./tests/bundles/bundle6.yaml', 'm4')]
+            mock.call('./tests/bundles/bundle1.yaml', 'm1',
+                      model_ctxt={'default_alias': 'm1'}),
+            mock.call('./tests/bundles/bundle2.yaml', 'm2',
+                      model_ctxt={'default_alias': 'm2'}),
+            mock.call(
+                './tests/bundles/bundle5.yaml',
+                'm3',
+                model_ctxt={'model_alias_5': 'm3', 'model_alias_6': 'm4'}),
+            mock.call(
+                './tests/bundles/bundle6.yaml',
+                'm4',
+                model_ctxt={'model_alias_5': 'm3', 'model_alias_6': 'm4'})]
         configure_calls = [
             mock.call('m1', [
                 'zaza.charm_tests.mycharm.setup.basic_setup',
@@ -190,7 +200,8 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
                 'zaza.charm_tests.mycharm.tests.ComplexTest']}
         lc_func_test_runner.func_test_runner(smoke=True)
         deploy_calls = [
-            mock.call('./tests/bundles/bundle2.yaml', 'newmodel')]
+            mock.call('./tests/bundles/bundle2.yaml', 'newmodel',
+                      model_ctxt={'default_alias': 'newmodel'})]
         self.deploy.assert_has_calls(deploy_calls)
 
     def test_func_test_runner_dev(self):
@@ -215,8 +226,10 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
                 'zaza.charm_tests.mycharm.tests.ComplexTest']}
         lc_func_test_runner.func_test_runner(dev=True)
         deploy_calls = [
-            mock.call('./tests/bundles/bundle3.yaml', 'newmodel'),
-            mock.call('./tests/bundles/bundle4.yaml', 'newmodel')]
+            mock.call('./tests/bundles/bundle3.yaml', 'newmodel',
+                      model_ctxt={'default_alias': 'newmodel'}),
+            mock.call('./tests/bundles/bundle4.yaml', 'newmodel',
+                      model_ctxt={'default_alias': 'newmodel'})]
         self.deploy.assert_has_calls(deploy_calls)
 
     def test_func_test_runner_specify_bundle(self):
@@ -241,7 +254,10 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
                 'zaza.charm_tests.mycharm.tests.ComplexTest']}
         lc_func_test_runner.func_test_runner(bundle='maveric-filebeat')
         deploy_calls = [
-            mock.call('./tests/bundles/maveric-filebeat.yaml', 'newmodel')]
+            mock.call(
+                './tests/bundles/maveric-filebeat.yaml',
+                'newmodel',
+                model_ctxt={'default_alias': 'newmodel'})]
         self.deploy.assert_has_calls(deploy_calls)
 
     def test_main_smoke_dev_ambiguous(self):

--- a/unit_tests/test_zaza_charm_lifecycle_utils.py
+++ b/unit_tests/test_zaza_charm_lifecycle_utils.py
@@ -66,11 +66,11 @@ class TestCharmLifecycleUtils(ut_utils.BaseTestCase):
                 'model_alias1': ['test3'],
                 'model_alias2': ['test4']})
 
-    def test_get_test_bundles(self):
+    def test_get_test_bundle_mappings(self):
         self.patch_object(lc_utils, "get_charm_config")
         self.get_charm_config.return_value = {
             'gate_bundles': ['bundle1']}
-        self.assertEqual(lc_utils.get_test_bundles(
+        self.assertEqual(lc_utils.get_test_bundle_mappings(
             'gate_bundles'),
             [{'default_alias': 'bundle1'}])
         self.get_charm_config.return_value = {
@@ -80,7 +80,7 @@ class TestCharmLifecycleUtils(ut_utils.BaseTestCase):
                 {
                     'model_alias1': 'bundle_3',
                     'model_alias2': 'bundle_4'}]}
-        self.assertEqual(lc_utils.get_test_bundles(
+        self.assertEqual(lc_utils.get_test_bundle_mappings(
             'gate_bundles'),
             [
                 {'default_alias': 'bundle1'},

--- a/zaza/charm_lifecycle/deploy.py
+++ b/zaza/charm_lifecycle/deploy.py
@@ -135,6 +135,9 @@ def render_template(template, target_file, model_ctxt=None):
     :type template: jinja2.Template
     :param target_file: File name for rendered template
     :type target_file: str
+    :param model_ctxt: Additional context to be used when rendering bundle
+                       templates.
+    :type model_ctxt: {}
     """
     model_ctxt = model_ctxt or {}
     try:
@@ -158,6 +161,9 @@ def render_overlay(overlay_name, target_dir, model_ctxt=None):
     :type overlay_name: str
     :param target_dir: Directory to render overlay in
     :type overlay_name: str
+    :param model_ctxt: Additional context to be used when rendering bundle
+                       templates.
+    :type model_ctxt: {}
     :returns: Path to rendered overlay
     :rtype: str
     """
@@ -176,6 +182,9 @@ def render_local_overlay(target_dir, model_ctxt=None):
 
     :param target_dir: Directory to render overlay in
     :type overlay_name: str
+    :param model_ctxt: Additional context to be used when rendering bundle
+                       templates.
+    :type model_ctxt: {}
     :returns: Path to rendered overlay
     :rtype: str
     """
@@ -218,6 +227,9 @@ def render_overlays(bundle, target_dir, model_ctxt=None):
     :type bundle: str
     :param target_dir: Directory to render overlay in
     :type overlay_name: str
+    :param model_ctxt: Additional context to be used when rendering bundle
+                       templates.
+    :type model_ctxt: {}
     :returns: List of rendered overlays
     :rtype: [str, str,...]
     """
@@ -240,6 +252,9 @@ def deploy_bundle(bundle, model, model_ctxt=None):
     :type bundle: str
     :param model: Name of model to deploy bundle in
     :type model: str
+    :param model_ctxt: Additional context to be used when rendering bundle
+                       templates.
+    :type model_ctxt: {}
     """
     logging.info("Deploying bundle '{}' on to '{}' model"
                  .format(bundle, model))
@@ -261,7 +276,10 @@ def deploy(bundle, model, wait=True, model_ctxt=None):
     :param model: Name of model to deploy bundle in
     :type model: str
     :param wait: Whether to wait until deployment completes
-    :type model: bool
+    :type wait: bool
+    :param model_ctxt: Additional context to be used when rendering bundle
+                       templates.
+    :type model_ctxt: {}
     """
     run_report.register_event_start('Deploy Bundle')
     deploy_bundle(bundle, model, model_ctxt=model_ctxt)

--- a/zaza/charm_lifecycle/deploy.py
+++ b/zaza/charm_lifecycle/deploy.py
@@ -128,7 +128,7 @@ def get_template(target_file):
     return template
 
 
-def render_template(template, target_file):
+def render_template(template, target_file, model_ctxt=None):
     """Render the template to the file supplied.
 
     :param template: Template to be rendered
@@ -136,10 +136,13 @@ def render_template(template, target_file):
     :param target_file: File name for rendered template
     :type target_file: str
     """
+    model_ctxt = model_ctxt or {}
     try:
+        overlay_ctxt = get_template_overlay_context()
+        overlay_ctxt.update(model_ctxt)
         with open(target_file, "w") as fh:
             fh.write(
-                template.render(get_template_overlay_context()))
+                template.render(overlay_ctxt))
     except jinja2.exceptions.UndefinedError as e:
         logging.error("Template error. You may be missing"
                       " a mandatory environment variable : {}".format(e))
@@ -148,7 +151,7 @@ def render_template(template, target_file):
                                                               target_file))
 
 
-def render_overlay(overlay_name, target_dir):
+def render_overlay(overlay_name, target_dir, model_ctxt=None):
     """Render the overlay template in the directory supplied.
 
     :param overlay_name: Name of overlay to be rendered
@@ -164,11 +167,11 @@ def render_overlay(overlay_name, target_dir):
     rendered_template_file = os.path.join(
         target_dir,
         os.path.basename(overlay_name))
-    render_template(template, rendered_template_file)
+    render_template(template, rendered_template_file, model_ctxt=model_ctxt)
     return rendered_template_file
 
 
-def render_local_overlay(target_dir):
+def render_local_overlay(target_dir, model_ctxt=None):
     """Render the local overlay template in the directory supplied.
 
     :param target_dir: Directory to render overlay in
@@ -184,7 +187,10 @@ def render_local_overlay(target_dir):
         target_dir,
         os.path.basename(LOCAL_OVERLAY_TEMPLATE_NAME))
     if utils.get_charm_config().get('charm_name', None):
-        render_template(template, rendered_template_file)
+        render_template(
+            template,
+            rendered_template_file,
+            model_ctxt=model_ctxt)
         return rendered_template_file
 
 
@@ -205,7 +211,7 @@ def is_local_overlay_enabled(bundle):
         return yaml.safe_load(stream).get(LOCAL_OVERLAY_ENABLED_KEY, True)
 
 
-def render_overlays(bundle, target_dir):
+def render_overlays(bundle, target_dir, model_ctxt=None):
     """Render the overlays for the given bundle in the directory provided.
 
     :param bundle: Name of bundle being deployed
@@ -217,16 +223,17 @@ def render_overlays(bundle, target_dir):
     """
     overlays = []
     if is_local_overlay_enabled(bundle):
-        local_overlay = render_local_overlay(target_dir)
+        local_overlay = render_local_overlay(target_dir, model_ctxt=model_ctxt)
         if local_overlay:
             overlays.append(local_overlay)
-    rendered_bundle_overlay = render_overlay(bundle, target_dir)
+    rendered_bundle_overlay = render_overlay(bundle, target_dir,
+                                             model_ctxt=model_ctxt)
     if rendered_bundle_overlay:
         overlays.append(rendered_bundle_overlay)
     return overlays
 
 
-def deploy_bundle(bundle, model):
+def deploy_bundle(bundle, model, model_ctxt=None):
     """Deploy the given bundle file in the specified model.
 
     :param bundle: Path to bundle file
@@ -238,14 +245,15 @@ def deploy_bundle(bundle, model):
                  .format(bundle, model))
     cmd = ['juju', 'deploy', '-m', model, bundle]
     with tempfile.TemporaryDirectory() as tmpdirname:
-        for overlay in render_overlays(bundle, tmpdirname):
+        for overlay in render_overlays(bundle, tmpdirname,
+                                       model_ctxt=model_ctxt):
             logging.info("Deploying overlay '{}' on to '{}' model"
                          .format(overlay, model))
             cmd.extend(['--overlay', overlay])
         utils.check_output_logging(cmd)
 
 
-def deploy(bundle, model, wait=True):
+def deploy(bundle, model, wait=True, model_ctxt=None):
     """Run all steps to complete deployment.
 
     :param bundle: Path to bundle file
@@ -256,7 +264,7 @@ def deploy(bundle, model, wait=True):
     :type model: bool
     """
     run_report.register_event_start('Deploy Bundle')
-    deploy_bundle(bundle, model)
+    deploy_bundle(bundle, model, model_ctxt=model_ctxt)
     run_report.register_event_finish('Deploy Bundle')
     if wait:
         run_report.register_event_start('Wait for Deployment')

--- a/zaza/charm_lifecycle/func_test_runner.py
+++ b/zaza/charm_lifecycle/func_test_runner.py
@@ -28,7 +28,7 @@ import zaza.utilities.cli as cli_utils
 import zaza.utilities.run_report as run_report
 
 
-def run_env_deployments(env_deployment, keep_model=False):
+def run_env_deployment(env_deployment, keep_model=False):
     """Run the environment deployment.
 
     :param env_deployment: Environment Deploy to execute.
@@ -104,7 +104,7 @@ def func_test_runner(keep_model=False, smoke=False, dev=False, bundle=None):
         preserve_model = False
         if keep_model and last_test == env_deployment.name:
             preserve_model = True
-        run_env_deployments(env_deployment, keep_model=preserve_model)
+        run_env_deployment(env_deployment, keep_model=preserve_model)
 
 
 def parse_args(args):

--- a/zaza/charm_lifecycle/func_test_runner.py
+++ b/zaza/charm_lifecycle/func_test_runner.py
@@ -28,6 +28,49 @@ import zaza.utilities.cli as cli_utils
 import zaza.utilities.run_report as run_report
 
 
+def run_env_deployments(env_deployment, keep_model=False):
+    """Run the environment deployment.
+
+    :param env_deployment: Environment Deploy to execute.
+    :type env_deployment: utils.EnvironmentDeploy
+    :param keep_model: Whether to destroy models at end of run
+    :type keep_model: boolean
+    """
+    config_steps = utils.get_config_steps()
+    test_steps = utils.get_test_steps()
+
+    model_aliases = {model_deploy.model_alias: model_deploy.model_name
+                     for model_deploy in env_deployment.model_deploys}
+
+    for deployment in env_deployment.model_deploys:
+        prepare.prepare(deployment.model_name)
+
+    for deployment in env_deployment.model_deploys:
+        deploy.deploy(
+            os.path.join(
+                utils.BUNDLE_DIR, '{}.yaml'.format(deployment.bundle)),
+            deployment.model_name,
+            model_ctxt=model_aliases)
+
+    for deployment in env_deployment.model_deploys:
+        configure.configure(
+            deployment.model_name,
+            config_steps.get(deployment.model_alias, []))
+
+    for deployment in env_deployment.model_deploys:
+        test.test(
+            deployment.model_name,
+            test_steps.get(deployment.model_alias, []))
+
+    # Destroy
+    # Keep the model from the last run if keep_model is true, this is to
+    # maintian compat with osci and should change when the zaza collect
+    # functions take over from osci for artifact collection.
+    if not keep_model:
+        for model_name in model_aliases.values():
+            destroy.destroy(model_name)
+
+
 def func_test_runner(keep_model=False, smoke=False, dev=False, bundle=None):
     """Deploy the bundles and run the tests as defined by the charms tests.yaml.
 
@@ -39,7 +82,14 @@ def func_test_runner(keep_model=False, smoke=False, dev=False, bundle=None):
     :type dev: boolean
     """
     if bundle:
-        bundles = [{utils.DEFAULT_MODEL_ALIAS: bundle}]
+        environment_deploys = [
+            utils.EnvironmentDeploy(
+                'default',
+                [utils.ModelDeploy(
+                    utils.DEFAULT_MODEL_ALIAS,
+                    utils.generate_model_name(),
+                    bundle)],
+                True)]
     else:
         if smoke:
             bundle_key = 'smoke_bundles'
@@ -47,42 +97,14 @@ def func_test_runner(keep_model=False, smoke=False, dev=False, bundle=None):
             bundle_key = 'dev_bundles'
         else:
             bundle_key = 'gate_bundles'
-        bundles = utils.get_test_bundles(bundle_key)
-    last_test = bundles[-1]
-    config_steps = utils.get_config_steps()
-    test_steps = utils.get_test_steps()
-    for bundle in bundles:
-        model_aliases = {}
-        for model_alias in sorted(bundle.keys()):
-            model_name = utils.generate_model_name()
-            # Prepare
-            prepare.prepare(model_name)
-            model_aliases[model_alias] = model_name
-        for model_alias, model_name in model_aliases.items():
-            # TODO Deploys should run in parallel
-            # Deploy
-            deploy.deploy(
-                os.path.join(
-                    utils.BUNDLE_DIR, '{}.yaml'.format(bundle[model_alias])),
-                model_aliases[model_alias])
-        for model_alias, model_name in model_aliases.items():
-            configure.configure(
-                model_name,
-                config_steps.get(model_alias, []))
-        # Test
-        for model_alias, model_name in model_aliases.items():
-            test.test(
-                model_name,
-                test_steps.get(model_alias, []))
-        # Destroy
-        # Keep the model from the last run if keep_model is true, this is to
-        # maintian compat with osci and should change when the zaza collect
-        # functions take over from osci for artifact collection.
-        if keep_model and bundle == last_test:
-            pass
-        else:
-            for model_name in model_aliases.values():
-                destroy.destroy(model_name)
+        environment_deploys = utils.get_environment_deploys(bundle_key)
+    last_test = environment_deploys[-1].name
+
+    for env_deployment in environment_deploys:
+        preserve_model = False
+        if keep_model and last_test == env_deployment.name:
+            preserve_model = True
+        run_env_deployments(env_deployment, keep_model=preserve_model)
 
 
 def parse_args(args):

--- a/zaza/charm_lifecycle/utils.py
+++ b/zaza/charm_lifecycle/utils.py
@@ -176,7 +176,7 @@ def get_environment_deploy_multi_unordered(deployment_directive):
 
 
 def get_environment_deploys(bundle_key, deployment_name=None):
-    """Describe environment deploys for a given set ug bundles.
+    """Describe environment deploys for a given set of bundles.
 
     Get a list of test bundles with their model alias. If no model alias is
     supplied then DEFAULT_MODEL_ALIAS is used.


### PR DESCRIPTION
Adding support for cross-model relations has involved these following changes:

1) Pass a model context when rendering the bundle. This context contains the model alias name and the model name eg ```{'vault_model': 'zaza-234wfsf'}```. This context is used to insert the model name into a bundle or overlay which contains a consume stanza:

```
relations:
- - keystone:certificates
  - vault:certificates
saas:
  vault:
    url: admin/{{ vault_model }}.my-offer
```
2) Support for deploying models with model aliases in a particular order. The CMR bundle that consumes an offer needs to be deployed after the bundle making an offer. These same bundles need to also use model aliases to target setup and test steps at the right. These allows a test other to declare multiple bundles in a CMR deployment in their test.yaml with:

```
smoke_bundles:
  - xenial-queens:
    - vault_model: xenial-mysql
    - keystone_model: keystone-queens
```

3) Two new types: ModelDeploy and EnvironmentDeploy. A ModelDeploy is a single bundle being deployed to a single model. An EnvironmentDeploy is comprised of one or more ModelDeploys as multiple models may be needed for a single test (CMR testing for example).

```
ModelDeploy   ModelDeploy         ModelDeploy
     |               |                  |
      ----------------                  |
            |                           |
    EnvironmentDeploy               EnvironmentDeploy
            |                           |
            -----------------------------
                        |
                EnvironmentDeploys
```