### PR TITLE
Revert "Fix invalid args reference"

### DIFF
--- a/zaza/charm_lifecycle/deploy.py
+++ b/zaza/charm_lifecycle/deploy.py
@@ -426,7 +426,7 @@ def main():
         logging.warn("Using the --force argument for 'juju deploy'. Note "
                      "that this disables juju checks for compatibility.")
     deploy(
-        args.bundles,
+        args.bundle,
         args.model,
         wait=args.wait,
         force=args.force,


### PR DESCRIPTION
This change was invalid as it was mimicking a similiar,
but semantically different, change.

This reverts commit 96f913ac23a6838134e7c0ea8e3f4845798cddee.