### PR TITLE
Update relative path to not depend on charm name

### DIFF
--- a/unit_tests/test_zaza_charm_lifecycle_deploy.py
+++ b/unit_tests/test_zaza_charm_lifecycle_deploy.py
@@ -28,13 +28,13 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
         self.get_deployment_context.return_value = {
             'OS_VIP04': '10.10.0.2'}
         self.get_charm_config_context.return_value = {
-            'charm_location': '../../.',
+            'charm_location': '../..',
             'charm_name': 'mycharm'}
         self.assertEqual(
             lc_deploy.get_template_overlay_context(),
             {
                 'OS_VIP04': '10.10.0.2',
-                'charm_location': '../../.',
+                'charm_location': '../..',
                 'charm_name': 'mycharm'})
 
     def test_get_charm_config_context(self):
@@ -45,7 +45,7 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
         self.abspath.return_value = '/some/absolute/path'
         self.assertEqual(
             lc_deploy.get_charm_config_context(),
-            {'charm_location': '/some/absolute/path/../../.',
+            {'charm_location': '/some/absolute/path',
              'charm_name': 'mycharm'})
 
     def test_get_overlay_template_dir(self):

--- a/unit_tests/test_zaza_charm_lifecycle_deploy.py
+++ b/unit_tests/test_zaza_charm_lifecycle_deploy.py
@@ -28,13 +28,13 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
         self.get_deployment_context.return_value = {
             'OS_VIP04': '10.10.0.2'}
         self.get_charm_config_context.return_value = {
-            'charm_location': '../../../mycharm',
+            'charm_location': '../../.',
             'charm_name': 'mycharm'}
         self.assertEqual(
             lc_deploy.get_template_overlay_context(),
             {
                 'OS_VIP04': '10.10.0.2',
-                'charm_location': '../../../mycharm',
+                'charm_location': '../../.',
                 'charm_name': 'mycharm'})
 
     def test_get_charm_config_context(self):
@@ -45,7 +45,7 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
         self.abspath.return_value = '/some/absolute/path'
         self.assertEqual(
             lc_deploy.get_charm_config_context(),
-            {'charm_location': '/some/absolute/path/../../../mycharm',
+            {'charm_location': '/some/absolute/path/../../.',
              'charm_name': 'mycharm'})
 
     def test_get_overlay_template_dir(self):

--- a/zaza/charm_lifecycle/deploy.py
+++ b/zaza/charm_lifecycle/deploy.py
@@ -54,7 +54,7 @@ def get_charm_config_context():
     test_config = utils.get_charm_config()
     ctxt = {
         'charm_name': test_config['charm_name'],
-        'charm_location': '{}/../../.'.format(bundle_dir_abspath),
+        'charm_location': os.path.abspath(f"{bundle_dir_abspath}/../.."),
     }
     return ctxt
 

--- a/zaza/charm_lifecycle/deploy.py
+++ b/zaza/charm_lifecycle/deploy.py
@@ -54,7 +54,9 @@ def get_charm_config_context():
     test_config = utils.get_charm_config()
     ctxt = {
         'charm_name': test_config['charm_name'],
-        'charm_location': os.path.abspath(f"{bundle_dir_abspath}/../.."),
+        'charm_location': os.path.abspath(
+            "{}/../..".format(bundle_dir_abspath)
+        ),
     }
     return ctxt
 

--- a/zaza/charm_lifecycle/deploy.py
+++ b/zaza/charm_lifecycle/deploy.py
@@ -54,9 +54,7 @@ def get_charm_config_context():
     test_config = utils.get_charm_config()
     ctxt = {
         'charm_name': test_config['charm_name'],
-        'charm_location': '{}/../../../{}'
-                          .format(bundle_dir_abspath,
-                                  test_config['charm_name']),
+        'charm_location': '{}/../../.'.format(bundle_dir_abspath),
     }
     return ctxt
 


### PR DESCRIPTION
As initially discussed on on a glance bug report [1], this will allow Zaza to deploy the charm even if the charm name doesn't match the directory name.

[1] https://bugs.launchpad.net/charm-glance/+bug/1913498