### PR TITLE
Add global options

### DIFF
--- a/unit_tests/test_zaza_global_options.py
+++ b/unit_tests/test_zaza_global_options.py
@@ -1,0 +1,211 @@
+# Copyright 2021 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for global options."""
+
+import collections
+
+import unit_tests.utils as ut_utils
+
+import zaza.utilities.ro_types as ro_types
+import zaza.global_options as g
+
+
+class TestGetRawOptions(ut_utils.BaseTestCase):
+
+    def test_get_raw_options(self):
+        self.patch_object(g, '_options', new={})
+        self.assertEqual(g.get_raw_options(), self._options)
+        g._options = {"hello": "there"}
+        self.assertEqual(g.get_raw_options(), {"hello": "there"})
+
+
+class TestGetOptions(ut_utils.BaseTestCase):
+
+    def test_get_options(self):
+        self.patch_object(g, 'get_raw_options', return_value={})
+        options = g.get_options()
+        self.assertIsInstance(options, ro_types.ReadOnlyDict)
+        self.assertEqual(len(options.keys()), 0)
+        self.get_raw_options.return_value = {"hello": "there"}
+        options = g.get_options()
+        self.assertEqual(options['hello'], "there")
+
+
+class TestResetOptions(ut_utils.BaseTestCase):
+
+    def test_reset_options(self):
+        self.patch_object(g, '_options')
+        self.assertIs(g._options, self._options)
+        g.reset_options()
+        self.assertIsNot(g._options, self._options)
+
+
+class TestHelpers(ut_utils.BaseTestCase):
+
+    def test__keys_to_level_types(self):
+        keys = ["this", "is", "0", "1", "and"]
+        result = [g.LevelType.DICT, g.LevelType.DICT, g.LevelType.LIST,
+                  g.LevelType.LIST, g.LevelType.DICT]
+        self.assertEqual(g._keys_to_level_types(keys), result)
+        self.assertEqual(g._keys_to_level_types(keys, use_list=False),
+                         [g.LevelType.DICT] * len(keys))
+
+        with self.assertRaises(AssertionError):
+            g._keys_to_level_types(None)
+        with self.assertRaises(AssertionError):
+            g._keys_to_level_types([None])
+
+    def test__ref_to_level_type(self):
+        self.assertEqual(g._ref_to_level_type({}), g.LevelType.DICT)
+        self.assertEqual(g._ref_to_level_type(collections.OrderedDict()),
+                         g.LevelType.DICT)
+        self.assertEqual(g._ref_to_level_type([]), g.LevelType.LIST)
+        self.assertEqual(g._ref_to_level_type((1,)), g.LevelType.LIST)
+        self.assertEqual(g._ref_to_level_type(None), g.LevelType.LEAF)
+        self.assertEqual(g._ref_to_level_type(1), g.LevelType.LEAF)
+        self.assertEqual(g._ref_to_level_type("hello"), g.LevelType.LEAF)
+        self.assertEqual(g._ref_to_level_type(object), g.LevelType.LEAF)
+
+    def test__collection_for_type(self):
+        self.assertIsInstance(g._collection_for_type(g.LevelType.DICT),
+                              collections.OrderedDict)
+        self.assertIsInstance(g._collection_for_type(g.LevelType.LIST),
+                              list)
+        with self.assertRaises(RuntimeError):
+            g._collection_for_type(g.LevelType.LEAF)
+
+    def test__convert_key_type(self):
+        self.assertIsInstance(g._convert_key_type("hello", g.LevelType.DICT),
+                              str)
+        self.assertIsInstance(g._convert_key_type("0", g.LevelType.LIST), int)
+        self.assertIsInstance(g._convert_key_type("0", g.LevelType.DICT), str)
+        with self.assertRaises(AssertionError):
+            g._convert_key_type("hello", g.LevelType.LEAF)
+        with self.assertRaises(AssertionError):
+            g._convert_key_type(None, g.LevelType.DICT)
+        with self.assertRaises(AssertionError):
+            g._convert_key_type(object, g.LevelType.DICT)
+
+
+class TestSetOption(ut_utils.BaseTestCase):
+
+    def test_set_option(self):
+        self.patch_object(g, '_options', new={})
+        g.set_option("this.interesting.key", 1)
+        self.assertEqual(g._options['this']['interesting']['key'], 1)
+        g.set_option("this.other.thing", 2)
+        self.assertEqual(g._options['this']['interesting']['key'], 1)
+        self.assertEqual(g._options['this']['other']['thing'], 2)
+        g.set_option("this.list.1", 3)
+        self.assertEqual(g._options['this']['list'][1], 3)
+        self.assertEqual(g._options['this']['list'][0], None)
+        g.set_option("this.list.1", "goodbye")
+        self.assertEqual(g._options['this']['list'][1], "goodbye")
+        # re-write an option type
+        g.set_option("this.list.is", "on", override=True)
+        self.assertEqual(g._options['this']['list']['is'], "on")
+
+    def test_get_option(self):
+        options = {
+            'key1': 'value1',
+            'key2': 2,
+            'key3': {
+                'key3-1': 3,
+                'key3-2': 4,
+            },
+            'key4': ['a', 'b', 'c', {"key4-3-1": 5}],
+        }
+        self.patch_object(g, '_options', new=options)
+        self.assertEqual(g.get_option("key1"), "value1")
+        self.assertEqual(g.get_option("key2"), 2)
+        self.assertEqual(g.get_option("key3.key3-1"), 3)
+        self.assertEqual(g.get_option("key3.key3-2"), 4)
+        self.assertEqual(g.get_option("key4.3.key4-3-1"), 5)
+
+    def test_get_options(self):
+        options = {
+            'key1': 'value1',
+            'key2': 2,
+            'key3': {
+                'key3-1': 3,
+                'key3-2': 4,
+            },
+            'key4': ['a', 'b', 'c', {"key4-3-1": 5}],
+        }
+        self.patch_object(g, '_options', new=options)
+        o = g.get_options()
+        self.assertEqual(o.key1, "value1")
+        self.assertEqual(o.key2, 2)
+        self.assertEqual(o.key3.key3_1, 3)
+        self.assertEqual(o.key3.key3_2, 4)
+        self.assertEqual(o.key4[3].key4_3_1, 5)
+
+    def test_merge_to_None(self):
+        options = {
+            'key1': 'value1',
+            'key2': 2,
+            'key3': {
+                'key3-1': 3,
+                'key3-2': 4,
+            },
+            'key4': ['a', 'b', 'c', {"key4-3-1": 5}],
+        }
+        self.patch_object(g, '_options', new={})
+        g.merge(options)
+        o = g.get_options()
+        self.assertEqual(o.key1, "value1")
+        self.assertEqual(o.key2, 2)
+        self.assertEqual(o.key3.key3_1, 3)
+        self.assertEqual(o.key3.key3_2, 4)
+        self.assertEqual(o.key4[3].key4_3_1, 5)
+
+    def test_merge_no_override(self):
+        start_options = {
+            'key1': 'value0',
+            'key5': 'value5',
+        }
+        options = {
+            'key1': 'value1',
+            'key2': 2,
+            'key3': {
+                'key3-1': 3,
+                'key3-2': 4,
+            },
+            'key4': ['a', 'b', 'c', {"key4-3-1": 5}],
+        }
+        self.patch_object(g, '_options', new=start_options)
+        g.merge(options)
+        o = g.get_options()
+        self.assertEqual(o.key1, "value1")
+        self.assertEqual(o.key2, 2)
+        self.assertEqual(o.key3.key3_1, 3)
+        self.assertEqual(o.key3.key3_2, 4)
+        self.assertEqual(o.key4[3].key4_3_1, 5)
+        self.assertEqual(o.key5, "value5")
+
+    def test_merge_override(self):
+        start_options = {
+            'key1': 'value0',
+            'key5': 'value5',
+        }
+        options = {
+            'key1': [0, 1, 2, 3, 4],
+        }
+        self.patch_object(g, '_options', new=start_options)
+        with self.assertRaises(KeyError):
+            g.merge(options)
+        g.merge(options, override=True)
+        o = g.get_options()
+        self.assertEqual(o.key1[3], 3)

