### PR TITLE
Pin cryptography<3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ install_require = [
     'async_generator',
 
     # Newer versions require a Rust compiler to build, see
-    # https://mail.python.org/pipermail/cryptography-dev/2021-January/001003.html
+    # * https://github.com/openstack-charmers/zaza/issues/421
+    # * https://mail.python.org/pipermail/cryptography-dev/2021-January/001003.html
     'cryptography<3.4',
 
     'hvac<0.7.0',

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,11 @@ version = "0.0.1.dev1"
 install_require = [
     'oslo.config<6.12.0',  # pin at stable/train to retain Py3.5 support
     'async_generator',
-    'cryptography',
+
+    # Newer versions require a Rust compiler to build, see
+    # https://mail.python.org/pipermail/cryptography-dev/2021-January/001003.html
+    'cryptography<3.4',
+
     'hvac<0.7.0',
     'jinja2',
     'juju',


### PR DESCRIPTION
Newer versions require a Rust compiler to build.

This should unblock https://github.com/openstack-charmers/zaza-openstack-tests/pull/369