### PR TITLE
Ensure that config object handed is a copy

### DIFF
--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -873,6 +873,8 @@ class TestModel(ut_utils.BaseTestCase):
                    name="mock_asyncio_sleep",
                    new=mock.AsyncMock())
         self.patch_object(model.logging, 'info', name="mock_logging_info")
+        self.patch_object(
+            model.logging, 'warning', name="mock_logging_warning")
 
     def test_units_with_wl_status_state(self):
         self._application_states_setup({

--- a/zaza/charm_lifecycle/utils.py
+++ b/zaza/charm_lifecycle/utils.py
@@ -403,7 +403,7 @@ def get_charm_config(yaml_file=None, fatal=True, cached=True):
         else:
             yaml_file = DEFAULT_TEST_CONFIG
     if cached and yaml_file in _charm_config:
-        return _charm_config[yaml_file]
+        return _charm_config[yaml_file].copy()
     try:
         with open(yaml_file, 'r') as stream:
             content = yaml.safe_load(stream)
@@ -411,7 +411,7 @@ def get_charm_config(yaml_file=None, fatal=True, cached=True):
             if "tests_options" in content:
                 zaza.global_options.merge(content["tests_options"],
                                           override=True)
-            return content
+            return content.copy()
     except OSError:
         if not fatal:
             charm_name = os.path.basename(os.getcwd())


### PR DESCRIPTION
Due to caching of the config fropm the tests.yaml file, tests can mutate
the config.  This change ensures that the clean/pure version is provided
from get_charm_config()