### PR TITLE
Fix return code checking in check_output_logging

### DIFF
--- a/unit_tests/test_zaza_charm_lifecycle_utils.py
+++ b/unit_tests/test_zaza_charm_lifecycle_utils.py
@@ -232,6 +232,7 @@ class TestCharmLifecycleUtils(ut_utils.BaseTestCase):
         popen_mock.stdout = io.StringIO("logline1\nlogline2\nlogline3\n")
         poll_output = [0, 0, None, None, None]
         popen_mock.poll.side_effect = poll_output.pop
+        popen_mock.returncode = 0
         self.Popen.return_value = popen_mock
         lc_utils.check_output_logging(['cmd', 'arg1', 'arg2'])
         log_calls = [
@@ -245,8 +246,9 @@ class TestCharmLifecycleUtils(ut_utils.BaseTestCase):
         self.patch_object(lc_utils.subprocess, 'Popen')
         popen_mock = mock.MagicMock()
         popen_mock.stdout = io.StringIO("logline1\n")
-        poll_output = [1, 1, None]
+        poll_output = [0, 0, None]
         popen_mock.poll.side_effect = poll_output.pop
+        popen_mock.returncode = 1
         self.Popen.return_value = popen_mock
         with self.assertRaises(subprocess.CalledProcessError):
             lc_utils.check_output_logging(['cmd', 'arg1', 'arg2'])

--- a/zaza/charm_lifecycle/utils.py
+++ b/zaza/charm_lifecycle/utils.py
@@ -19,6 +19,7 @@ import logging
 import os
 import subprocess
 import uuid
+import time
 import sys
 import yaml
 
@@ -438,6 +439,7 @@ def check_output_logging(cmd):
             break
         logging.info(line.strip())
     popen.stdout.close()
-    return_code = popen.poll()
-    if return_code:
-        raise subprocess.CalledProcessError(return_code, cmd)
+    while popen.poll() is None:
+        time.sleep(0.5)
+    if popen.returncode:
+        raise subprocess.CalledProcessError(popen.returncode, cmd)


### PR DESCRIPTION
If the child process had not exited before the returncode was checked
then check_output_logging would fail to catch the returncode of
the child process. This is because popen.poll() returns None if the
child process is still running *1.  This change adds a wait to ensure
that the child process is complete before checking the returncode.
Closes issue #342
