### PR TITLE
Add --force for deploy to override juju constraint checks

### DIFF
--- a/unit_tests/test_zaza_charm_lifecycle_deploy.py
+++ b/unit_tests/test_zaza_charm_lifecycle_deploy.py
@@ -287,9 +287,9 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
         self.patch_object(lc_deploy, 'render_overlays')
         self.patch_object(lc_deploy.utils, 'check_output_logging')
         self.render_overlays.return_value = []
-        lc_deploy.deploy_bundle('bun.yaml', 'newmodel')
+        lc_deploy.deploy_bundle('bun.yaml', 'newmodel', force=True)
         self.check_output_logging.assert_called_once_with(
-            ['juju', 'deploy', '-m', 'newmodel', 'bun.yaml'])
+            ['juju', 'deploy', '-m', 'newmodel', 'bun.yaml', '--force'])
 
     def test_deploy(self):
         self.patch_object(lc_deploy.zaza.model, 'wait_for_application_states')
@@ -298,7 +298,8 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
         self.patch_object(lc_deploy, 'deploy_bundle')
         lc_deploy.deploy('bun.yaml', 'newmodel')
         self.deploy_bundle.assert_called_once_with('bun.yaml', 'newmodel',
-                                                   model_ctxt=None)
+                                                   model_ctxt=None,
+                                                   force=False)
         self.wait_for_application_states.assert_called_once_with(
             'newmodel',
             {})
@@ -314,7 +315,8 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
         self.patch_object(lc_deploy, 'deploy_bundle')
         lc_deploy.deploy('bun.yaml', 'newmodel')
         self.deploy_bundle.assert_called_once_with('bun.yaml', 'newmodel',
-                                                   model_ctxt=None)
+                                                   model_ctxt=None,
+                                                   force=False)
         self.wait_for_application_states.assert_called_once_with(
             'newmodel',
             {'vault': {
@@ -326,7 +328,8 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
         self.patch_object(lc_deploy, 'deploy_bundle')
         lc_deploy.deploy('bun.yaml', 'newmodel', wait=False)
         self.deploy_bundle.assert_called_once_with('bun.yaml', 'newmodel',
-                                                   model_ctxt=None)
+                                                   model_ctxt=None,
+                                                   force=False)
         self.assertFalse(self.wait_for_application_states.called)
 
     def test_parser(self):
@@ -358,3 +361,13 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
             '--log', 'DEBUG'
         ])
         self.assertEqual(args.loglevel, 'DEBUG')
+
+    def test_parser_force(self):
+        args = lc_deploy.parse_args(['-m', 'model', '-b', 'bundle.yaml'])
+        self.assertFalse(args.force)
+        # Now test we can override
+        args = lc_deploy.parse_args(['-m', 'model', '-b', 'bundle.yaml',
+                                     '--force'])
+        self.assertTrue(args.force)
+        args = lc_deploy.parse_args(['-m', 'model', '-b', 'bundle.yaml', '-f'])
+        self.assertTrue(args.force)

--- a/unit_tests/test_zaza_charm_lifecycle_func_test_runner.py
+++ b/unit_tests/test_zaza_charm_lifecycle_func_test_runner.py
@@ -67,17 +67,17 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
             'tests': [
                 'zaza.charm_tests.mycharm.tests.SmokeTest',
                 'zaza.charm_tests.mycharm.tests.ComplexTest']}
