### PR TITLE
Always check for local overlay override

### DIFF
--- a/unit_tests/test_zaza_charm_lifecycle_deploy.py
+++ b/unit_tests/test_zaza_charm_lifecycle_deploy.py
@@ -248,6 +248,7 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
         _bundle = "bundle.yaml"
 
         # File exists no bundle override
+        self.get_charm_config.return_value = {}
         self.assertTrue(lc_deploy.should_render_local_overlay(_bundle))
 
         # File exists bundle overrides False
@@ -256,12 +257,20 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
 
         # No file, charm_name present
         self.isfile.return_value = False
+        self.is_local_overlay_enabled_in_bundle.return_value = True
         self.get_charm_config.return_value = {"charm_name": "CHARM"}
         self.assertTrue(lc_deploy.should_render_local_overlay(_bundle))
 
         # No file, charm_name not present
         self.isfile.return_value = False
+        self.is_local_overlay_enabled_in_bundle.return_value = True
         self.get_charm_config.return_value = {}
+        self.assertFalse(lc_deploy.should_render_local_overlay(_bundle))
+
+        # No file, charm_name present, bundle override set to False
+        self.isfile.return_value = False
+        self.get_charm_config.return_value = {"charm_name": "CHARM"}
+        self.is_local_overlay_enabled_in_bundle.return_value = False
         self.assertFalse(lc_deploy.should_render_local_overlay(_bundle))
 
     def test_render_overlays(self):

--- a/zaza/charm_lifecycle/deploy.py
+++ b/zaza/charm_lifecycle/deploy.py
@@ -262,18 +262,15 @@ def should_render_local_overlay(bundle):
     :rtype: bool
     """
     # Is there a local overlay file?
-    if os.path.isfile(
-            os.path.join(
-                DEFAULT_OVERLAY_TEMPLATE_DIR,
-                "{}.j2".format(LOCAL_OVERLAY_TEMPLATE_NAME))):
+    overlay = os.path.join(
+        DEFAULT_OVERLAY_TEMPLATE_DIR,
+        "{}.j2".format(LOCAL_OVERLAY_TEMPLATE_NAME))
+    charm_name = utils.get_charm_config().get('charm_name', None)
+    if os.path.isfile(overlay) or charm_name:
         # Check for an override in the bundle.
         # Note: the default is True if the LOCAL_OVERLAY_ENABLED_KEY
         # is not present.
         return is_local_overlay_enabled_in_bundle(bundle)
-    # Should we render the LOCAL_OVERLAY_TEMPLATE?
-    elif utils.get_charm_config().get('charm_name', None):
-        # Need to convert to boolean
-        return True
     return False
 
 


### PR DESCRIPTION
The local_overlay_enabled flag in a bundle was being ignored if
there was a charm_name in the tests.yaml. There are valid use cases
for having a charm_name in tests.yaml and needing to disable the
local overlay (such as cmr testing). This patch closes issue #379.