### PR TITLE
Handle juju disconnects

### DIFF
--- a/zaza/model.py
+++ b/zaza/model.py
@@ -266,6 +266,7 @@ async def block_until_auto_reconnect_model(*conditions,
             # reconnect if disconnected, as the conditions still need to be
             # checked.
             if _disconnected():
+                print("disconnected")
                 logging.warning(
                     "model: %s has disconnected, forcing full disconnection "
                     "and then reconnecting ...", model_name)

--- a/zaza/model.py
+++ b/zaza/model.py
@@ -278,7 +278,7 @@ async def block_until_auto_reconnect_model(*conditions,
                 await model.connect_model(model_name)
             result = _done()
             aresult = await _adone()
-            if all(not _disconnected(), result, aresult):
+            if all((not _disconnected(), result, aresult)):
                 return
             else:
                 await asyncio.sleep(wait_period, loop=loop)

--- a/zaza/model.py
+++ b/zaza/model.py
@@ -268,6 +268,13 @@ async def block_until_auto_reconnect_model(*conditions,
             # reconnect if disconnected, as the conditions still need to be
             # checked.
             if _disconnected():
+                try:
+                    await model.disconnect()
+                except Exception:
+                    # pass we don't care if disconnect fails; we're much more
+                    # interested in re-connecting, and this is just to clean up
+                    # anything.
+                    pass
                 await model.connect_model(model_name)
             result = _done()
             aresult = await _adone()

--- a/zaza/model.py
+++ b/zaza/model.py
@@ -221,8 +221,7 @@ async def block_until_auto_reconnect_model(*conditions,
     Note that conditions are just passed as an unamed list in the function call
     to make it work more like the more simple 'block_until' function.
 
-    :param model: the model to use OR None, in which case the model_name is
-        also optionally used.
+    :param model: the model to use
     :type model: :class:'juju.Model()'
     :param conditions: a list of callables that need to evaluate to True.
     :type conditions: [List[Callable[[:class:'juju.Model()'], bool]]]
@@ -258,7 +257,7 @@ async def block_until_auto_reconnect_model(*conditions,
         for c in aconditions:
             evaluated.append(await c())
             if _disconnected():
-                return True
+                return False
         return all(evaluated)
 
     async def _block():
@@ -266,7 +265,6 @@ async def block_until_auto_reconnect_model(*conditions,
             # reconnect if disconnected, as the conditions still need to be
             # checked.
             if _disconnected():
-                print("disconnected")
                 logging.warning(
                     "model: %s has disconnected, forcing full disconnection "
                     "and then reconnecting ...", model_name)


### PR DESCRIPTION
The libjuju model.block_until() raises websockets.exceptions.ConnectionClosed() if the model disconnects for any reason during the call.  This is extremely annoying, but it is what it is.

What is actually needed, is to trap the condition, and if it happens, reconnect to the model and then try the conditions again, as they may rely on the model being connected.

Related-Bug: zaza: #402