### PR TITLE
More logging in async_wait_for_application_states

### DIFF
--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -655,8 +655,8 @@ class TestModel(ut_utils.BaseTestCase):
             model.wait_for_application_states('modelname', timeout=-3)
         self.assertEqual(
             timeout.exception.args[0],
-            ("Timed out waiting for app/2. It is in state blocked which is "
-             "not one of the approved states (['active'])"))
+            ("Timed out waiting for 'app/2'. The workload status is 'blocked' "
+             "which is not one of '['active']'"))
 
     def test_get_current_model(self):
         self.patch_object(model, 'Model')

--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -655,8 +655,8 @@ class TestModel(ut_utils.BaseTestCase):
             model.wait_for_application_states('modelname', timeout=-3)
         self.assertEqual(
             timeout.exception.args[0],
-            "Zaza has timed out waiting on the model to reach expected "
-            "workload statuses.")
+            ("Timed out waiting for app/2. It is in state blocked which is "
+             "not one of the approved states (['active'])"))
 
     def test_get_current_model(self):
         self.patch_object(model, 'Model')

--- a/zaza/model.py
+++ b/zaza/model.py
@@ -859,40 +859,58 @@ async def async_wait_for_application_states(model_name=None, states=None,
         errored_units = units_with_wl_status_state(model, 'error')
         if errored_units:
             raise UnitError(errored_units)
-        try:
-            for application, app_data in model.applications.items():
-                check_info = states.get(application, {})
-                for unit in app_data.units:
-                    app_wls = check_info.get('workload-status')
-                    if app_wls:
-                        all_approved_statuses = approved_statuses + [app_wls]
-                    else:
-                        all_approved_statuses = approved_statuses
-                    logging.info("Checking workload status of {}".format(
-                        unit.entity_id))
+
+        for application, app_data in model.applications.items():
+            check_info = states.get(application, {})
+            for unit in app_data.units:
+                app_wls = check_info.get('workload-status')
+                if app_wls:
+                    all_approved_statuses = approved_statuses + [app_wls]
+                else:
+                    all_approved_statuses = approved_statuses
+                logging.info("Checking workload status of {}".format(
+                    unit.entity_id))
+                try:
                     await model.block_until(
                         lambda: check_unit_workload_status(
                             model,
                             unit,
                             all_approved_statuses),
                         timeout=timeout)
-                    check_msg = check_info.get('workload-status-message')
-                    logging.info("Checking workload status message of {}"
-                                 .format(unit.entity_id))
+                except concurrent.futures._base.TimeoutError:
+                    msg = (
+                        "Timed out waiting for {}. It is in state {} which is "
+                        "not one of the approved states ({})").format(
+                            unit.entity_id,
+                            unit.workload_status,
+                            all_approved_statuses)
+                    raise ModelTimeout(msg)
+
+                check_msg = check_info.get('workload-status-message')
+                logging.info("Checking workload status message of {}"
+                             .format(unit.entity_id))
+                prefixes = approved_message_prefixes
+                if check_msg is not None:
+                    prefixes = approved_message_prefixes + [check_msg]
+                else:
                     prefixes = approved_message_prefixes
-                    if check_msg is not None:
-                        prefixes = approved_message_prefixes + [check_msg]
-                    else:
-                        prefixes = approved_message_prefixes
+                try:
                     await model.block_until(
                         lambda: check_unit_workload_status_message(
                             model,
                             unit,
                             prefixes=prefixes),
                         timeout=timeout)
-        except concurrent.futures._base.TimeoutError:
-            raise ModelTimeout("Zaza has timed out waiting on the model to "
-                               "reach expected workload statuses.")
+                except concurrent.futures._base.TimeoutError:
+                    msg = (
+                        "Timed out waiting for {}. It has wl status message "
+                        "{} which is not one of the approved "
+                        " messages ({})").format(
+                            unit.entity_id,
+                            unit.workload_status_message,
+                            prefixes)
+                    raise ModelTimeout(msg)
+
 
 wait_for_application_states = sync_wrapper(async_wait_for_application_states)
 


### PR DESCRIPTION
Replace the general model timeout message with a message which is
contians information about which unit timed out,  what state that
unit is in and what state did it fail to reach.