### PR TITLE
Fix deploy.py's usage

### DIFF
--- a/zaza/charm_lifecycle/deploy.py
+++ b/zaza/charm_lifecycle/deploy.py
@@ -402,7 +402,8 @@ def parse_args(args):
                         help='Model to deploy to',
                         required=True)
     parser.add_argument('-b', '--bundle',
-                        help='Bundle name (excluding file ext)',
+                        help='Path to bundle file '
+                        '(e.g. ./tests/bundles/groovy-victoria.yaml)',
                         required=True)
     parser.add_argument('-f', '--force', dest='force',
                         help='Pass --force to the juju deploy command',


### PR DESCRIPTION
The command usage was wrong because it said to omit the `.yaml` extension but it is actually required