--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -481,6 +481,16 @@ class TestModel(ut_utils.BaseTestCase):
             model.get_first_unit_name('model', 'app'),
             'app/2')
 
+    def test_get_lead_unit(self):
+        self.patch_object(model, 'get_juju_model', return_value='mname')
+        self.patch_object(model, 'get_units')
+        self.get_units.return_value = self.units
+        self.patch_object(model, 'Model')
+        self.Model.return_value = self.Model_mock
+        # unit2 is the leader
+        self.assertEqual(
+            model.get_lead_unit('app', 'model'), self.unit2)
+
     def test_get_lead_unit_name(self):
         self.patch_object(model, 'get_juju_model', return_value='mname')
         self.patch_object(model, 'get_units')

--- a/unit_tests/utilities/test_ro_types.py
+++ b/unit_tests/utilities/test_ro_types.py
@@ -1,0 +1,124 @@
+# Copyright 2021 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tets for read-only Dictionaries and Lists."""
+
+import collections
+import unittest
+
+import zaza.utilities.ro_types as ro_types
+
+
+class TestResolveValue(unittest.TestCase):
+
+    def test_resolve_immutable(self):
+        self.assertEqual(ro_types.resolve_immutable(5), 5)
+        self.assertTrue(isinstance(ro_types.resolve_immutable({}),
+                                   ro_types.ReadOnlyDict))
+        self.assertEqual(ro_types.resolve_immutable("hello"), "hello")
+        self.assertTrue(isinstance(ro_types.resolve_immutable([]),
+                                   ro_types.ReadOnlyList))
+        self.assertTrue(isinstance(ro_types.resolve_immutable(tuple()),
+                                   ro_types.ReadOnlyList))
+
+
+class TestReadOnlyDict(unittest.TestCase):
+
+    def test_init(self):
+        # should only allow things that can be mapped (e.g. dictionary)
+        # and that have a copy() function
+        with self.assertRaises(AssertionError):
+            x = ro_types.ReadOnlyDict([])
+        # should work with a dictionary
+        x = ro_types.ReadOnlyDict({'a': 1, 'b': 2})
+        # should work with an OrderedDict
+        x = ro_types.ReadOnlyDict(collections
+                                  .OrderedDict([('a', 1), ('b', 2)]))
+        # check that the data is copied
+        b = {'a': 1}
+        x = ro_types.ReadOnlyDict(b)
+        b['a'] = 2
+        self.assertEqual(x['a'], 1)
+
+    def test_getitem(self):
+        x = ro_types.ReadOnlyDict({'a': 1, 'b': 5})
+        self.assertEqual(x['a'], 1)
+        self.assertEqual(x['b'], 5)
+        with self.assertRaises(KeyError):
+            x['c']
+
+    def test_getattr(self):
+        x = ro_types.ReadOnlyDict({'a': 1, 'b': 5})
+        self.assertEqual(x.a, 1)
+        self.assertEqual(x.b, 5)
+        with self.assertRaises(KeyError):
+            x.c
+
+    def test_setattr(self):
+        x = ro_types.ReadOnlyDict({'a': 1, 'b': 5})
+        with self.assertRaises(TypeError):
+            x.c = 1
+
+    def test_setitem(self):
+        x = ro_types.ReadOnlyDict({'a': 1, 'b': 5})
+        with self.assertRaises(TypeError):
+            x['c'] = 1
+
+    def test_iter(self):
+        x = ro_types.ReadOnlyDict(collections
+                                  .OrderedDict([('a', 1), ('b', 5)]))
+        self.assertEqual(list(iter(x)), ['a', 'b'])
+
+    def test_serialize(self):
+        x = ro_types.ReadOnlyDict({'a': 1})
+        self.assertEqual(x.__serialize__(), {'a': 1})
+
+
+class TestReadOnlyList(unittest.TestCase):
+
+    def test_create_new_tuple(self):
+        x = ro_types.ReadOnlyList([1, 2, 3])
+        self.assertEqual(x[0], 1)
+        self.assertEqual(x[1], 2)
+        self.assertEqual(x[2], 3)
+        self.assertEqual(len(x), 3)
+        # also check that the dicts and lists become readonly
+        x = ro_types.ReadOnlyList([[], {}, 1])
+        self.assertTrue(isinstance(x[0], ro_types.ReadOnlyList))
+        self.assertTrue(isinstance(x[1], ro_types.ReadOnlyDict))
+        # note that it becomes 1, because it was a lambda
+        self.assertEqual(x[2], 1)
+
+    def test_iter(self):
+        x = ro_types.ReadOnlyList([1, 2, 3])
+        self.assertEqual(list(iter(x)), [1, 2, 3])
+
+    def test_repr(self):
+        x = ro_types.ReadOnlyList([1, 2, 3])
+        self.assertEqual(repr(x), "ReadOnlyList((1, 2, 3))")
+
+    def test_str(self):
+        x = ro_types.ReadOnlyList([1, 2, 3])
+        self.assertEqual(str(x), "(1, 2, 3)")
+
+    def test_serialize(self):
+        x = ro_types.ReadOnlyList([1, 2, 3])
+        self.assertEqual(x.__serialize__(), [1, 2, 3])
+
+    def test_is_readonly(self):
+        x = ro_types.ReadOnlyList([1, 2, 3])
+        with self.assertRaises(TypeError):
+            x[0] = 2
+        with self.assertRaises(TypeError):
+            x.hello = 4

