### PR TITLE
Enables zaza to get the status of LXD containers

### DIFF
--- a/zaza/utilities/juju.py
+++ b/zaza/utilities/juju.py
@@ -200,7 +200,11 @@ def get_machine_status(machine, key=None):
     :rtype: dict
     """
     status = get_full_juju_status()
-    status = status.machines.get(machine)
+    if "lxd" in machine:
+        host = machine.split('/')[0]
+        status = status.machines.get(host)['containers'][machine]
+    else:
+        status = status.machines.get(machine)
     if key:
         status = status.get(key)
     return status


### PR DESCRIPTION
FullStatus only lists "physical" machines in the machines dict, so if we want to get the status of a container we have to request it explicitly 

Closes #330