### PR TITLE
Add function to format an IP address

### DIFF
--- a/unit_tests/utilities/test_zaza_utilities_networking.py
+++ b/unit_tests/utilities/test_zaza_utilities_networking.py
@@ -1,0 +1,28 @@
+# Copyright 2020 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import zaza.utilities.networking as network_utils
+
+
+class TestUtils(unittest.TestCase):
+
+    def test_format_addr(self):
+        self.assertEquals('1.2.3.4', network_utils.format_addr('1.2.3.4'))
+        self.assertEquals(
+            '[2001:db8::42]', network_utils.format_addr('2001:db8::42'))
+        with self.assertRaises(ValueError):
+            network_utils.format_addr('999.999.999.999')
+        with self.assertRaises(ValueError):
+            network_utils.format_addr('2001:db8::g')

--- a/zaza/utilities/networking.py
+++ b/zaza/utilities/networking.py
@@ -1,0 +1,33 @@
+# Copyright 2018 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Module for working with networking."""
+
+import ipaddress
+
+
+def format_addr(addr):
+    """Validate and format IP address.
+
+    :param addr: IPv6 or IPv4 address
+    :type addr: str
+    :returns: Address string, optionally encapsulated in brackets([])
+    :rtype: str
+    :raises: ValueError
+    """
+    ipaddr = ipaddress.ip_address(addr)
+    if isinstance(ipaddr, ipaddress.IPv6Address):
+        fmt = '[{}]'
+    else:
+        fmt = '{}'
+    return fmt.format(ipaddr)


### PR DESCRIPTION
This change is migrating a function that exists in [zaza-openstack-tests](https://github.com/openstack-charmers/zaza-openstack-tests/blob/29356f6419ef76dd182c63322bdba5edcfcefac9/zaza/openstack/charm_tests/test_utils.py#L546-L560) to Zaza, as it is not an OpenStack specific helper.