--- a/zaza/global_options.py
+++ b/zaza/global_options.py
@@ -1,0 +1,340 @@
+# Copyright 2021 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Manage global test config and options."""
+
+import collections
+import enum
+
+from zaza.utilities import ro_types
+
+# This file maintains and helps manage a set of global options that are
+# available to test functions for the duration of the test.  This started life
+# as the `tests_options` section in the test.yaml file, and indeed that can
+# still be used (and will be parsed into the options here).  However, options
+# can be provided separately in a yaml file, and also individually on the
+# functtest-test command line options.
+
+# Somewhere to store the tests_options directly.  Starts off as None prior to
+# being used.
+_options = None
+
+
+def get_raw_options():
+    """Get the actual options as a raw structure.
+
+    This returns the _tests_options from the file.
+
+    :returns: options that have been set
+    :rtype: Dict
+    """
+    global _options
+    if _options is None:
+        _options = collections.OrderedDict()
+    return _options
+
+
+def get_options():
+    """Get the options as read-only property accessible structure.
+
+    This returns the raw options as an Attribute-dict and list.
+    :returns: the options wrapped in a a ReadOnlyDict()
+    :rtype: ReadOnlyDict[]
+    """
+    return ro_types.resolve_immutable(get_raw_options())
+
+
+def reset_options():
+    """Reset the options to nothing.  Use sparingly."""
+    global _options
+    _options = None
+
+
+class LevelType(enum.Enum):
+    """Enum to describe different types of object at a level."""
+
+    LIST = 1
+    DICT = 2
+    LEAF = 3
+
+
+def _keys_to_level_types(keys, use_list=True):
+    """Map keys to LevelType of those keys.
+
+    If use_list is True, the default, then a key that looks like a list index
+    will return as a LIST type, rather than DICT type.
+
+    :param keys: the keys to map
+    :type keys: List[str]
+    :param use_list: whether to try to detect List indexes.
+    :type use_list: bool
+    :returns: the list of level types mapping to the keys
+    :rtype: List[LevelType]
+    :raises AssertionError if keys is not iterable, and the items yielded are
+        not strings.
+    """
+    level_types = []
+    assert isinstance(keys, collections.abc.Sequence)
+    for key in keys:
+        assert type(key) is str
+        level_types.append(
+            LevelType.LIST
+            if use_list and key.isnumeric() and str(int(key)) == key
+            else LevelType.DICT)
+    return level_types
+
+
+def _ref_to_level_type(ref):
+    """Map a reference to an object to a LevelType.
+
+    :param ref: the object to detect as a DICT, LIST or LEAF value.
+    :type ref: ANY
+    :returns: the level type
+    :rtype: LevelType
+    """
+    if isinstance(ref, collections.abc.Mapping):
+        return LevelType.DICT
+    elif (not isinstance(ref, str) and
+          isinstance(ref, collections.abc.Sequence)):
+        return LevelType.LIST
+    return LevelType.LEAF
+
+
+def _collection_for_type(level_type):
+    """Return the collection type for a LevelType.
+
+    :param level_type: the type to examine.
+    :type level_type: Union[LevelType.DICT, LevelType.LIST]
+    :returns: the collection for the level type
+    :rtype: Union[collections.OrderedDict, List]
+    :raises: RuntimeError if an unexpected type is passed.
+    """
+    if level_type == LevelType.DICT:
+        return collections.OrderedDict()
+    elif level_type == LevelType.LIST:
+        return list()
+    raise RuntimeError("No collection for: {}".format(level_type))
+
+
+def _convert_key_type(key, level_type):
+    """Speculatively convert a key based on the level_type.
+
+    If level_type is LIST then return the level_type as an int.
+
+    :param key: the key to (perhaps) convert.
+    :type key: str
+    :param level_type: the level_type to decide what to do.
+    :type level_type: LevelType
+    :returns: the key in a type according to the level_type.
+    :rtype: Union[str, int]
+    :raises: AssertionError if the level_type is not DICT or LIST
+    """
+    assert type(key) is str
+    assert level_type is not LevelType.LEAF
+    if level_type == LevelType.LIST:
+        return int(key)
+    return key
+
+
+def set_option(option, value, override=False, use_list=True):
+    """Set an option using the option and value passed.
+
+    The option is a dotted list representing dictionaries and lists that work
+    as a tree structure with a value as the leaf.
+
+    So this parses the option in a sequence of keys and then assigns a value.
+    Note that lists can be set this way, but only as a value.
+
+    If the "key" is an int then a list is inserted at that point.
+
+    :param option: The string to set as a key
+    :type option: str
+    :param value: The value to set
+    :type value: ANY
+    :param use_list: If True (default) then assume int keys indicate a list.
+        Note, for existing dictionary when creating new keys, we can have int
+        keys.
+    :param override: if True, override values into keys.
+    :type override: boolean
+    """
+    keys = option.split('.')
+    last_index = len(keys) - 1
+    levels = []
+    options = get_raw_options()
+
+    key_types = _keys_to_level_types(keys, use_list)
+
+    # follow the keys into the data structure.
+    for i, key in enumerate(keys):
+        levels.append(options)
+        if _ref_to_level_type(options) != key_types[i]:
+            if override and i > 0:
+                j = i - 1
+                levels[j][keys[j]] = _collection_for_type(key_types[i])
+                options = levels[j][keys[j]]
+            else:
+                raise ValueError(
+                    "Can't set key on value type with override=False: "
+                    "key={}, value at location: {}"
+                    .format(".".join(keys[:i]), options))
+
+        if i < last_index:
+            # attempt to recurse into options
+            _key = _convert_key_type(key, key_types[i])
+            try:
+                options = options[_key]
+            except KeyError:
+                # make a key for the next level
+                options[_key] = _collection_for_type(key_types[i + 1])
+                options = options[_key]
+            except IndexError:
+                # expand the List to accommodate the key index
+                options.extend([None] * (_key - len(options) + 1))
+                options[_key] = _collection_for_type(key_types[i + 1])
+                options = options[_key]
+        else:
+            # just set the value now
+            if _ref_to_level_type(options) == LevelType.LIST:
+                key = int(key)
+                try:
+                    options[key] = value
+                except IndexError:
+                    options.extend([None] * (key - len(options) + 1))
+
+            options[key] = value
+
+
+def get_option(option, default=None, raise_exception=False):
+    """Get an option using a dotted string.
+
+    If the option doesn't exist, and raise_exception is False then the default
+    is returned, otherwise and exception is raised.  If a List is at a key
+    level but the key isn't an int, then it is treated as though it doesn't
+    exist with raise_exception.  If a Dict is at the key location and the key
+    looks like a List index, then both the string and int forms of the key are
+    attempted to load the config item.
+
+    This means that we can do:
+
+        get_option_by_str('some.0.key', 'my-default')
+
+    to get the default option.
+
+    If the key location is not a leaf value then the resolved value is
+    returned.
+
+    :param key: the dotted option string to fetch.
+    :type key: str
+    :param default: the default value if not found.
+    :type default: ANY
+    :param raise_exception: raises a KeyError if the true and option isn't
+        found.
+    :type raise_exception: boolean
+    :raises: KeyError if key is not found and raise_exception is true
+    :returns: ANY
+    """
+    keys = option.split('.')
+    options = get_raw_options()
+
+    key_types = _keys_to_level_types(keys, True)
+    for i, key in enumerate(keys):
+        option_type = _ref_to_level_type(options)
+        if option_type == key_types[i]:
+            try:
+                options = options[_convert_key_type(key, key_types[i])]
+            except (KeyError, IndexError):
+                if raise_exception:
+                    raise KeyError(
+                        "Couldn't find {} option at {}"
+                        .format(option, ".".join(keys[:i])))
+                return default
+        elif option_type == LevelType.DICT:
+            try:
+                # it's a int like key
+                options = options[int(key)]
+            except KeyError:
+                if raise_exception:
+                    raise KeyError(
+                        "Couldn't find {} option at {} (forced to int)"
+                        .format(option, ".".join(keys[:i])))
+                return default
+        elif raise_exception:
+            raise KeyError(
+                "No option {} at {}".format(option, ".".join(keys[:i])))
+        else:
+            return default
+    return ro_types.resolve_immutable(options)
+
+
+def merge(data, override=False):
+    """Merge into the options from a data structure.
+
+    This takes the python data and merges it into the config.  data must be a
+    collection either a Mapping or a Sequence (but not a string).  This will be
+    merged with the existing config.  If override is True, then new structures
+    will override the existing structure.  If use_list=True (default) then the
+    types must match; if not then the override will override the existing type
+    or raise an exception.
+
+    :param data: the data to merge into the config
+    :type data: ANY
+    """
+    options = get_raw_options()
+
+    def _merge(ref, _data):
+        """Attempt to merge _data at ref.
+
+        If they are not the same type of thing, and override is false then
+        through an exception, otherwise, just override the data.
+        """
+        type_ref = _ref_to_level_type(ref)
+        type_data = _ref_to_level_type(_data)
+        assert type_ref == type_data, "Programming error: types must match"
+
+        if type_ref == LevelType.DICT:
+            for k, v_data in _data.items():
+                if k in ref:
+                    # we may have to merge the values if they are both
+                    # collections.
+                    v_ref = ref[k]
+                    if _ref_to_level_type(v_ref) == _ref_to_level_type(v_data):
+                        ref[k] = _merge(v_ref, v_data)
+                    elif override:
+                        ref[k] = v_data
+                    else:
+                        raise KeyError("Can't merge data at {} and {}"
+                                       .format(ref, k))
+                else:
+                    ref[k] = v_data
+            return ref
+        elif type_ref == LevelType.LIST:
+            for i in range(0, len(_data)):
+                try:
+                    if (_ref_to_level_type(ref[i]) ==
+                            _ref_to_level_type(_data[i])):
+                        ref[i] = _merge(ref[i], _data[i])
+                    elif override:
+                        ref[i] = _data[i]
+                    else:
+                        raise KeyError("Can't merge data at {} and {}"
+                                       .format(ref, i))
+                except IndexError:
+                    ref.append(_data[i])
+            return ref
+        return _data
+
+    if _ref_to_level_type(data) != LevelType.DICT:
+        raise RuntimeError("Top level must be Mapping type")
+    # finally merge the options
+    _merge(options, data)

