### PR TITLE
Move to TEST_ environment variables

### DIFF
--- a/unit_tests/utilities/test_deployment_env.py
+++ b/unit_tests/utilities/test_deployment_env.py
@@ -123,13 +123,12 @@ class TestUtilitiesDeploymentEnv(ut_utils.BaseTestCase):
             expect_config)
 
     def test_is_valid_env_key(self):
-        self.assertTrue(deployment_env.is_valid_env_key('OS_VIP04'))
-        self.assertTrue(deployment_env.is_valid_env_key('FIP_RANGE'))
-        self.assertTrue(deployment_env.is_valid_env_key('GATEWAY'))
-        self.assertTrue(deployment_env.is_valid_env_key('NAME_SERVER'))
-        self.assertTrue(deployment_env.is_valid_env_key('NET_ID'))
-        self.assertTrue(deployment_env.is_valid_env_key('VIP_RANGE'))
-        self.assertTrue(deployment_env.is_valid_env_key('AMULET_OS_VIP'))
+        self.assertTrue(deployment_env.is_valid_env_key('TEST_VIP04'))
+        self.assertTrue(deployment_env.is_valid_env_key('TEST_FIP_RANGE'))
+        self.assertTrue(deployment_env.is_valid_env_key('TEST_GATEWAY'))
+        self.assertTrue(deployment_env.is_valid_env_key('TEST_NAME_SERVER'))
+        self.assertTrue(deployment_env.is_valid_env_key('TEST_NET_ID'))
+        self.assertTrue(deployment_env.is_valid_env_key('TEST_VIP_RANGE'))
         self.assertFalse(
             deployment_env.is_valid_env_key('ZAZA_TEMPLATE_VIP00'))
         self.assertFalse(deployment_env.is_valid_env_key('PATH'))
@@ -210,14 +209,15 @@ class TestUtilitiesDeploymentEnv(ut_utils.BaseTestCase):
                 'OS_SETTING2': 'from-file'}})
         self.environ.items.return_value = [
             ('AMULET_OS_VIP', '10.10.0.2'),
+            ('TEST_VIP', '10.10.0.1'),
             ('OS_SETTING2', 'from-env'),
-            ('OS_VIP04', '10.10.0.2'),
+            ('TEST_VIP04', '10.10.0.4'),
             ('ZAZA_TEMPLATE_VIP00', '20.3.4.5'),
             ('PATH', 'aa')]
         self.assertEqual(
             deployment_env.get_deployment_context(),
-            {'OS_VIP04': '10.10.0.2',
-             'AMULET_OS_VIP': '10.10.0.2',
+            {'TEST_VIP': '10.10.0.1',
+             'TEST_VIP04': '10.10.0.4',
              'OS_SETTING1': 'from-file',
              'OS_SETTING2': 'from-env'}
         )

--- a/zaza/utilities/deployment_env.py
+++ b/zaza/utilities/deployment_env.py
@@ -33,13 +33,8 @@ MODEL_SETTINGS_SECTION = 'model_settings'
 MODEL_CONSTRAINTS_SECTION = 'model_constraints'
 
 VALID_ENVIRONMENT_KEY_PREFIXES = [
-    'FIP_RANGE',
-    'GATEWAY',
-    'NAME_SERVER',
-    'NET_ID',
     'OS_',
-    'VIP_RANGE',
-    'AMULET_',
+    'TEST_',
     'MOJO_',
     'JUJU_',
     'CHARM_',


### PR DESCRIPTION
OSCI and zaza-openstack-tests have already moved to TEST_ prefixed
variables in the environment. Bring zaza up to date.

Remove the AMULET_ prefix entirely. This will cause zaza to complain
appropriately that any use of AMULET_* is missing and thus prompt us to
fix it.