### PR TITLE
Add keystoneauth1 to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ oslo.context<3.0.0;python_version < '3.6'  # pin for py3.5 support
 osprofiler<3.0.0;python_version < '3.6'  # pin for py3.5 support
 python-openstackclient>=3.14.0
 aodhclient
+keystoneauth1
 python-designateclient
 python-ceilometerclient
 python-cinderclient


### PR DESCRIPTION
keystoneauth1 is a dependency since commit 4cccbdc9 and there are certain
environments where it's doesn't get installed indirectly.

Traceback (most recent call last):
  File ".tox/func/bin/functest-run-suite", line 8, in <module>
    sys.exit(main())
    ...
  File ".tox/func/lib/python3.8/site-packages/zaza/utilities/openstack_provider.py", line 21, in <module>
    from keystoneauth1 import session
ModuleNotFoundError: No module named 'keystoneauth1'