### PR TITLE
Fix pid checks and make them consistent.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ aiounittest
 async_generator
 juju
 juju_wait
-PyYAML<=4.2,>=3.0 
+PyYAML>=3.0 
 flake8>=2.2.4,<=3.5.0
 flake8-docstrings
 flake8-per-file-ignores

--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -789,7 +789,7 @@ class TestModel(ut_utils.BaseTestCase):
             pgrep_full=True)
         self.async_run_on_unit.assert_called_once_with(
             'app/2',
-            'pgrep -f "test_svc"',
+            "pgrep -f 'test_svc'",
             model_name=None,
             timeout=2700
         )
@@ -852,7 +852,8 @@ class TestModel(ut_utils.BaseTestCase):
         self.async_run_on_unit.side_effect = _run_on_unit
         self.assertEqual(
             model.get_unit_service_start_time('app/2', 'mysvc1'), 1524409654)
-        cmd = "stat -c %Y /proc/$(pidof -x mysvc1 | cut -f1 -d ' ')"
+        cmd = (r"pidof -x 'mysvc1'| tr -d '\n' | "
+               "xargs -d' ' -I {} stat -c %Y /proc/{}  | sort -n | head -1")
         self.async_run_on_unit.assert_called_once_with(
             unit_name='app/2',
             command=cmd,
@@ -875,7 +876,8 @@ class TestModel(ut_utils.BaseTestCase):
                                               'mysvc1',
                                               pgrep_full=True),
             1524409654)
-        cmd = "stat -c %Y /proc/$(pgrep -f \"mysvc1\" | cut -f1 -d ' ')"
+        cmd = "stat -c %Y /proc/$(pgrep -o -f 'mysvc1')"
+
         self.async_run_on_unit.assert_called_once_with(
             unit_name='app/2',
             command=cmd,


### PR DESCRIPTION
The pid checks need to quote the service name to ensure service
with characters such as brackes do not break the tests eg
'aodh-evaluator: AlarmEvaluationService worker(0)'

Also, the pid checks need to be able to handle the situation where a
service has more than one process. Currently the code partially fails
when using pgrep:

```
$ pgrep -f 'apache2'
16120
16126
16130
$ pgrep -f 'apache2' | cut -f1 -d ' '
16120
16126
16130
$ stat -c %Y /proc/$(pgrep -f "apache2" | cut -f1 -d ' ')
1569235446
stat: cannot stat '16126': No such file or directory
stat: cannot stat '16130': No such file or directory
```

When using pidof the first in the list is chosen, which may not be
correct:

```
$ pidof -x 'apache2'
16130 16126 16125 16124 16120
$ pidof -x apache2 | cut -f1 -d ' '
16130
$ stat -c %Y /proc/$(pidof -x apache2 | cut -f1 -d ' ' | cut -f1 -d ' ')
1569235472
```

This change updates both approaches to return the start time of the
oldest process.