### PR TITLE
Fix broken zaza tests

### DIFF
--- a/unit_tests/test_zaza_charm_lifecycle_utils.py
+++ b/unit_tests/test_zaza_charm_lifecycle_utils.py
@@ -172,6 +172,7 @@ class TestCharmLifecycleUtils(ut_utils.BaseTestCase):
                    new_callable=mock.mock_open(),
                    name="_open")
         self.patch_object(lc_utils, 'yaml')
+        self.patch_object(lc_utils.logging, 'warning')
         _yaml = "testconfig: someconfig"
         _yaml_dict = {'test_config': 'someconfig'}
         self.yaml.safe_load.return_value = _yaml_dict

--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -450,6 +450,7 @@ class TestModel(ut_utils.BaseTestCase):
             model.get_unit_from_name('app/10', model_name='mname')
 
         # Application does not exist
+        self.patch_object(model.logging, 'error')
         with self.assertRaises(model.UnitNotFound):
             model.get_unit_from_name('bad_name', model_name='mname')
 


### PR DESCRIPTION
The test_zaza_utilities_machine_os.py tests are broken and cause tox to
fail for both pep8 and py3.  This patch fixes those tests.

Also, clean-up some other tests which don't mock out the logging
functions.  This cleans up the output of those tests.