### PR TITLE
Add MAAS helpers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,6 +35,7 @@ python-swiftclient
 tenacity
 distro-info
 paramiko
+python-libmaas
 # Documentation requirements
 sphinx
 sphinxcontrib-asyncio

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ install_require = [
     'juju-wait',
     'PyYAML',
     'tenacity',
+    'python-libmaas',
 ]
 
 tests_require = [

--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -2016,3 +2016,16 @@ class AsyncModelTests(aiounittest.AsyncTestCase):
                 unitb = await model.async_get_principle_unit('absent-app/0')
         self.assertEqual(unita, 'app/0')
         self.assertIsNone(unitb)
+
+    async def test_async_get_cloud_data(self):
+        with mock.patch.object(model, 'run_in_model'):
+            with mock.patch.object(
+                    model.juju.client.jujudata, 'FileJujuData') as juju_data:
+                juju_data().load_credential.return_value = (
+                    'fake-cred-name', 'fake-cred')
+                result = await model.async_get_cloud_data()
+                self.assertIsInstance(result, model.CloudData)
+                self.assertEquals(result.cloud_name, mock.ANY)
+                self.assertEquals(result.cloud, mock.ANY)
+                self.assertEquals(result.credential_name, 'fake-cred-name')
+                self.assertEquals(result.credential, 'fake-cred')

--- a/unit_tests/utilities/test_zaza_utilities_maas.py
+++ b/unit_tests/utilities/test_zaza_utilities_maas.py
@@ -1,0 +1,158 @@
+# Copyright 2021 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest.mock as mock
+
+import zaza
+import zaza.utilities.maas as maas
+import unit_tests.utils as ut_utils
+
+
+class TestUtilitiesMaas(ut_utils.BaseTestCase):
+
+    def setUp(self):
+        super(TestUtilitiesMaas, self).setUp()
+        self.m1_interface1 = mock.MagicMock()
+        self.m1_link1 = mock.MagicMock()
+        self.m1_link1.subnet.cidr = '192.0.2.0/24'
+        self.m1_link1.mode = maas.LinkMode.LINK_UP
+        self.m1_interface2 = mock.MagicMock()
+        self.m1_link2 = mock.MagicMock()
+        self.m1_link2.subnet.cidr = '198.51.100.0/24'
+        self.m1_link2.mode = maas.LinkMode.AUTO
+        self.m1_interface2.links.__iter__.return_value = [self.m1_link2]
+        self.m1_interface1.links.__iter__.return_value = [self.m1_link1]
+        self.machine1 = mock.MagicMock()
+        self.machine1.interfaces.__iter__.return_value = [
+            self.m1_interface1,
+            self.m1_interface2,
+        ]
+
+        self.m2_interface1 = mock.MagicMock()
+        self.m2_link1 = mock.MagicMock()
+        self.m2_link1.subnet.cidr = '192.0.2.0/24'
+        self.m2_link1.mode = maas.LinkMode.AUTO
+        self.m2_interface2 = mock.MagicMock()
+        self.m2_link2 = mock.MagicMock()
+        self.m2_link2.subnet.cidr = '198.51.100.0/24'
+        self.m2_link2.mode = maas.LinkMode.LINK_UP
+        self.m2_interface2.links.__iter__.return_value = [self.m2_link2]
+        self.m2_interface1.links.__iter__.return_value = [self.m2_link1]
+        self.machine2 = mock.MagicMock()
+        self.machine2.interfaces.__iter__.return_value = [
+            self.m2_interface1,
+            self.m2_interface2,
+        ]
+
+        async def f():
+            return [self.machine1, self.machine2]
+        self.maas_client = mock.MagicMock()
+        self.maas_client.machines.list.side_effect = f
+
+    def test_get_maas_client(self):
+
+        async def f(*args, **kwargs):
+            pass
+
+        self.patch_object(maas.maas.client, 'connect')
+        self.connect.side_effect = f
+        maas.get_maas_client('FakeURL', 'FakeAPIKey')
+        self.connect.assert_called_once_with('FakeURL', apikey='FakeAPIKey')
+
+    def test_get_machine_interfaces(self):
+        async def af():
+            async for machine, interface in maas.get_machine_interfaces(
+                    self.maas_client):
+                if machine == self.machine1:
+                    self.assertIn(
+                        interface, (self.m1_interface1, self.m1_interface2))
+                elif machine == self.machine2:
+                    self.assertIn(
+                        interface, (self.m2_interface1, self.m2_interface2))
+                else:
+                    self.assertIn(machine, (self.machine1, self.machine2))
+        f = zaza.sync_wrapper(af)
+        f()
+
+    def test_get_macs_from_cidr(self):
+        self.maxDiff = None
+        self.assertEquals(
+            maas.get_macs_from_cidr(self.maas_client, '192.0.2.0/24'),
+            [
+                maas.MachineInterfaceMac(
+                    self.machine1.system_id,
+                    self.m1_interface1.name,
+                    self.m1_interface1.mac_address,
+                    '192.0.2.0/24',
+                    mock.ANY),
+                maas.MachineInterfaceMac(
+                    self.machine2.system_id,
+                    self.m2_interface1.name,
+                    self.m2_interface1.mac_address,
+                    '192.0.2.0/24',
+                    mock.ANY),
+            ])
+        self.assertEquals(
+            maas.get_macs_from_cidr(self.maas_client, '192.0.2.0/24',
+                                    link_mode=maas.LinkMode.LINK_UP),
+            [
+                maas.MachineInterfaceMac(
+                    self.machine1.system_id,
+                    self.m1_interface1.name,
+                    self.m1_interface1.mac_address,
+                    '192.0.2.0/24',
+                    maas.LinkMode.LINK_UP),
+            ])
+        self.assertEquals(
+            maas.get_macs_from_cidr(self.maas_client, '192.0.2.0/24',
+                                    link_mode=maas.LinkMode.AUTO),
+            [
+                maas.MachineInterfaceMac(
+                    self.machine2.system_id,
+                    self.m2_interface1.name,
+                    self.m2_interface1.mac_address,
+                    '192.0.2.0/24',
+                    maas.LinkMode.AUTO),
+            ])
+        self.assertEquals(
+            maas.get_macs_from_cidr(self.maas_client, '198.51.100.0/24'),
+            [
+                maas.MachineInterfaceMac(
+                    self.machine1.system_id,
+                    self.m1_interface2.name,
+                    self.m1_interface2.mac_address,
+                    '198.51.100.0/24',
+                    mock.ANY),
+                maas.MachineInterfaceMac(
+                    self.machine2.system_id,
+                    self.m2_interface2.name,
+                    self.m2_interface2.mac_address,
+                    '198.51.100.0/24',
+                    mock.ANY),
+            ])
+
+        async def fget(*args):
+            return self.machine2
+        self.maas_client.machines.get.side_effect = fget
+        self.assertEquals(
+            maas.get_macs_from_cidr(self.maas_client, '198.51.100.0/24',
+                                    machine_id=self.machine2.system_id),
+            [
+                maas.MachineInterfaceMac(
+                    self.machine2.system_id,
+                    self.m2_interface2.name,
+                    self.m2_interface2.mac_address,
+                    '198.51.100.0/24',
+                    mock.ANY),
+            ])

--- a/unit_tests/utilities/test_zaza_utilities_maas.py
+++ b/unit_tests/utilities/test_zaza_utilities_maas.py
@@ -72,7 +72,7 @@ class TestUtilitiesMaas(ut_utils.BaseTestCase):
 
     def test_get_machine_interfaces(self):
         async def af():
-            async for machine, interface in maas.get_machine_interfaces(
+            async for machine, interface in maas.async_get_machine_interfaces(
                     self.maas_client):
                 if machine == self.machine1:
                     self.assertIn(

--- a/zaza/utilities/maas.py
+++ b/zaza/utilities/maas.py
@@ -1,0 +1,110 @@
+# Copyright 2021 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Module for interacting with MAAS."""
+
+import collections
+
+import maas.client
+import maas.client.enum
+import maas.client.utils.maas_async as maas_async
+
+# Re-export the LinkMode enum to save our consumers the trouble of figuring out
+# the python-libmaas internal module path to it.
+from maas.client.enum import LinkMode  # noqa
+
+import zaza
+
+
+async def async_get_maas_client(maas_url, apikey):
+    """Get a connected MAAS client.
+
+    :param maas_url: URL to MAAS API.
+    :type maas_url: str
+    :param apikey: MAAS API Key for authentication.
+    :type apikey: str
+    :returns: Connected MAAS client.
+    :rtpye: maas.client.facade.Client object.
+    """
+    return await maas.client.connect(maas_url, apikey=apikey)
+
+get_maas_client = zaza.sync_wrapper(async_get_maas_client)
+
+
+async def async_get_machine_interfaces(maas_client, machine_id=None,
+                                       link_mode=None, cidr=None):
+    """Get machine and interface objects, optionally apply filters.
+
+    :param maas_client: MAAS Client object.
+    :type maas_client: maas.client.facade.Client
+    :param machine_id: ID of a specific machine to get information on.
+    :type machine_id: Optional[str]
+    :param link_mode: Only return interfaces with this link_mode.
+    :type link_mode: Optional[LinkMode]
+    :param cidr: Only return interfaces connected this CIDR.
+    :type cidr: Optional[str]
+    :returns: Async generator object
+    :rtype: async Iterator[maas.client.viscera.machines.Machine,
+                           maas.client.viscera.interfaces.Interface]
+    """
+    if machine_id:
+        machines = [await maas_client.machines.get(machine_id)]
+    else:
+        machines = await maas_client.machines.list()
+    for machine in machines:
+        for interface in machine.interfaces:
+            for link in interface.links:
+                if link_mode and link.mode != link_mode:
+                    continue
+                if cidr and link.subnet and link.subnet.cidr != cidr:
+                    continue
+                yield machine, interface
+
+# The Zaza sync_wrapper is not smart enough to handle async generators yet,
+# let's use MAAS's equivivalent for that.
+get_machine_interfaces = maas_async.asynchronous(async_get_machine_interfaces)
+
+
+MachineInterfaceMac = collections.namedtuple(
+    'MachineInterfaceMac',
+    ['machine_id', 'ifname', 'mac', 'cidr', 'link_mode'])
+
+
+async def async_get_macs_from_cidr(maas_client, cidr, machine_id=None,
+                                   link_mode=None):
+    """Get interface mac addresses from machines connected to cidr.
+
+    :param maas_client: MAAS Client object.
+    :type maas_client: maas.client.facade.Client
+    :param cidr: Only return interfaces connected this CIDR.
+    :type cidr: str
+    :param machine_id: ID of a specific machine to get information on.
+    :type machine_id: Optional[str]
+    :param link_mode: Only return interfaces with this link_mode.
+    :type link_mode: Optional[LinkMode]
+    :returns: List of MachineInterfaceMac tuples.
+    :rtype: List[MachineInterfaceMac[str,str,str,str,LinkMode]]
+    """
+    # We build a list and return that as async generators are a bit too much to
+    # spring on a causal consumer of this module.
+    result = []
+    async for machine, interface in get_machine_interfaces(
+            maas_client, machine_id=machine_id,
+            link_mode=link_mode, cidr=cidr):
+        for link in interface.links:
+            result.append(MachineInterfaceMac(
+                machine.system_id, interface.name, interface.mac_address,
+                link.subnet.cidr, link.mode))
+    return result
+
+get_macs_from_cidr = zaza.sync_wrapper(async_get_macs_from_cidr)

--- a/zaza/utilities/maas.py
+++ b/zaza/utilities/maas.py
@@ -26,6 +26,21 @@ from maas.client.enum import LinkMode  # noqa
 import zaza
 
 
+def get_maas_client_from_juju_cloud_data(cloud_data):
+    """Get a connected MAAS client from Juju Cloud data.
+
+    :param cloud_data: Juju Cloud and Credential data
+    :type cloud_data: zaza.model.CloudData
+    :returns: Connected MAAS client.
+    :rtpye: maas.client.facade.Client object.
+    :raises: AssertionError
+    """
+    assert cloud_data.cloud.type_ == 'maas', "cloud_data not for MAAS cloud."
+    maas_url = cloud_data.cloud['endpoint']
+    apikey = cloud_data.credential['attrs']['maas-oauth']
+    return get_maas_client(maas_url, apikey)
+
+
 async def async_get_maas_client(maas_url, apikey):
     """Get a connected MAAS client.
 


### PR DESCRIPTION
Test and setup code have use for some details that are not
available from Juju.

Examples:
- MAC address and subnet information for physical interfaces with
  no IP address assigned.
- Underlying storage configuration.