--- a/zaza/model.py
+++ b/zaza/model.py
@@ -38,6 +38,7 @@ from juju.model import Model
 
 from zaza import sync_wrapper
 import zaza.utilities.generic as generic_utils
+import zaza.utilities.exceptions as zaza_exceptions
 
 CURRENT_MODEL = None
 MODEL_ALIASES = {}
@@ -595,6 +596,28 @@ def get_first_unit_name(application_name, model_name=None):
     return get_units(application_name, model_name=model_name)[0].name
 
 
+async def async_get_lead_unit(application_name, model_name=None):
+    """Return the leader unit for a given application.
+
+    :param model_name: Name of model to query.
+    :type model_name: str
+    :param application_name: Name of application
+    :type application_name: str
+    :returns: Name of unit with leader status
+    :raises: zaza.utilities.exceptions.JujuError
+    """
+    async with run_in_model(model_name) as model:
+        for unit in model.applications[application_name].units:
+            is_leader = await unit.is_leader_from_status()
+            if is_leader:
+                return unit
+    raise zaza_exceptions.JujuError("No leader found for application {}"
+                                    .format(application_name))
+
+
+get_lead_unit = sync_wrapper(async_get_lead_unit)
+
+
 async def async_get_lead_unit_name(application_name, model_name=None):
     """Return name of unit with leader status for given application.
 
@@ -604,12 +627,10 @@ async def async_get_lead_unit_name(application_name, model_name=None):
     :type application_name: str
     :returns: Name of unit with leader status
     :rtype: str
+    :raises: zaza.utilities.exceptions.JujuError
     """
