### PR TITLE
Add support for model tmp dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,6 @@ script:
   - if [ $ENV = 'func' ]; then
        sudo apt remove -y --purge lxd lxd-client;
        sudo snap install --stable lxd;
-       sudo systemctl status snap.lxd.activate.service;
-       sudo journalctl -xe;
        sudo snap install --classic juju;
        sudo sh -c 'echo PATH=/snap/bin:$PATH >> /etc/environment';
        sudo lxd waitready;

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ script:
   - if [ $ENV = 'func' ]; then
        sudo apt remove -y --purge lxd lxd-client;
        sudo snap install --stable lxd;
+       sudo systemctl status snap.lxd.activate.service;
+       sudo journalctl -xe;
        sudo snap install --classic juju;
        sudo sh -c 'echo PATH=/snap/bin:$PATH >> /etc/environment';
        sudo lxd waitready;

--- a/unit_tests/utilities/test_deployment_env.py
+++ b/unit_tests/utilities/test_deployment_env.py
@@ -240,3 +240,14 @@ class TestUtilitiesDeploymentEnv(ut_utils.BaseTestCase):
         self.assertEqual(
             deployment_env.get_cloud_region(),
             None)
+
+    def test_get_tmpdir(self):
+        self.patch_object(deployment_env.os, 'mkdir')
+        self.patch_object(deployment_env.os.path, 'exists')
+        self.exists.return_value = False
+        deployment_env.get_tmpdir(model_name='mymodel')
+        self.mkdir.assert_called_once_with('/tmp/mymodel')
+        self.mkdir.reset_mock()
+        self.exists.return_value = True
+        deployment_env.get_tmpdir(model_name='mymodel')
+        self.assertFalse(self.mkdir.called)

--- a/zaza/utilities/deployment_env.py
+++ b/zaza/utilities/deployment_env.py
@@ -19,6 +19,8 @@ import os
 import functools
 import yaml
 
+import zaza.model
+
 ZAZA_SETUP_FILE_LOCATIONS = [
     '{home}/.zaza.yaml']
 
@@ -192,3 +194,19 @@ def get_deployment_context():
         if is_valid_env_key(k):
             runtime_config[k] = v
     return runtime_config
+
+
+def get_tmpdir(model_name=None):
+    """Return a model specific temp directory.
+
+    Return a model specific temp directory. If the dirctory does not already
+    exist then create it.
+
+    :param model_name: Model name temp dir is associated with.
+    :type model_name: str
+    """
+    model_name = model_name or zaza.model.get_juju_model()
+    tmp_dir = '/tmp/{}'.format(model_name)
+    if not os.path.exists(tmp_dir):
+        os.mkdir(tmp_dir)
+    return tmp_dir


### PR DESCRIPTION
When doing zaza runs in parallel, or when running CMR tests, the
resources that the tests create and store on local disk (private
keys, certificates etc) can overwrite each other. This PR adds
support for a model specific temporary directory that the tests
can safely use.