### PR TITLE
Remove domain name when mapping hostname to units

### DIFF
--- a/unit_tests/utilities/test_zaza_utilities_juju.py
+++ b/unit_tests/utilities/test_zaza_utilities_juju.py
@@ -146,7 +146,7 @@ class TestJujuUtils(ut_utils.BaseTestCase):
                 self.subordinate_application)),
             [self.machine1])
 
-    def test_get_unit_name_from_host_name(self):
+    def test_get_unit_name_from_host_name_maas(self):
         self.assertEqual(
             juju_utils.get_unit_name_from_host_name('juju-model-1', 'app'),
             'app/1')
@@ -154,6 +154,20 @@ class TestJujuUtils(ut_utils.BaseTestCase):
         self.assertEqual(
             juju_utils.get_unit_name_from_host_name('node-jaeger.maas', 'app'),
             'app/2')
+
+    def test_get_unit_name_from_host_name(self):
+        self.patch_object(juju_utils, "get_application_status")
+        self.get_application_status.side_effect = self._get_application_status
+        self.assertEqual(
+            juju_utils.get_unit_name_from_host_name(
+                'juju-model-1',
+                self.application),
+            'app/1')
+        self.assertEqual(
+            juju_utils.get_unit_name_from_host_name(
+                'juju-model-1.project.serverstack',
+                self.application),
+            'app/1')
 
     def test_get_unit_name_from_host_name_bad_app(self):
         self.assertIsNone(

--- a/zaza/utilities/juju.py
+++ b/zaza/utilities/juju.py
@@ -202,6 +202,8 @@ def get_unit_name_from_host_name(host_name, application, model_name=None):
         # This is probably a non-maas deploy.
         if not machine_number:
             try:
+                # Remove domain name if it is present.
+                host_name = host_name.split('.')[0]
                 # Assume that a juju managed hostname always ends in the
                 # machine number.
                 machine_number = int(host_name.split('-')[-1])


### PR DESCRIPTION
Remove the domain name when trying to derive the machine number
from the hostname. This bug was introduced when the duplicate
`get_unit_name_from_host_name` functions were consolidated and
a wrapper put around the z-o-t version to point at this one. The
domain name was correctly removed by the old z-o-t version.