### PR TITLE
Pin osprofiler when running PY35 tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ six>=1.9.0
 dnspython>=1.12.0
 psutil>=1.1.1,<2.0.0
 oslo.context<3.0.0;python_version < '3.6'  # pin for py3.5 support
+osprofiler<3.0.0;python_version < '3.6'  # pin for py3.5 support
 python-openstackclient>=3.14.0
 aodhclient
 python-designateclient


### PR DESCRIPTION
osprofiler 3.0.0+ only works for python3.6.  Pin it for earlier
versions.