### PR TITLE
Add sync wrapped function block_until for async_block_until.

### DIFF
--- a/zaza/model.py
+++ b/zaza/model.py
@@ -1137,6 +1137,9 @@ async def async_block_until(*conditions, timeout=None, wait_period=0.5,
     await asyncio.wait_for(_block(), timeout, loop=loop)
 
 
+block_until = sync_wrapper(async_block_until)
+
+
 async def async_block_until_file_ready(application_name, remote_file,
                                        check_function, model_name=None,
                                        timeout=2700):


### PR DESCRIPTION
Mirrors the other sync wrapped functions in the class, which are callable outside async functions. Allows for generic conditions to be waited on. 