### PR TITLE
Wait for all models to settle after deploy

### DIFF
--- a/unit_tests/test_zaza_charm_lifecycle_func_test_runner.py
+++ b/unit_tests/test_zaza_charm_lifecycle_func_test_runner.py
@@ -47,6 +47,9 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
         self.patch_object(lc_func_test_runner.configure, 'configure')
         self.patch_object(lc_func_test_runner.test, 'test')
         self.patch_object(lc_func_test_runner.destroy, 'destroy')
+        self.patch_object(
+            lc_func_test_runner.zaza.model,
+            'block_until_all_units_idle')
         self.generate_model_name.return_value = 'newmodel'
         self.get_charm_config.return_value = {
             'charm_name': 'mycharm',
@@ -99,6 +102,9 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
         self.patch_object(lc_func_test_runner.configure, 'configure')
         self.patch_object(lc_func_test_runner.test, 'test')
         self.patch_object(lc_func_test_runner.destroy, 'destroy')
+        self.patch_object(
+            lc_func_test_runner.zaza.model,
+            'block_until_all_units_idle')
         self.generate_model_name.return_value = 'newmodel'
         model_names = ['m6', 'm5', 'm4', 'm3', 'm2', 'm1']
         self.generate_model_name.side_effect = model_names.pop
@@ -186,6 +192,9 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
         self.patch_object(lc_func_test_runner.configure, 'configure')
         self.patch_object(lc_func_test_runner.test, 'test')
         self.patch_object(lc_func_test_runner.destroy, 'destroy')
+        self.patch_object(
+            lc_func_test_runner.zaza.model,
+            'block_until_all_units_idle')
         self.generate_model_name.return_value = 'newmodel'
         self.get_charm_config.return_value = {
             'charm_name': 'mycharm',
@@ -213,6 +222,9 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
         self.patch_object(lc_func_test_runner.test, 'test')
         self.patch_object(lc_func_test_runner.destroy, 'destroy')
         self.generate_model_name.return_value = 'newmodel'
+        self.patch_object(
+            lc_func_test_runner.zaza.model,
+            'block_until_all_units_idle')
         self.get_charm_config.return_value = {
             'charm_name': 'mycharm',
             'gate_bundles': ['bundle1', 'bundle2'],
@@ -240,6 +252,9 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
         self.patch_object(lc_func_test_runner.configure, 'configure')
         self.patch_object(lc_func_test_runner.test, 'test')
         self.patch_object(lc_func_test_runner.destroy, 'destroy')
+        self.patch_object(
+            lc_func_test_runner.zaza.model,
+            'block_until_all_units_idle')
         self.generate_model_name.return_value = 'newmodel'
         self.get_charm_config.return_value = {
             'charm_name': 'mycharm',
@@ -265,6 +280,9 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
         self.patch_object(lc_func_test_runner, 'cli_utils')
         self.patch_object(lc_func_test_runner, 'func_test_runner')
         self.patch_object(lc_func_test_runner, 'asyncio')
+        self.patch_object(
+            lc_func_test_runner.zaza.model,
+            'block_until_all_units_idle')
         _args = mock.Mock()
         _args.loglevel = 'DEBUG'
         _args.dev = True

--- a/zaza/charm_lifecycle/func_test_runner.py
+++ b/zaza/charm_lifecycle/func_test_runner.py
@@ -15,6 +15,7 @@
 """Run full test lifecycle."""
 import argparse
 import asyncio
+import logging
 import os
 import sys
 
@@ -53,6 +54,13 @@ def run_env_deployment(env_deployment, keep_model=False):
                 utils.BUNDLE_DIR, '{}.yaml'.format(deployment.bundle)),
             deployment.model_name,
             model_ctxt=model_aliases)
+
+    # When deploying bundles with cross model relations, hooks may be triggered
+    # in already deployedi models so wait for all models to settle.
+    for deployment in env_deployment.model_deploys:
+        logging.info("Waiting for {} to settle".format(deployment.model_name))
+        zaza.model.block_until_all_units_idle(
+            model_name=deployment.model_name)
 
     for deployment in env_deployment.model_deploys:
         configure.configure(


### PR DESCRIPTION
When deploying bundles with cross model relations, hooks may be
triggered in already deployedi models so wait for all models to
settle.