### PR TITLE
Pin oslo.context when running PY35 tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ Jinja2>=2.6  # BSD License (3 clause)
 six>=1.9.0
 dnspython>=1.12.0
 psutil>=1.1.1,<2.0.0
+oslo.context<3.0.0;python_version < '3.6'  # pin for py3.5 support
 python-openstackclient>=3.14.0
 aodhclient
 python-designateclient


### PR DESCRIPTION
oslo.context 3.0.0+ only works for python3.6.  Pin it for earlier
versions.