### PR TITLE
Fix AttributeError in maas.get_macs_from_cidr()

### DIFF
--- a/zaza/utilities/maas.py
+++ b/zaza/utilities/maas.py
@@ -83,7 +83,7 @@ async def async_get_machine_interfaces(maas_client, machine_id=None,
             for link in interface.links:
                 if link_mode and link.mode != link_mode:
                     continue
-                if cidr and link.subnet and link.subnet.cidr != cidr:
+                if cidr and (link.subnet is None or link.subnet.cidr != cidr):
                     continue
                 await yield_((machine, interface))
 


### PR DESCRIPTION
When running Zaza against MAAS, if some interfaces aren't
attached to a subnet, get_machine_interfaces() will yield
items where link.subnet is None. get_macs_from_cidr() will
then raise when trying to access link.subnet.cidr

This fix makes sure that get_machine_interfaces() called
with a CIDR criterion won't yield items where link.subnet
is None.

Without this fix, when validating [openstack-bundles/development/openstack-base-bionic-ussuri-ovn](https://github.com/openstack-charmers/openstack-bundles/blob/master/development/openstack-base-bionic-ussuri-ovn/tests/tests.yaml) on MAAS we end up with

```
Traceback (most recent call last):
  File "/home/ubuntu/Documents/git/openstack-bundles/development/openstack-base-bionic-ussuri-ovn/.tox/func/bin/functest-run-suite", line 8, in <module>
    sys.exit(main())
  File "/home/ubuntu/Documents/git/openstack-bundles/development/openstack-base-bionic-ussuri-ovn/.tox/func/lib/python3.8/site-packages/zaza/charm_lifecycle/func_test_runner.py", line 272, in main
    func_test_runner(
  File "/home/ubuntu/Documents/git/openstack-bundles/development/openstack-base-bionic-ussuri-ovn/.tox/func/lib/python3.8/site-packages/zaza/charm_lifecycle/func_test_runner.py", line 212, in func_test_runner
    run_env_deployment(env_deployment, keep_model=preserve_model,
  File "/home/ubuntu/Documents/git/openstack-bundles/development/openstack-base-bionic-ussuri-ovn/.tox/func/lib/python3.8/site-packages/zaza/charm_lifecycle/func_test_runner.py", line 140, in run_env_deployment
    configure.configure(
  File "/home/ubuntu/Documents/git/openstack-bundles/development/openstack-base-bionic-ussuri-ovn/.tox/func/lib/python3.8/site-packages/zaza/charm_lifecycle/configure.py", line 51, in configure
    run_configure_list(functions)
  File "/home/ubuntu/Documents/git/openstack-bundles/development/openstack-base-bionic-ussuri-ovn/.tox/func/lib/python3.8/site-packages/zaza/charm_lifecycle/configure.py", line 37, in run_configure_list
    utils.get_class(func)()
  File "/home/ubuntu/Documents/git/openstack-bundles/development/openstack-base-bionic-ussuri-ovn/.tox/func/lib/python3.8/site-packages/zaza/openstack/charm_tests/neutron/setup.py", line 106, in basic_overcloud_network
    openstack_utils.configure_charmed_openstack_on_maas(
  File "/home/ubuntu/Documents/git/openstack-bundles/development/openstack-base-bionic-ussuri-ovn/.tox/func/lib/python3.8/site-packages/zaza/openstack/utilities/openstack.py", line 1036, in configure_charmed_openstack_on_maas
    for mim in zaza.utilities.maas.get_macs_from_cidr(
  File "/home/ubuntu/Documents/git/openstack-bundles/development/openstack-base-bionic-ussuri-ovn/.tox/func/lib/python3.8/site-packages/zaza/__init__.py", line 48, in _wrapper
    return run(_run_it())
  File "/home/ubuntu/Documents/git/openstack-bundles/development/openstack-base-bionic-ussuri-ovn/.tox/func/lib/python3.8/site-packages/zaza/__init__.py", line 36, in run
    return task.result()
  File "/home/ubuntu/Documents/git/openstack-bundles/development/openstack-base-bionic-ussuri-ovn/.tox/func/lib/python3.8/site-packages/zaza/__init__.py", line 47, in _run_it
    return await f(*args, **kwargs)
  File "/home/ubuntu/Documents/git/openstack-bundles/development/openstack-base-bionic-ussuri-ovn/.tox/func/lib/python3.8/site-packages/zaza/utilities/maas.py", line 120, in async_get_macs_from_cidr
    link.subnet.cidr, link.mode))
AttributeError: 'NoneType' object has no attribute 'cidr'
```