### PR TITLE
Fix applications with 0 units in wait_for_application_states

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,6 @@ passenv = HOME TERM CS_* OS_* TEST_*
 install_command =
   pip install {opts} {packages}
 commands = nosetests --with-coverage --cover-package=zaza {posargs} {toxinidir}/unit_tests
-;commands = nosetests --nocapture --with-coverage --cover-package=zaza {posargs}
 
 [testenv:py3]
 basepython = python3

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,7 @@ passenv = HOME TERM CS_* OS_* TEST_*
 install_command =
   pip install {opts} {packages}
 commands = nosetests --with-coverage --cover-package=zaza {posargs} {toxinidir}/unit_tests
+;commands = nosetests --nocapture --with-coverage --cover-package=zaza {posargs}
 
 [testenv:py3]
 basepython = python3

--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -1081,6 +1081,48 @@ class TestModel(ut_utils.BaseTestCase):
             "which is not one of '['active']'"),
             self.mock_logging_info.mock_calls)
 
+    def test_wait_for_application_states_zero_units(self):
+        self._application_states_setup({
+            'workload-status': 'active',
+            'workload-status-message': 'Unit is ready'})
+        # override to zero units
+        self.mymodel.applications['app'].units = []
+        model.wait_for_application_states(
+            'modelname',
+            states={
+                'app': {
+                    'num-expected-units': 0,
+                }
+            },
+            timeout=-1)
+
+    def test_wait_for_application_states_zero_units_expect_one(self):
+        self._application_states_setup({
+            'workload-status': 'active',
+            'workload-status-message': 'Unit is ready'})
+        # override to zero units
+        self.mymodel.applications['app'].units = []
+        with self.assertRaises(model.ModelTimeout):
+            model.wait_for_application_states(
+                'modelname',
+                states={
+                    'app': {
+                        'num-expected-units': 1,
+                    }
+                },
+                timeout=-1)
+
+    def test_wait_for_application_states_zero_units_none_set(self):
+        self._application_states_setup({
+            'workload-status': 'active',
+            'workload-status-message': 'Unit is ready'})
+        # override to zero units
+        self.mymodel.applications['app'].units = []
+        with self.assertRaises(model.ModelTimeout):
+            model.wait_for_application_states(
+                'modelname',
+                timeout=1)
+
     def test_get_current_model(self):
         self.patch_object(model, 'Model')
         self.Model.return_value = self.Model_mock

--- a/zaza/model.py
+++ b/zaza/model.py
@@ -1250,7 +1250,9 @@ async def async_wait_for_application_states(model_name=None, states=None,
         states = {
             'app': {
                 'workload-status': 'blocked',
-                'workload-status-message-prefix': 'No requests without a prod'}
+                'workload-status-message-prefix': 'No requests without a prod',
+                'num-expected-units': 3,
+            },
             'anotherapp': {
                 'workload-status-message-prefix': 'Unit is super ready'}}
         wait_for_application_states('modelname', states=states)