-    async with run_in_model(model_name) as model:
-        for unit in model.applications[application_name].units:
-            is_leader = await unit.is_leader_from_status()
-            if is_leader:
-                return unit.entity_id
+    return (await async_get_lead_unit(application_name, model_name)).entity_id
+
 
 get_lead_unit_name = sync_wrapper(async_get_lead_unit_name)
 
@@ -637,12 +658,10 @@ async def async_get_lead_unit_ip(application_name, model_name=None):
     :type application_name: str
     :returns: IP of the lead unit
     :rtype: str
+    :raises: zaza.utilities.exceptions.JujuError
     """
-    async with run_in_model(model_name) as model:
-        for unit in model.applications[application_name].units:
-            is_leader = await unit.is_leader_from_status()
-            if is_leader:
-                return unit.public_address
+    return (await async_get_lead_unit(
+        application_name, model_name)).public_address
 
 
 get_lead_unit_ip = sync_wrapper(async_get_lead_unit_ip)

--- a/zaza/utilities/exceptions.py
+++ b/zaza/utilities/exceptions.py
@@ -15,6 +15,12 @@
 """Module of exceptions that zaza may raise."""
 
 
+class JujuError(Exception):
+    """Exception when libjuju does something unexpected."""
+
+    pass
+
+
 class TemplateConflict(Exception):
     """Exception when templates are in conflict."""
 

--- a/zaza/utilities/ro_types.py
+++ b/zaza/utilities/ro_types.py
@@ -1,0 +1,144 @@
+# Copyright 2021 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Provide read-only Dictionaries and Lists."""
+
+
+import collections
+
+
+class ReadOnlyDict(collections.OrderedDict):
+    """The ReadOnly dictionary accessible via attributes."""
+
+    def __init__(self, data):
+        """Initialise the dictionary, by copying the keys and values.
+
+        This recurses till the values are simple values, or callables.
+
+        :param data: a dictionary/mapping supporting structure (iter)
+        :type data: instanceof collections.abc.Mapping
+        :raises AssertionError: if data is not iterable and mapping
+        """
+        assert isinstance(data, collections.abc.Mapping)
+        for k, v in data.items():
+            super().__setitem__(k, v)
+
+    def __getitem__(self, key):
+        """Get the item using the key, resolves a callable.
+
+        Note if the key has '_' in it, then they will be tried first.  If a key
+        error occurs then the '_' will be converted to '-' and tried again.
+
+        :param key: string, or indexable object
+        :type key: has str representation.
+        :returns: value of item
+        """
+        try:
+            return resolve_immutable(super().__getitem__(key))
+        except KeyError:
+            return resolve_immutable(
+                super().__getitem__(key.replace('_', '-')))
+
+    __getattr__ = __getitem__
+
+    def __setattr__(self, *_):
+        """Set the attribute; disabled."""
+        raise TypeError("{} does not allow setting of attributes"
+                        .format(self.__class__.__name__))
+
+    def __setitem__(self, *_):
+        """Set the item; disabled."""
+        raise TypeError("{} does not allow setting of items"
+                        .format(self.__class__.__name__))
+
+    def __serialize__(self):
+        """Serialise ourself (the OrderedDict) to a regular dictionary.
+
+        :returns: a dictionary of self
+        :rtype: Dict
+        """
+        return {k: v for k, v in self.items()}
+
+
+class ReadOnlyList(tuple):
+    """Essentially, this is a 'smart' tuple.
+
+    It copies iterable data into a tuple, and resolves each value into a
+    read-only structure.  The purpose is to make a read-only list.
+    """
+
+    def __new__(cls, data):
+        """Take data and copies it to an internal tuple.
+
+        Also recursively resolves the values to a read-only data structure.
+
+        :param data: must be iterable, so that it can be copied.
+        :type data: has __iter__ method
+        """
+        return tuple.__new__(cls, [v for v in data])
+
+    def __getitem__(self, index):
+        """Get the item at index, resolving the values as needed.
+
+        :param index: the index of item to get.
+        :type index: int
+        :returns: the data item from the typle
+        :rtype: ANY
+        """
+        return resolve_immutable(super().__getitem__(index))
+
+    def __setattr__(self, *_):
+        """Set the attribute; disabled."""
+        raise TypeError("{} does not allow setting of items"
+                        .format(self.__class__.__name__))
+
+    def __iter__(self):
+        """Yield values from the list."""
+        for v in super().__iter__():
+            yield resolve_immutable(v)
+
+    def __repr__(self):
+        """Return human-readable representation of self."""
+        return ("{}(({}))"
+                .format(self.__class__.__name__,
+                        ", ".join(["{}".format(repr(v)) for v in self])))
+
+    def __str__(self):
+        """Return str() version of self."""
+        return "({})".format(", ".join(["{}".format(v) for v in self]))
+
+    def __serialize__(self):
+        """Turn the tuple into a list."""
+        return [v for v in self]
+
+
+def resolve_immutable(value):
+    """Turn value into an immutable object (as much as possible).
+
+    If it's a dictionary like object, return the ReadOnlyDict() object.
+    If it's a list like object, return the ReadOnlyList() object.
+    Otherwise, just return the value.
+
+    :param value: the value to resolve
+    :type value: ANY
+    :returns: transformed/wrapped value for 'read-only' use.
+    :rtype: Union[type(value), ReadOnlyDict[type(value)],
+                ReadOnlyList[type(value)]]
+    """
+    if isinstance(value, collections.abc.Mapping):
+        return ReadOnlyDict(value)
+    elif (not isinstance(value, str) and
+          isinstance(value, collections.abc.Sequence)):
+        return ReadOnlyList(value)
+    return value


### PR DESCRIPTION
At some point the tests.yaml grew a section called "tests_options",
which was introduced to cope with providing additional, optional, values
to test functions.  This only worked if a tests.yaml is provided; there
was no way to provide options on the command line using functest-test
(for example).

This patch does several things:

 * Adds a read-only module for Dictionaries and Lists.
 * Adds a global options module with helpers to get, set and merge
   optios into the a global options set.
 * Loads the options in from the tests.yaml:tests_options key.
 * Provides a way to pass an option using on the command line using the
   functest-test CLI entry point.

Incidentally, this patch was driven by a need to prevent the explosion
of named tests in a bundle to cover multiple versions of OpenStack.

There is also a minor addition to the zaza.model module to get the lead
unit object.