### PR TITLE
Add get_latest_charm_url

### DIFF
--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -1651,6 +1651,17 @@ disk_formats = ami,ari,aki,vhd,vmdk,raw,qcow2,vdi,iso,root-tar
             revision=None,
             switch='cs:~me/new-charm-45')
 
+    def test_get_latest_charm_url(self):
+        async def _entity(charm_url, channel=None):
+            return {'Id': 'cs:something-23'}
+        self.patch_object(model, 'get_juju_model', return_value='mname')
+        self.patch_object(model, 'Model')
+        self.Model.return_value = self.Model_mock
+        self.Model_mock.charmstore.entity.side_effect = _entity
+        self.assertEqual(
+            model.get_latest_charm_url('cs:something'),
+            'cs:something-23')
+
     def test_prepare_series_upgrade(self):
         self.patch_object(model, 'subprocess')
         self.patch_object(model, 'get_juju_model',

--- a/zaza/model.py
+++ b/zaza/model.py
@@ -1744,6 +1744,26 @@ async def async_upgrade_charm(application_name, channel=None,
 upgrade_charm = sync_wrapper(async_upgrade_charm)
 
 
+async def async_get_latest_charm_url(charm_url, channel=None, model_name=None):
+    """Get charm url, including revision number, for latest charm version.
+
+    :param charm_url: Charm url without revision number
+    :type charm_url: str
+    :param channel: Channel to use when getting the charm from the charm store,
+                    e.g. 'development'
+    :type channel: str
+    :param model_name: Name of model to operate on
+    :type model_name: str
+    """
+    async with run_in_model(model_name) as model:
+        charmstore_entity = await model.charmstore.entity(
+            charm_url,
+            channel=channel)
+        return charmstore_entity['Id']
+
+get_latest_charm_url = sync_wrapper(async_get_latest_charm_url)
+
+
 class UnitNotFound(Exception):
     """Unit was not found in model."""
 


### PR DESCRIPTION
Add get_latest_charm_url to return the url of the latest revision of
a charm. This is useful when performing a charm upgrade with the
'switch' option as the charm url must include the target revision.