### PR TITLE
Stop connecting to wrong model on model create

### DIFF
--- a/zaza/controller.py
+++ b/zaza/controller.py
@@ -31,10 +31,7 @@ async def async_add_model(model_name, config=None):
     controller = Controller()
     await controller.connect()
     logging.debug("Adding model {}".format(model_name))
-    model = await controller.add_model(model_name, config=config)
-    await model.connect()
-    model_name = model.info.name
-    await model.disconnect()
+    await controller.add_model(model_name, config=config)
     await controller.disconnect()
 
 add_model = sync_wrapper(async_add_model)


### PR DESCRIPTION
When creating a model zaza.controller.add_model used to call
model.connect() which would try to connect to the model in
jujus cache rather than the newly created model. There is also
no need to connect to the model so drop this action.