### PR TITLE
Add get_lead_unit_ip function

### DIFF
--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -334,6 +334,16 @@ class TestModel(ut_utils.BaseTestCase):
             model.get_lead_unit_name('app', 'model'),
             'app/4')
 
+    def test_get_lead_unit_ip(self):
+        self.patch_object(model, 'get_juju_model', return_value='mname')
+        self.patch_object(model, 'get_units')
+        self.get_units.return_value = self.units
+        self.patch_object(model, 'Model')
+        self.Model.return_value = self.Model_mock
+        self.assertEqual(
+            model.get_lead_unit_ip('app', 'model'),
+            'ip2')
+
     def test_get_unit_from_name(self):
         self.patch_object(model, 'get_juju_model', return_value='mname')
         self.patch_object(model, 'Model')

--- a/zaza/model.py
+++ b/zaza/model.py
@@ -506,7 +506,7 @@ async def async_get_lead_unit_ip(application_name, model_name=None):
     :type model_name: str
     :param application_name: Name of application
     :type application_name: str
-    :returns: Name of lowest numbered unit
+    :returns: IP of the lead unit
     :rtype: str
     """
     async with run_in_model(model_name) as model:

--- a/zaza/model.py
+++ b/zaza/model.py
@@ -499,6 +499,26 @@ def get_app_ips(application_name, model_name=None):
             for u in get_units(application_name, model_name=model_name)]
 
 
+async def async_get_lead_unit_ip(application_name, model_name=None):
+    """Return the IP address of the lead unit of a given application.
+
+    :param model_name: Name of model to query.
+    :type model_name: str
+    :param application_name: Name of application
+    :type application_name: str
+    :returns: Name of lowest numbered unit
+    :rtype: str
+    """
+    async with run_in_model(model_name) as model:
+        for unit in model.applications[application_name].units:
+            is_leader = await unit.is_leader_from_status()
+            if is_leader:
+                return unit.public_address
+
+
+get_lead_unit_ip = sync_wrapper(async_get_lead_unit_ip)
+
+
 async def async_get_application_config(application_name, model_name=None):
     """Return application configuration.
 


### PR DESCRIPTION
This PR adds a facility to obtain the IP address of the lead unit in
an application.  This is used, firstly, by the vault pause/resume
test.