### PR TITLE
Fix sleep in async_wait_for_application_states

### DIFF
--- a/zaza/model.py
+++ b/zaza/model.py
@@ -1326,6 +1326,9 @@ async def async_wait_for_application_states(model_name=None, states=None,
 
         logging.info("Now checking workload status and status messages")
         while True:
+            # now we sleep to allow progress to be made in the libjuju futures
+            await asyncio.sleep(2)
+
             await ensure_model_connected(model)
             timed_out = int(time.time() - start) > timeout
             issues = []
@@ -1420,9 +1423,6 @@ async def async_wait_for_application_states(model_name=None, states=None,
                 for issue in issues:
                     logging.info(issue)
                 raise ModelTimeout("Work state not achieved within timeout.")
-
-            # now we sleep to allow progress to be made in the libjuju futures
-            await asyncio.sleep(2)
 
 
 wait_for_application_states = sync_wrapper(async_wait_for_application_states)


### PR DESCRIPTION
With the async sleep at the end of the while loop in
async_wait_for_application_states(), it's possible for the loop to miss
the sleep due to the use of `continue` statements in the while block.
When this happens, no other async coroutines will make progress which
means that the status of the juju model will not be updated.  This can
lead to the effect of the function not thinking units have achieved idle
status, when in fact they have.  This leads to erroneous abandoning of a
test run.

Moving the sleep to the start of the while loop ensures that the event
loop will make progress and the status of the model will be updated in
python-libjuju.