-        lc_func_test_runner.func_test_runner()
+        lc_func_test_runner.func_test_runner(force=True)
         prepare_calls = [
             mock.call('newmodel'),
             mock.call('newmodel')]
         deploy_calls = [
             mock.call('./tests/bundles/bundle1.yaml', 'newmodel',
                       model_ctxt={'default_alias': 'newmodel'},
-                      force=False),
+                      force=True),
             mock.call('./tests/bundles/bundle2.yaml', 'newmodel',
                       model_ctxt={'default_alias': 'newmodel'},
-                      force=False)]
+                      force=True)]
         configure_calls = [
             mock.call('newmodel', [
                 'zaza.charm_tests.mycharm.setup.basic_setup'

--- a/unit_tests/test_zaza_charm_lifecycle_func_test_runner.py
+++ b/unit_tests/test_zaza_charm_lifecycle_func_test_runner.py
@@ -26,6 +26,7 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
         self.assertFalse(args.keep_model)
         self.assertFalse(args.smoke)
         self.assertFalse(args.dev)
+        self.assertFalse(args.force)
         self.assertIsNone(args.bundle)
         # Test flags
         args = lc_func_test_runner.parse_args(['--keep-model'])
@@ -38,6 +39,10 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
         self.assertEqual(args.bundle, 'mybundle')
         args = lc_func_test_runner.parse_args(['--log', 'DEBUG'])
         self.assertEqual(args.loglevel, 'DEBUG')
+        args = lc_func_test_runner.parse_args(['-f'])
+        self.assertTrue(args.force)
+        args = lc_func_test_runner.parse_args(['--force'])
+        self.assertTrue(args.force)
 
     def test_func_test_runner(self):
         self.patch_object(lc_func_test_runner.utils, 'get_charm_config')
@@ -68,9 +73,11 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
             mock.call('newmodel')]
         deploy_calls = [
             mock.call('./tests/bundles/bundle1.yaml', 'newmodel',
-                      model_ctxt={'default_alias': 'newmodel'}),
+                      model_ctxt={'default_alias': 'newmodel'},
+                      force=False),
             mock.call('./tests/bundles/bundle2.yaml', 'newmodel',
-                      model_ctxt={'default_alias': 'newmodel'})]
+                      model_ctxt={'default_alias': 'newmodel'},
+                      force=False)]
         configure_calls = [
             mock.call('newmodel', [
                 'zaza.charm_tests.mycharm.setup.basic_setup'
@@ -138,17 +145,19 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
             mock.call('m4')]
         deploy_calls = [
             mock.call('./tests/bundles/bundle1.yaml', 'm1',
-                      model_ctxt={'default_alias': 'm1'}),
+                      model_ctxt={'default_alias': 'm1'}, force=False),
             mock.call('./tests/bundles/bundle2.yaml', 'm2',
-                      model_ctxt={'default_alias': 'm2'}),
+                      model_ctxt={'default_alias': 'm2'}, force=False),
             mock.call(
                 './tests/bundles/bundle5.yaml',
                 'm3',
-                model_ctxt={'model_alias_5': 'm3', 'model_alias_6': 'm4'}),
+                model_ctxt={'model_alias_5': 'm3', 'model_alias_6': 'm4'},
+                force=False),
             mock.call(
                 './tests/bundles/bundle6.yaml',
                 'm4',
-                model_ctxt={'model_alias_5': 'm3', 'model_alias_6': 'm4'})]
+                model_ctxt={'model_alias_5': 'm3', 'model_alias_6': 'm4'},
+                force=False)]
         configure_calls = [
             mock.call('m1', [
                 'zaza.charm_tests.mycharm.setup.basic_setup',
@@ -210,7 +219,8 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
         lc_func_test_runner.func_test_runner(smoke=True)
         deploy_calls = [
             mock.call('./tests/bundles/bundle2.yaml', 'newmodel',
-                      model_ctxt={'default_alias': 'newmodel'})]
+                      model_ctxt={'default_alias': 'newmodel'},
+                      force=False)]
         self.deploy.assert_has_calls(deploy_calls)
 
     def test_func_test_runner_dev(self):
@@ -239,9 +249,9 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
         lc_func_test_runner.func_test_runner(dev=True)
         deploy_calls = [
             mock.call('./tests/bundles/bundle3.yaml', 'newmodel',
-                      model_ctxt={'default_alias': 'newmodel'}),
+                      model_ctxt={'default_alias': 'newmodel'}, force=False),
             mock.call('./tests/bundles/bundle4.yaml', 'newmodel',
-                      model_ctxt={'default_alias': 'newmodel'})]
+                      model_ctxt={'default_alias': 'newmodel'}, force=False)]
         self.deploy.assert_has_calls(deploy_calls)
 
     def test_func_test_runner_specify_bundle(self):
