### PR TITLE
Derive type of {mod_alias: bundle} deployments

### DIFF
--- a/unit_tests/test_zaza_charm_lifecycle_utils.py
+++ b/unit_tests/test_zaza_charm_lifecycle_utils.py
@@ -74,6 +74,12 @@ class TestCharmLifecycleUtils(ut_utils.BaseTestCase):
                 'model_alias2': 'bundle2'}),
             lc_utils.MUTLI_UNORDERED)
 
+    def test_get_deployment_type_single_aliased(self):
+        self.assertEqual(
+            lc_utils.get_deployment_type(
+                {'model_alias1': 'bundle1'}),
+            lc_utils.SINGLE_ALIASED)
+
     def test_get_deployment_type_multi_unordered(self):
         self.assertEqual(
             lc_utils.get_deployment_type({
@@ -124,6 +130,24 @@ class TestCharmLifecycleUtils(ut_utils.BaseTestCase):
         self.assertEqual(
             lc_utils.get_environment_deploys('smoke_bundles'),
             [env_depl1, env_depl2, env_depl3])
+
+    def test_get_environment_deploy_single_aliased(self):
+        self.patch_object(
+            lc_utils,
+            'generate_model_name',
+            return_value='zaza-model-1')
+        self.patch_object(
+            lc_utils,
+            'get_default_env_deploy_name',
+            return_value='env-alias-1')
+        expect = lc_utils.EnvironmentDeploy(
+            'env-alias-1',
+            [lc_utils.ModelDeploy('alias', 'zaza-model-1', 'bundle')],
+            True)
+        self.assertEqual(
+            lc_utils.get_environment_deploy_single_aliased(
+                {'alias': 'bundle'}),
+            expect)
 
     def test_generate_model_name(self):
         self.patch_object(lc_utils.uuid, "uuid4")

--- a/zaza/charm_lifecycle/utils.py
+++ b/zaza/charm_lifecycle/utils.py
@@ -27,6 +27,7 @@ DEFAULT_MODEL_ALIAS = "default_alias"
 DEFAULT_DEPLOY_NAME = 'default{}'
 
 RAW_BUNDLE = "raw-bundle"
+SINGLE_ALIASED = "single-aliased"
 MUTLI_UNORDERED = "multi-unordered"
 MUTLI_ORDERED = "multi-ordered"
 
@@ -107,6 +108,8 @@ def get_deployment_type(deployment_directive):
             first_value = deployment_directive[list(deployment_directive)[0]]
             if isinstance(first_value, list):
                 return MUTLI_ORDERED
+            else:
+                return SINGLE_ALIASED
         else:
             return MUTLI_UNORDERED
 
@@ -120,6 +123,7 @@ def get_environment_deploy(deployment_directive):
     env_deploy_f = {
         RAW_BUNDLE: get_environment_deploy_raw,
         MUTLI_ORDERED: get_environment_deploy_multi_ordered,
+        SINGLE_ALIASED: get_environment_deploy_single_aliased,
         MUTLI_UNORDERED: get_environment_deploy_multi_unordered}
     return env_deploy_f[get_deployment_type(deployment_directive)](
         deployment_directive)
@@ -173,6 +177,23 @@ def get_environment_deploy_multi_unordered(deployment_directive):
                 generate_model_name(),
                 bundle))
     return EnvironmentDeploy(env_alias, model_deploys, True)
+
+
+def get_environment_deploy_single_aliased(deployment_directive):
+    """Get EnvironmentDeploy for a single_aliased deployment_directive.
+
+    :returns: The EnvironmentDeploy for the give deployment directive.
+    :rtype: EnvironmentDeploy
+    """
+    env_alias = get_default_env_deploy_name()
+    (alias, bundle) = list(deployment_directive.items())[0]
+    return EnvironmentDeploy(
+        env_alias,
+        [ModelDeploy(
+            alias,
+            generate_model_name(),
+            bundle)],
+        True)
 
 
 def get_environment_deploys(bundle_key, deployment_name=None):


### PR DESCRIPTION
Tests which contain bundle directives of the type:

```
gate_bundles:
  - model_alias: bundle_name
```

were failing because **get_deployment_type** was failing to
categorise it. This change fixes that by categorising it as
**SINGLE_ALIASED** and adding a function for constructing the
environment deployment type.

Closes issue #302