### PR TITLE
Quote process name in pidof check

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ aiounittest
 async_generator
 juju
 juju_wait
-PyYAML<=4.2,>=3.0 
+PyYAML>=3.0 
 flake8>=2.2.4,<=3.5.0
 flake8-docstrings
 flake8-per-file-ignores

--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -852,7 +852,7 @@ class TestModel(ut_utils.BaseTestCase):
         self.async_run_on_unit.side_effect = _run_on_unit
         self.assertEqual(
             model.get_unit_service_start_time('app/2', 'mysvc1'), 1524409654)
-        cmd = "stat -c %Y /proc/$(pidof -x mysvc1 | cut -f1 -d ' ')"
+        cmd = 'stat -c %Y /proc/$(pidof -x "mysvc1" | cut -f1 -d \' \')'
         self.async_run_on_unit.assert_called_once_with(
             unit_name='app/2',
             command=cmd,

--- a/zaza/model.py
+++ b/zaza/model.py
@@ -938,7 +938,7 @@ async def async_block_until_service_status(unit_name, services, target_status,
             if pgrep_full:
                 command = 'pgrep -f "{}"'.format(service)
             else:
-                command = "pidof -x {}".format(service)
+                command = 'pidof -x "{}"'.format(service)
             out = await async_run_on_unit(
                 unit_name,
                 command,

--- a/zaza/model.py
+++ b/zaza/model.py
@@ -343,7 +343,7 @@ async def async_get_unit_service_start_time(unit_name, service,
     if pgrep_full:
         pid_cmd = 'pgrep -f "{}"'.format(service)
     else:
-        pid_cmd = "pidof -x {}".format(service)
+        pid_cmd = 'pidof -x "{}"'.format(service)
     cmd = "stat -c %Y /proc/$({} | cut -f1 -d ' ')".format(pid_cmd)
     out = await async_run_on_unit(
         unit_name=unit_name,


### PR DESCRIPTION
As with pgrep ensude the process name is quoted. Otherwise process
names which contain brackets etc break (like aodh).