@@ -272,7 +282,8 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
             mock.call(
                 './tests/bundles/maveric-filebeat.yaml',
                 'newmodel',
-                model_ctxt={'default_alias': 'newmodel'})]
+                model_ctxt={'default_alias': 'newmodel'},
+                force=False)]
         self.deploy.assert_has_calls(deploy_calls)
 
     def test_main_smoke_dev_ambiguous(self):

--- a/zaza/charm_lifecycle/deploy.py
+++ b/zaza/charm_lifecycle/deploy.py
@@ -276,6 +276,9 @@ def render_overlays(bundle, target_dir, model_ctxt=None):
 def deploy_bundle(bundle, model, model_ctxt=None, force=False):
     """Deploy the given bundle file in the specified model.
 
+    The force param is used to enable zaza testing with Juju with charms
+    that would be rejected by juju (e.g. series not supported).
+
     :param bundle: Path to bundle file
     :type bundle: str
     :param model: Name of model to deploy bundle in

--- a/zaza/charm_lifecycle/deploy.py
+++ b/zaza/charm_lifecycle/deploy.py
@@ -273,7 +273,7 @@ def render_overlays(bundle, target_dir, model_ctxt=None):
     return overlays
 
 
-def deploy_bundle(bundle, model, model_ctxt=None):
+def deploy_bundle(bundle, model, model_ctxt=None, force=False):
     """Deploy the given bundle file in the specified model.
 
     :param bundle: Path to bundle file
@@ -283,10 +283,14 @@ def deploy_bundle(bundle, model, model_ctxt=None):
     :param model_ctxt: Additional context to be used when rendering bundle
                        templates.
     :type model_ctxt: {}
+    :param force: Pass the force parameter if True
+    :type force: Boolean
     """
     logging.info("Deploying bundle '{}' on to '{}' model"
                  .format(bundle, model))
     cmd = ['juju', 'deploy', '-m', model, bundle]
+    if force:
+        cmd.append('--force')
     with tempfile.TemporaryDirectory() as tmpdirname:
         for overlay in render_overlays(bundle, tmpdirname,
                                        model_ctxt=model_ctxt):
@@ -296,7 +300,7 @@ def deploy_bundle(bundle, model, model_ctxt=None):
         utils.check_output_logging(cmd)
 
 
-def deploy(bundle, model, wait=True, model_ctxt=None):
+def deploy(bundle, model, wait=True, model_ctxt=None, force=False):
     """Run all steps to complete deployment.
 
     :param bundle: Path to bundle file
@@ -308,9 +312,11 @@ def deploy(bundle, model, wait=True, model_ctxt=None):
     :param model_ctxt: Additional context to be used when rendering bundle
                        templates.
     :type model_ctxt: {}
+    :param force: Pass the force parameter if True
+    :type force: Boolean
     """
     run_report.register_event_start('Deploy Bundle')
-    deploy_bundle(bundle, model, model_ctxt=model_ctxt)
+    deploy_bundle(bundle, model, model_ctxt=model_ctxt, force=force)
     run_report.register_event_finish('Deploy Bundle')
     if wait:
         run_report.register_event_start('Wait for Deployment')
@@ -338,6 +344,9 @@ def parse_args(args):
     parser.add_argument('-b', '--bundle',
                         help='Bundle name (excluding file ext)',
                         required=True)
+    parser.add_argument('-f', '--force', dest='force',
+                        help='Pass --force to the juju deploy command',
+                        action='store_true')
     parser.add_argument('--no-wait', dest='wait',
                         help='Do not wait for deployment to settle',
                         action='store_false')
@@ -351,5 +360,8 @@ def main():
     """Deploy bundle."""
     args = parse_args(sys.argv[1:])
     cli_utils.setup_logging(log_level=args.loglevel.upper())
-    deploy(args.bundle, args.model, wait=args.wait)
+    if args.force:
+        logging.warn("Using the --force argument for 'juju deploy'. Note "
+                     "that this disables juju checks for compatibility.")
+    deploy(args.bundle, args.model, wait=args.wait, force=args.force)
     run_report.output_event_report()

--- a/zaza/charm_lifecycle/func_test_runner.py
+++ b/zaza/charm_lifecycle/func_test_runner.py
@@ -30,13 +30,15 @@ import zaza.utilities.cli as cli_utils
 import zaza.utilities.run_report as run_report
 
 
-def run_env_deployment(env_deployment, keep_model=False):
+def run_env_deployment(env_deployment, keep_model=False, force=False):
     """Run the environment deployment.
 
     :param env_deployment: Environment Deploy to execute.
     :type env_deployment: utils.EnvironmentDeploy
     :param keep_model: Whether to destroy models at end of run
     :type keep_model: boolean
