### PR TITLE
Fix the annoying warning from zaza about using yaml.load()

### DIFF
--- a/zaza/charm_lifecycle/func_test_runner.py
+++ b/zaza/charm_lifecycle/func_test_runner.py
@@ -77,7 +77,7 @@ def failure_report(model_aliases, show_juju_status=False):
         if show_juju_status:
             logging.error(
                 yaml.dump(
-                    yaml.load(status.to_json()),
+                    yaml.safe_load(status.to_json()),
                     default_flow_style=False))
 
 


### PR DESCRIPTION
The warning is:

../func_test_runner.py:80: YAMLLoadWarning: calling yaml.load()
without Loader=... is deprecated, as the default Loader is unsafe.
Please read https://msg.pyyaml.org/load for full details.

This patch fixes it by using safe_load() instead.