### PR TITLE
Add maas support to get_unit_name_from_host_name

### DIFF
--- a/unit_tests/utilities/test_zaza_utilities_juju.py
+++ b/unit_tests/utilities/test_zaza_utilities_juju.py
@@ -32,12 +32,10 @@ class TestJujuUtils(ut_utils.BaseTestCase):
         self.key_data = "machine-uuid"
 
         self.machine1 = "1"
-        self.machine1_data = {self.key: self.key_data}
         self.machine1_mock = MachineMock()
         self.machine1_mock[self.key] = self.key_data
 
         self.machine2 = "2"
-        self.machine2_data = {self.key: self.key_data}
         self.machine2_mock = MachineMock()
         self.machine2_mock[self.key] = self.key_data
 
@@ -195,7 +193,7 @@ class TestJujuUtils(ut_utils.BaseTestCase):
         # All machine data
         self.assertEqual(
             juju_utils.get_machine_status(self.machine1),
-            self.machine1_data)
+            {self.key: self.key_data})
         self.get_full_juju_status.assert_called_once()
 
         # Request a specific key
@@ -210,7 +208,7 @@ class TestJujuUtils(ut_utils.BaseTestCase):
         self.assertEqual(
             list(juju_utils.get_machine_uuids_for_application(
                 self.application)),
-            [self.machine1_data.get("instance-id")])
+            [self.key_data])
         self.get_machines_for_application.assert_called_once_with(
             self.application,
             model_name=None)

--- a/unit_tests/utilities/test_zaza_utilities_juju.py
+++ b/unit_tests/utilities/test_zaza_utilities_juju.py
@@ -22,15 +22,24 @@ class TestJujuUtils(ut_utils.BaseTestCase):
     def setUp(self):
         super(TestJujuUtils, self).setUp()
 
+        class MachineMock(dict):
+
+            def __init__(self, display_name=''):
+                self.display_name = display_name
+
         # Juju Status Object and data
         self.key = "instance-id"
         self.key_data = "machine-uuid"
 
         self.machine1 = "1"
         self.machine1_data = {self.key: self.key_data}
+        self.machine1_mock = MachineMock()
+        self.machine1_mock[self.key] = self.key_data
 
-        self.machine2 = "1"
+        self.machine2 = "2"
         self.machine2_data = {self.key: self.key_data}
+        self.machine2_mock = MachineMock()
+        self.machine2_mock[self.key] = self.key_data
 
         self.unit1 = "app/1"
         self.unit1_data = {"machine": self.machine1}
@@ -59,8 +68,8 @@ class TestJujuUtils(ut_utils.BaseTestCase):
             self.application: self.application_data,
             self.subordinate_application: self.subordinate_application_data}
         self.juju_status.machines = {
-            self.machine1: self.machine1_data,
-            self.machine2: self.machine2_data}
+            self.machine1: self.machine1_mock,
+            self.machine2: self.machine2_mock}
 
         # Model
         self.patch_object(juju_utils, "model")
@@ -143,6 +152,10 @@ class TestJujuUtils(ut_utils.BaseTestCase):
         self.assertEqual(
             juju_utils.get_unit_name_from_host_name('juju-model-1', 'app'),
             'app/1')
+        self.machine2_mock.display_name = 'node-jaeger.maas'
+        self.assertEqual(
+            juju_utils.get_unit_name_from_host_name('node-jaeger.maas', 'app'),
+            'app/2')
 
     def test_get_unit_name_from_host_name_bad_app(self):
         self.assertIsNone(

--- a/zaza/utilities/exceptions.py
+++ b/zaza/utilities/exceptions.py
@@ -21,6 +21,12 @@ class TemplateConflict(Exception):
     pass
 
 
+class MachineNotFound(Exception):
+    """Exception when machine is not found."""
+
+    pass
+
+
 class MissingOSAthenticationException(Exception):
     """Exception when some data needed to authenticate is missing."""
 

--- a/zaza/utilities/juju.py
+++ b/zaza/utilities/juju.py
@@ -157,7 +157,6 @@ def get_unit_name_from_host_name(host_name, application, model_name=None):
     :returns: The unit name of the application running on host_name.
     :rtype: str or None
     """
-    # Assume that a juju managed hostname always ends in the machine number.
     unit = None
     app_status = get_application_status(application, model_name=model_name)
     # If the application is not present there cannot be a matching unit.
@@ -203,6 +202,8 @@ def get_unit_name_from_host_name(host_name, application, model_name=None):
         # This is probably a non-maas deploy.
         if not machine_number:
             try:
+                # Assume that a juju managed hostname always ends in the
+                # machine number.
                 machine_number = int(host_name.split('-')[-1])
             except ValueError:
                 msg = ("Could not derive machine number from "


### PR DESCRIPTION
get_unit_name_from_host_name currently assumes that the machine
number of a host can be derived from the last part of the hostname.
This is not true of maas machines. The machine number can be found
recursing over the machines in the model and looking for a matching
display name. To keep things exciting display_name is an empty
string when using the openstack provider.