+    :param force: Pass the force parameter if True
+    :type force: Boolean
     """
     config_steps = utils.get_config_steps()
     test_steps = utils.get_test_steps()
@@ -53,7 +55,8 @@ def run_env_deployment(env_deployment, keep_model=False):
             os.path.join(
                 utils.BUNDLE_DIR, '{}.yaml'.format(deployment.bundle)),
             deployment.model_name,
-            model_ctxt=model_aliases)
+            model_ctxt=model_aliases,
+            force=force)
 
     # When deploying bundles with cross model relations, hooks may be triggered
     # in already deployedi models so wait for all models to settle.
@@ -82,7 +85,8 @@ def run_env_deployment(env_deployment, keep_model=False):
     zaza.model.unset_juju_model_aliases()
 
 
-def func_test_runner(keep_model=False, smoke=False, dev=False, bundle=None):
+def func_test_runner(keep_model=False, smoke=False, dev=False, bundle=None,
+                     force=False):
     """Deploy the bundles and run the tests as defined by the charms tests.yaml.
 
     :param keep_model: Whether to destroy model at end of run
@@ -91,6 +95,8 @@ def func_test_runner(keep_model=False, smoke=False, dev=False, bundle=None):
     :param dev: Whether to just run dev test.
     :type smoke: boolean
     :type dev: boolean
+    :param force: Pass the force parameter if True to the juju deploy command
+    :type force: Boolean
     """
     if bundle:
         environment_deploys = [
@@ -115,7 +121,8 @@ def func_test_runner(keep_model=False, smoke=False, dev=False, bundle=None):
         preserve_model = False
         if keep_model and last_test == env_deployment.name:
             preserve_model = True
-        run_env_deployment(env_deployment, keep_model=preserve_model)
+        run_env_deployment(env_deployment, keep_model=preserve_model,
+                           force=force)
 
 
 def parse_args(args):
@@ -139,6 +146,9 @@ def parse_args(args):
     parser.add_argument('-b', '--bundle', dest='bundle',
                         help='Override the bundle to be run',
                         required=False)
+    parser.add_argument('-f', '--force', dest='force',
+                        help='Pass --force to the juju deploy command',
+                        action='store_true')
     parser.add_argument('--log', dest='loglevel',
                         help='Loglevel [DEBUG|INFO|WARN|ERROR|CRITICAL]')
     parser.set_defaults(keep_model=False,
@@ -166,10 +176,15 @@ def main():
         raise ValueError('Ambiguous arguments: --bundle and '
                          '--smoke cannot be used together')
 
+    if args.force:
+        logging.warn("Using the --force argument for 'juju deploy'. Note "
+                     "that this disables juju checks for compatibility.")
+
     func_test_runner(
         keep_model=args.keep_model,
         smoke=args.smoke,
         dev=args.dev,
-        bundle=args.bundle)
+        bundle=args.bundle,
+        force=args.force)
     run_report.output_event_report()
     asyncio.get_event_loop().close()


### PR DESCRIPTION
To be able to run tests on a series that juju doesn't support, the
--force param is needed for the 'juju deploy' command.  This PR
adds the option to the deploy phase and the test runner.  It is
intentionally not provided in the bundle as the intention is for it to
be obvious (and more difficult) to override Juju constraint checks.