### PR TITLE
Add back ``oslo.config``

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ from setuptools.command.test import test as TestCommand
 
 version = "0.0.1.dev1"
 install_require = [
+    'oslo.config<6.12.0',  # pin at stable/train to retain Py3.5 support
     'async_generator',
     'cryptography',
     'hvac<0.7.0',


### PR DESCRIPTION
Commit b6192fb5969c277d36c06a3cdde53a2032f62dd6 removed
``oslo.config`` which is imported in zaza/model.py.

Add it back, pin at stable/train to retain Python 3.5 support.