### PR TITLE
Add options to block when adding/removing units

### DIFF
--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -1071,6 +1071,8 @@ class TestModel(ut_utils.BaseTestCase):
         model.block_until_unit_count('app', 2)
         with self.assertRaises(AsyncTimeoutError):
             model.block_until_unit_count('app', 3, timeout=0.1)
+        with self.assertRaises(AssertionError):
+            model.block_until_unit_count('app', 2.3)
 
     def block_until_service_status_base(self, rou_return):
 

--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -524,6 +524,17 @@ class TestModel(ut_utils.BaseTestCase):
         self.mymodel.applications['app'].add_unit.assert_called_once_with(
             count=2, to='lxd/0')
 
+    def test_add_unit_wait(self):
+        self.patch_object(model, 'async_block_until_unit_count')
+        self.patch_object(model, 'get_juju_model', return_value='mname')
+        self.patch_object(model, 'Model')
+        self.Model.return_value = self.Model_mock
+        model.add_unit('app', count=2, to='lxd/0', wait_appear=True)
+        self.mymodel.applications['app'].add_unit.assert_called_once_with(
+            count=2, to='lxd/0')
+        self.async_block_until_unit_count.assert_called_once_with(
+            'app', 4, model_name=None)
+
     def test_destroy_unit(self):
         self.patch_object(model, 'get_juju_model', return_value='mname')
         self.patch_object(model, 'Model')
@@ -531,6 +542,17 @@ class TestModel(ut_utils.BaseTestCase):
         model.destroy_unit('app', 'app/2')
         self.mymodel.applications['app'].destroy_unit.assert_called_once_with(
             'app/2')
+
+    def test_destroy_unit_wait(self):
+        self.patch_object(model, 'async_block_until_unit_count')
+        self.patch_object(model, 'get_juju_model', return_value='mname')
+        self.patch_object(model, 'Model')
+        self.Model.return_value = self.Model_mock
+        model.destroy_unit('app', 'app/2', wait_disappear=True)
+        self.mymodel.applications['app'].destroy_unit.assert_called_once_with(
+            'app/2')
+        self.async_block_until_unit_count.assert_called_once_with(
+            'app', 1, model_name=None)
 
     def test_get_relation_id_interface(self):
         self.patch_object(model, 'get_juju_model', return_value='mname')
@@ -1028,6 +1050,27 @@ class TestModel(ut_utils.BaseTestCase):
         self.Model_mock.block_until.side_effect = _block_until
         with self.assertRaises(model.UnitError):
             model.block_until_all_units_idle('modelname')
+
+    def test_block_until_unit_count(self):
+
+        async def _block_until(f, timeout=None):
+            rc = await f()
+            if not rc:
+                raise AsyncTimeoutError
+
+        async def _get_status():
+            return self.juju_status
+        self.patch_object(model, 'Model')
+        self.Model.return_value = self.Model_mock
+        self.patch_object(model, 'async_block_until')
+        self.async_block_until.side_effect = _block_until
+        self.patch_object(model, 'async_get_status')
+        self.async_get_status.side_effect = _get_status
+        self.juju_status.applications[self.application]["units"] = [
+            'app/1', 'app/2']
+        model.block_until_unit_count('app', 2)
+        with self.assertRaises(AsyncTimeoutError):
+            model.block_until_unit_count('app', 3, timeout=0.1)
 
     def block_until_service_status_base(self, rou_return):
 

--- a/zaza/model.py
+++ b/zaza/model.py
@@ -1065,8 +1065,9 @@ async def async_block_until_unit_count(application, target_count,
     async def _check_unit():
         model_status = await async_get_status()
         unit_count = len(model_status.applications[application]['units'])
-        return unit_count == int(target_count)
+        return unit_count == target_count
 
+    assert target_count == int(target_count), "target_count not an int"
     async with run_in_model(model_name):
         await async_block_until(_check_unit, timeout=timeout)
 

--- a/zaza/model.py
+++ b/zaza/model.py
@@ -1045,6 +1045,35 @@ async def async_block_until_all_units_idle(model_name=None, timeout=2700):
 block_until_all_units_idle = sync_wrapper(async_block_until_all_units_idle)
 
 
+async def async_block_until_unit_count(application, target_count,
+                                       model_name=None, timeout=2700):
+    """Block until the number of units matches target_count.
+
+    An example accessing this function via its sync wrapper::
+
+        block_until_unit_count('keystone', 4)
+
+    :param application_name: Name of application
+    :type application_name: str
+    :param target_count: Number of expected units.
+    :type target_count: int
+    :param model_name: Name of model to interact with.
+    :type model_name: str
+    :param timeout: Time to wait for status to be achieved
+    :type timeout: float
+    """
+    async def _check_unit():
+        model_status = await async_get_status()
+        unit_count = len(model_status.applications[application]['units'])
+        return unit_count == int(target_count)
+
+    async with run_in_model(model_name):
+        await async_block_until(_check_unit, timeout=timeout)
+
+block_until_unit_count = sync_wrapper(
+    async_block_until_unit_count)
+
+
 async def async_block_until_service_status(unit_name, services, target_status,
                                            model_name=None, timeout=2700,
                                            pgrep_full=False):
@@ -1591,7 +1620,8 @@ async def async_remove_relation(application_name, local_relation,
 remove_relation = sync_wrapper(async_remove_relation)
 
 
-async def async_add_unit(application_name, count=1, to=None, model_name=None):
+async def async_add_unit(application_name, count=1, to=None, model_name=None,
+                         wait_appear=False):
     """
     Add unit(s) to an application.
 
@@ -1603,15 +1633,25 @@ async def async_add_unit(application_name, count=1, to=None, model_name=None):
     :type to: str
     :param model_name: Name of model to operate on.
     :type model_name: str
+    :param wait_appear: Whether to wait for the unit to appear in juju status
+    :type wait_appear: bool
     """
     async with run_in_model(model_name) as model:
         app = model.applications[application_name]
+        current_unit_count = len(app.units)
         await app.add_unit(count=count, to=to)
+        if wait_appear:
+            target_count = current_unit_count + count
+            await async_block_until_unit_count(
+                application_name,
+                target_count,
+                model_name=model_name)
 
 add_unit = sync_wrapper(async_add_unit)
 
 
-async def async_destroy_unit(application_name, *unit_names, model_name=None):
+async def async_destroy_unit(application_name, *unit_names, model_name=None,
+                             wait_disappear=False):
     """
     Remove unit(s) of an application.
 
@@ -1621,10 +1661,20 @@ async def async_destroy_unit(application_name, *unit_names, model_name=None):
     :type unit_name: str(s)
     :param model_name: Name of model to operate on.
     :type model_name: str
+    :param wait_disappear: Whether to wait for the unit to disappear from juju
+                           status
+    :type wait_disappear: bool
     """
     async with run_in_model(model_name) as model:
         app = model.applications[application_name]
+        current_unit_count = len(app.units)
         await app.destroy_unit(*unit_names)
+        if wait_disappear:
+            target_count = current_unit_count - len(unit_names)
+            await async_block_until_unit_count(
+                application_name,
+                target_count,
+                model_name=model_name)
 
 destroy_unit = sync_wrapper(async_destroy_unit)
 


### PR DESCRIPTION
Add options to block when adding/removing units by using a new
helper function which blocks until unit count is expected
value.