### PR TITLE
Strip whitespace from the passed bundle for func-test-runner

### DIFF
--- a/zaza/charm_lifecycle/func_test_runner.py
+++ b/zaza/charm_lifecycle/func_test_runner.py
@@ -119,9 +119,9 @@ def func_test_runner(keep_model=False, smoke=False, dev=False, bundle=None,
             utils.EnvironmentDeploy(
                 'default',
                 [utils.ModelDeploy(
-                    model_alias,
+                    model_alias.strip(),
                     utils.generate_model_name(),
-                    bundle)],
+                    bundle.strip())],
                 True)]
     else:
         if smoke:


### PR DESCRIPTION
This is so that it's a bit more rubust when passing model_alias:bundle
into the func-test-runner as most written combinations in tests.yaml
have a space (as it's a 'hash' in the yaml) but really, it's treated as
a string when passed directly.  We probably should use something other
that ':' as the divider as that means something in yaml.