@@ -1264,9 +1266,17 @@ async def async_wait_for_application_states(model_name=None, states=None,
        matches.
      - "workloaed-status-message" - DEPRECATED; use
            "workload-status-message-prefix" instead.
+    - "num-expected-units' - the number of units to be 'ready'.
 
     To match an empty string, use:
       "workload-status-message-regex": "^$"
+
+    NOTE: all applications that are being waited on are expected to have at
+    least one unit for that application to be ready.  Any subordinate charms
+    which have not be related to their principle by the time this function is
+    called will 'hang' the function; in this case (if this is expected), then
+    the application should b e passed in the :param:states parameter with a
+    'num-expected-units' of 0 for the app in question.
 
     :param model_name: Name of model to query.
     :type model_name: str
@@ -1320,12 +1330,31 @@ async def async_wait_for_application_states(model_name=None, states=None,
             timed_out = int(time.time() - start) > timeout
             issues = []
             for application in applications_left.copy():
+                check_info = states.get(application, {})
                 app_data = model.applications.get(application, None)
                 units = list(app_data.units)
-                # if there are no units the application is 'ready'
-                if len(units) > 0:
-                    check_info = states.get(application, {})
 
+                # all_okay is a Boolean of the current state.  It starts as
+                # True, but if False by the end of the checks, then the
+                # application is not ready.
+                all_okay = True
+
+                # if there are no units then the application may not be ready.
+                # However, if the caller explicitly allows that situation then
+                # we gate on that.
+                num_expected = check_info.get('num-expected-units', None)
+                if num_expected is not None:
+                    if len(units) != num_expected:
+                        print("all_okay is now false")
+                        all_okay = False
+                else:
+                    # num_expected is None, so 0 units means we are still
+                    # waiting
+                    if len(units) == 0:
+                        continue
+
+                # If we are still okay to check
+                if all_okay:
                     check_wl_statuses = approved_statuses.copy()
                     app_wls = check_info.get('workload-status', None)
                     if app_wls is not None:
@@ -1342,11 +1371,10 @@ async def async_wait_for_application_states(model_name=None, states=None,
                         prefixes.append(check_msg)
 
                     # check all the units; any not in status, we continue
-                    oks = []
                     for unit in units:
                         # if a unit isn't idle, then not ready yet.
                         ok = is_unit_idle(unit)
-                        oks.append(ok)
+                        all_okay = all_okay and ok
                         if not ok and timed_out:
                             issues.append(
                                 timeout_msg.format(
@@ -1357,7 +1385,7 @@ async def async_wait_for_application_states(model_name=None, states=None,
                             continue
                         ok = check_unit_workload_status(
                             model, unit, check_wl_statuses)
-                        oks.append(ok)
+                        all_okay = all_okay and ok
                         if not ok and timed_out:
                             issues.append(
                                 timeout_msg.format(
@@ -1367,7 +1395,7 @@ async def async_wait_for_application_states(model_name=None, states=None,
                                     approved_states=check_wl_statuses))
                         ok = check_unit_workload_status_message(
                             model, unit, prefixes=prefixes, regex=check_regex)
-                        oks.append(ok)
+                        all_okay = all_okay and ok
                         if not ok and timed_out:
                             issues.append(
                                 timeout_msg.format(
@@ -1375,16 +1403,17 @@ async def async_wait_for_application_states(model_name=None, states=None,
                                     gate_attr='workload status message',
                                     unit_state=unit.workload_status_message,
                                     approved_states=prefixes))
-                    # if not all states are okay, continue to the next one.
-                    if not(all(oks)):
-                        continue
+                # if not all states are okay, continue to the next one.
+                if not(all_okay):
+                    continue
 
                 applications_left.remove(application)
                 logging.info("Application %s is ready.", application)
 
             if not(applications_left):
-                logging.info("All applications reached approved status and "
-                             "workload status message checks.")
+                logging.info("All applications reached approved status, "
+                             "number of units (where relevant), and workload"
+                             " status message checks.")
                 return
 
             # check if we've timed-out, if so record the problem charms to the

--- a/zaza/model.py
+++ b/zaza/model.py
@@ -1345,7 +1345,6 @@ async def async_wait_for_application_states(model_name=None, states=None,
                 num_expected = check_info.get('num-expected-units', None)
                 if num_expected is not None:
                     if len(units) != num_expected:
-                        print("all_okay is now false")
                         all_okay = False
                 else:
                     # num_expected is None, so 0 units means we are still


### PR DESCRIPTION
So (async_)wait_for_application_states(..) had a hidden issue before it
was refactored to its current form: essentially, a subordinate charm
with no units would be "ready" as the principle's may not have been
installed 'enough' for Juju to allocate the units for the subordinates.

The refactor of the function to do all the checking in parallel (rather
than waiting on the first, then the 2nd, etc.) would see those as ready
immediately and not check them again.

This refactor allows the caller of the function to explicitly allow
charms to be ready with no units, otherwise every application needs at
least 1 unit for it to be ready.