### PR TITLE
Add support for guessing the model alias

### DIFF
--- a/unit_tests/test_zaza_charm_lifecycle_func_test_runner.py
+++ b/unit_tests/test_zaza_charm_lifecycle_func_test_runner.py
@@ -415,6 +415,35 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
                 test_directory=None)]
         self.deploy.assert_has_calls(deploy_calls)
 
+    def test_func_test_runner_specify_bundle_with_implicit_alias(self):
+        self.patch_object(lc_func_test_runner.utils, 'get_charm_config')
+        self.patch_object(lc_func_test_runner.utils, 'generate_model_name')
+        self.patch_object(lc_func_test_runner.prepare, 'prepare')
+        self.patch_object(lc_func_test_runner.before_deploy, 'before_deploy')
+        self.patch_object(lc_func_test_runner.deploy, 'deploy')
+        self.patch_object(lc_func_test_runner.configure, 'configure')
+        self.patch_object(lc_func_test_runner.test, 'test')
+        self.patch_object(lc_func_test_runner.destroy, 'destroy')
+        self.patch_object(
+            lc_func_test_runner.zaza.model,
+            'block_until_all_units_idle')
+        self.generate_model_name.return_value = 'newmodel'
+        self.get_charm_config.return_value = {
+            'charm_name': 'mycharm',
+            'gate_bundles': [{'alias': 'maveric-filebeat'}],
+        }
+        lc_func_test_runner.func_test_runner(
+            bundles=['maveric-filebeat'])
+        cwd = os.getcwd()
+        deploy_calls = [
+            mock.call(
+                cwd + '/tests/bundles/maveric-filebeat.yaml',
+                'newmodel',
+                model_ctxt={'alias': 'newmodel'},
+                force=False,
+                test_directory=None)]
+        self.deploy.assert_has_calls(deploy_calls)
+
     def test_func_test_runner_cmr_specify_bundle_with_alias(self):
         self.patch_object(lc_func_test_runner.utils, 'get_charm_config')
         self.patch_object(lc_func_test_runner.utils, 'generate_model_name')


### PR DESCRIPTION
When calling  functest-run-suite --keep-model --bundle $bundle,
Zaza will read the tests.yaml to determine the model alias to
use for a deployment, unless a model alias is explicitly passed
in with a colon. Additionally, if multiple bundles in the
tests.yaml match, Zaza will log that and fall back to the
default alias.