### PR TITLE
Ensure action result keys are consistent.

### DIFF
--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -459,7 +459,33 @@ class TestModel(ut_utils.BaseTestCase):
 
     def test_run_on_unit(self):
         self.patch_object(model, 'get_juju_model', return_value='mname')
-        expected = {'Code': '0', 'Stderr': '', 'Stdout': 'RESULT'}
+        expected = {
+            'Code': '0',
+            'Stderr': '',
+            'Stdout': 'RESULT',
+            'stderr': '',
+            'stdout': 'RESULT'}
+        self.cmd = cmd = 'somecommand someargument'
+        self.patch_object(model, 'Model')
+        self.patch_object(model, 'get_unit_from_name')
+        self.get_unit_from_name.return_value = self.unit1
+        self.Model.return_value = self.Model_mock
+        self.assertEqual(model.run_on_unit('app/2', cmd),
+                         expected)
+        self.unit1.run.assert_called_once_with(cmd, timeout=None)
+
+    def test_run_on_unit_lc_keys(self):
+        self.patch_object(model, 'get_juju_model', return_value='mname')
+        self.action.data['results'] = {
+            'Code': '0',
+            'stdout': 'RESULT',
+            'stderr': 'some error'}
+        expected = {
+            'Code': '0',
+            'Stderr': 'some error',
+            'Stdout': 'RESULT',
+            'stderr': 'some error',
+            'stdout': 'RESULT'}
         self.cmd = cmd = 'somecommand someargument'
         self.patch_object(model, 'Model')
         self.patch_object(model, 'get_unit_from_name')
@@ -471,7 +497,12 @@ class TestModel(ut_utils.BaseTestCase):
 
     def test_run_on_unit_missing_stderr(self):
         self.patch_object(model, 'get_juju_model', return_value='mname')
-        expected = {'Code': '0', 'Stderr': '', 'Stdout': 'RESULT'}
+        expected = {
+            'Code': '0',
+            'Stderr': '',
+            'Stdout': 'RESULT',
+            'stderr': '',
+            'stdout': 'RESULT'}
         self.action.data['results'] = {'Code': '0', 'Stdout': 'RESULT'}
         self.cmd = cmd = 'somecommand someargument'
         self.patch_object(model, 'Model')
@@ -484,7 +515,12 @@ class TestModel(ut_utils.BaseTestCase):
 
     def test_run_on_leader(self):
         self.patch_object(model, 'get_juju_model', return_value='mname')
-        expected = {'Code': '0', 'Stderr': '', 'Stdout': 'RESULT'}
+        expected = {
+            'Code': '0',
+            'Stderr': '',
+            'Stdout': 'RESULT',
+            'stderr': '',
+            'stdout': 'RESULT'}
         self.cmd = cmd = 'somecommand someargument'
         self.patch_object(model, 'Model')
         self.Model.return_value = self.Model_mock

--- a/zaza/model.py
+++ b/zaza/model.py
@@ -284,7 +284,7 @@ def _normalise_action_results(results):
     :rtype: Dict[str, str]
     """
     if results:
-        # In Juju 2.7 some keys are dropped from the results if there
+        # In Juju 2.7 some keys are dropped from the results if their
         # value was empty. This breaks some functions downstream, so
         # ensure the keys are always present.
         for key in ['Stderr', 'Stdout', 'stderr', 'stdout']:

--- a/zaza/model.py
+++ b/zaza/model.py
@@ -273,7 +273,7 @@ scp_from_unit = sync_wrapper(async_scp_from_unit)
 def _normalise_action_results(results):
     """Put action results in a consistent format.
 
-    :param results: Command to execute
+    :param results: Results dictionary to process.
     :type results: Dict[str, str]
     :returns: {
         'Code': '',


### PR DESCRIPTION
Juju has started using a lowercase "stdout" key in new action commands in
recent Juju versions. Ensure that the new and the old key are present in the
results.

https://github.com/juju/juju/blame/6a73647d12471a93d0099f3a5f7fb803de678028/cmd/juju/action/showoutput.go#L399-L403
https://github.com/juju/juju/blame/6a73647d12471a93d0099f3a5f7fb803de678028/cmd/juju/action/showoutput.go#L55-L56
https://github.com/juju/juju/commit/bfd0d9dc166d71bf390c63b822002da9b1c8153e#diff-4d62021012bcd3dbf2b0cc1462125c4fR266-R273