### PR TITLE
Enable a tests_options force_deploy option

### DIFF
--- a/doc/source/addingcharmtests.rst
+++ b/doc/source/addingcharmtests.rst
@@ -15,7 +15,7 @@ Add targets to tox.ini should include a target like::
     basepython = python3
     commands =
         functest-run-suite --keep-model
-    
+
     [testenv:func-smoke]
     basepython = python3
     commands =
@@ -123,3 +123,34 @@ look like::
       - base-bionic
     dev_bundles:
       - base-xenial-ha
+
+Deploying bundles using --force
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In order to allow early testing of new Ubuntu series the `juju deploy` command
+has a `--force` option.  This allows deployment of charms that don't specify
+the series being used, or for a new series that juju doesn't support yet.
+
+Force deploying can be achieved in two ways, either on the command line, or via
+an `tests_options.force_deploy` entry in the `tests.yaml` file.
+
+For the command line a `--force` param is provided:
+
+    functest-run-suite --keep-model --dev --force
+    functest-deploy <other options> --force
+
+In the `tests.yaml` the option is added as a list item:
+
+    charm_name: keystone
+    smoke_bundles:
+    - focal-ussuri
+
+    ...
+
+    tests_options:
+      force_deploy:
+        - focal-ussuri
+
+In the above case, focal-ussuri will be deployed using the --force parameter.
+i.e. the `tests_options.force_deploy['focal-ussuri']` option applies to the
+`focal-ussuri` bundle whether it appears in any of the bundle sections.

--- a/unit_tests/test_zaza_charm_lifecycle_utils.py
+++ b/unit_tests/test_zaza_charm_lifecycle_utils.py
@@ -183,6 +183,30 @@ class TestCharmLifecycleUtils(ut_utils.BaseTestCase):
         self.assertEqual(lc_utils.get_charm_config(fatal=False),
                          {'charm_name': 'fakecwd'})
 
+    def test_is_config_deploy_forced_for_bundle(self):
+        self.patch_object(lc_utils, 'get_charm_config')
+        # test that no options at all returns value
+        self.get_charm_config.return_value = {}
+        self.assertFalse(lc_utils.is_config_deploy_forced_for_bundle('x'))
+        # test that if options exist but no bundle
+        self.get_charm_config.return_value = {
+            'tests_options': {}
+        }
+        self.assertFalse(lc_utils.is_config_deploy_forced_for_bundle('x'))
+        self.get_charm_config.return_value = {
+            'tests_options': {
+                'force_deploy': []
+            }
+        }
+        self.assertFalse(lc_utils.is_config_deploy_forced_for_bundle('x'))
+        # verify that it returns True if the bundle is mentioned
+        self.get_charm_config.return_value = {
+            'tests_options': {
+                'force_deploy': ['x']
+            }
+        }
+        self.assertTrue(lc_utils.is_config_deploy_forced_for_bundle('x'))
+
     def test_get_class(self):
         self.assertEqual(
             type(lc_utils.get_class('unit_tests.'

--- a/zaza/charm_lifecycle/func_test_runner.py
+++ b/zaza/charm_lifecycle/func_test_runner.py
@@ -50,6 +50,9 @@ def run_env_deployment(env_deployment, keep_model=False, force=False):
     for deployment in env_deployment.model_deploys:
         prepare.prepare(deployment.model_name)
 
+    force = force or utils.is_config_deploy_forced_for_bundle(
+        deployment.bundle)
+
     for deployment in env_deployment.model_deploys:
         deploy.deploy(
             os.path.join(

--- a/zaza/charm_lifecycle/utils.py
+++ b/zaza/charm_lifecycle/utils.py
@@ -315,6 +315,42 @@ def get_charm_config(yaml_file=None, fatal=True):
         raise
 
 
+def is_config_deploy_forced_for_bundle(
+        bundle_name, yaml_file=None, fatal=True):
+    """Ask the config if the bundle_name should be deploy_forced.
+
+    In the config file for the tests, the tests_options.force_deploy option
+    may be used to force the juju deploy; e.g. the bundle combination isn't
+    officially supported by Juju and thus the only way to test it is to parse
+    --force to the option.
+
+    The tests_options section needs to look like:
+
+        tests_options:
+          force_deploy:
+            - focal-ussuri
+
+    e.g. force_deploy is a list of bundle names; if the bundle is mentioned
+    then that bundle will be force_deployed.
+
+    :param bundle_name: the bundle to check in the force_deploy list
+    :type bundle_name: str
+    :param yaml_file: the YAML file that contains the tests specification
+    :type yaml_file: Optional[str]
+    :param fatal: whether any errors cause an exception or are just logged.
+    :type fatal: bool
+    :returns: True if the config option is set for the bundle
+    :rtype: bool
+    :raises: OSError if the YAML file doesn't exist and fatal=True
+    """
+    config = get_charm_config(yaml_file, fatal)
+    try:
+        return bundle_name in config['tests_options']['force_deploy']
+    except KeyError:
+        pass
+    return False
+
+
 def get_class(class_str):
     """Get the class represented by the given string.
 


### PR DESCRIPTION
This PR adds an option to the tests.yaml so that a bundle can be
identified as needing --force on the deploy.  This enables bundles to be
added to the tests.yaml which target Ubuntu series that can't be tested
with juju without the --force option.