### PR TITLE
Travis tests are failing due to lxd channel  3.20/stable being awol

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ comment: |
 script:
   - if [ $ENV = 'func' ]; then
        sudo apt remove -y --purge lxd lxd-client;
-       sudo snap install --channel=3.20/stable lxd;
+       sudo snap install --stable lxd;
        sudo snap install --classic juju;
        sudo sh -c 'echo PATH=/snap/bin:$PATH >> /etc/environment';
        sudo lxd waitready;


### PR DESCRIPTION
Travis tests are failing due to "lxd" is not available on
3.20/stable. Lxd was pinned to that channel due to Bug #1867886
. That bug appears to have been resolved so move to stable.