### PR TITLE
Change some of the model functions to work better when used concurrently

### DIFF
--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -1903,31 +1903,31 @@ class AsyncModelTests(aiounittest.AsyncTestCase):
     async def test_run_on_machine(self):
         with mock.patch.object(
             model.generic_utils,
-            'check_call'
-        ) as check_call:
+            'check_output'
+        ) as check_output:
             await model.async_run_on_machine('1', 'test')
-        check_call.assert_called_once_with(
-            ['juju', 'run', '--machine=1', 'test'])
+        check_output.assert_called_once_with(
+            ['juju', 'run', '--machine=1', '--', 'test'])
 
     async def test_run_on_machine_with_timeout(self):
         # self.patch_object(model.generic_utils, 'check_call')
         with mock.patch.object(
             model.generic_utils,
-            'check_call'
-        ) as check_call:
+            'check_output'
+        ) as check_output:
             await model.async_run_on_machine('1', 'test', timeout='20m')
-        check_call.assert_called_once_with(
-            ['juju', 'run', '--machine=1', '--timeout=20m', 'test'])
+        check_output.assert_called_once_with(
+            ['juju', 'run', '--machine=1', '--timeout=20m', '--', 'test'])
 
     async def test_run_on_machine_with_model(self):
         # self.patch_object(model.generic_utils, 'check_call')
         with mock.patch.object(
             model.generic_utils,
-            'check_call'
-        ) as check_call:
+            'check_output'
+        ) as check_output:
             await model.async_run_on_machine('1', 'test', model_name='test')
-        check_call.assert_called_once_with(
-            ['juju', 'run', '--machine=1', '--model=test', 'test'])
+        check_output.assert_called_once_with(
+            ['juju', 'run', '--machine=1', '--model=test', '--', 'test'])
 
     async def test_async_get_agent_status(self):
         model_mock = mock.MagicMock()

--- a/zaza/model.py
+++ b/zaza/model.py
@@ -2354,6 +2354,7 @@ async def async_run_on_machine(
         cmd.append('--model={}'.format(model_name))
     if timeout:
         cmd.append('--timeout={}'.format(timeout))
+    cmd.append('--')
     cmd.append(command)
     logging.info("About to call '{}'".format(cmd))
     return await generic_utils.check_output(cmd)

--- a/zaza/model.py
+++ b/zaza/model.py
@@ -1635,16 +1635,14 @@ async def async_block_until_file_missing_on_machine(
     :type path: str
     :param model_name: Name of model to query.
     :type model_name: str
-    :param timeout: Time to wait for contents to appear in file
+    :param timeout: Time to wait for until file is missing on a machine.
     :type timeout: float
     """
     async def _check_for_file(model):
         try:
-            # output = await unit.run('test -e "{}"; echo $?'.format(path))
             output = await async_run_on_machine(
                 machine, 'test -e "{}"; echo $?'.format(path),
                 model_name)
-            # contents = output.data.get('results')['Stdout']
             contents = output.get('Stdout', "")
             return "1" in contents
         # libjuju throws a generic error for connection failure. So we
@@ -1672,7 +1670,7 @@ async def async_block_until_units_on_machine_are_idle(
     :type machine: str
     :param model_name: Name of model to query.
     :type model_name: str
-    :param timeout: Time to wait for contents to appear in file
+    :param timeout: Time to wait for units on machine to be idle.
     :type timeout: float
     """
     async def _ready():
@@ -1695,7 +1693,7 @@ async def async_block_until_units_on_machine_are_idle(
         for app in apps:
             for u_name, u_bag in _status.applications[app]['units'].items():
                 if u_name in units:
-                    subordinates = u_bag.get('subordinates', [])
+                    subordinates = u_bag.get('subordinates', {})
                     statuses.extend([
                         unit['agent-status']['status'] == 'idle'
                         for unit in subordinates.values()])

--- a/zaza/utilities/generic.py
+++ b/zaza/utilities/generic.py
@@ -664,6 +664,22 @@ async def check_call(cmd):
     :type cmd: List[str]
     :returns: None
     :rtype: None
+    :raises: subprocess.CalledProcessError if returncode !=0
+    """
+    await check_output(cmd)
+
+
+async def check_output(cmd):
+    """Asynchronous function to run a subprocess and get the output.
+
+    Note, as the code raises an Exception on returncode != 0, 'Code' in the
+    dictionary will always be '0'.  This is included for compatability reasons.
+
+    :param cmd: Command to execute
+    :type cmd: List[str]
+    :returns: {'Code': '', 'Stderr': '', 'Stdout': ''}
+    :rtype: dict
+    :raises: subprocess.CalledProcessError if returncode !=0
     """
     proc = await asyncio.create_subprocess_exec(
         *cmd,
@@ -681,3 +697,8 @@ async def check_call(cmd):
             logging.info("STDERR: {} ({})".format(stderr, ' '.join(cmd)))
         if stdout:
             logging.info("STDOUT: {} ({})".format(stdout, ' '.join(cmd)))
+    return {
+        'Code': str(proc.returncode),
+        'Stderr': stderr,
+        'Stdout': stdout,
+    }


### PR DESCRIPTION
Specifically the async_get_status function can now be 'limited' in the speed at which it re-requests the status from the model.  This, by default, is 'off' (i.e. previous behaviour), but when 'on' the function will limit the speed of response and optionally either return the cached value immediately, or simply wait for the predetermined period (using an async wait) before refetching the status and then returning.

This limits the 'strain' on the controller when doing multiple async / concurrent checks (e.g. series upgrade on a large model).

Secondly, additional functionality to the check_output function to return stderr and stdout.