### PR TITLE
Add the concept of atexit hooks to Zaza

### DIFF
--- a/zaza/charm_lifecycle/test.py
+++ b/zaza/charm_lifecycle/test.py
@@ -19,6 +19,7 @@ import logging
 import unittest
 import sys
 
+import zaza
 import zaza.model
 import zaza.global_options as global_options
 import zaza.charm_lifecycle.utils as utils
@@ -121,6 +122,7 @@ def test(model_name, tests, test_directory=None):
     utils.set_base_test_dir(test_dir=test_directory)
     zaza.model.set_juju_model(model_name)
     run_test_list(tests)
+    zaza.run_atexit_hooks()
 
 
 def parse_args(args):


### PR DESCRIPTION
These hooks will be run after a test run completes via the
test portion of Zaza's lifecycle. An example situation where
atexit hooks can be beneficial to Zaza would be the case where
resources are created and verified in one test, and then the
thing under test is modified, and then the resources should
be re-verified. A specific example of the above would be for
a charm or payload upgrade.

An minimal example test using `atexit`:

    import zaza.atexit
  
    def cleanup_vm():
        for vm in cls.nova_client.servers.list():
            if vm.name == 'ins-1':
                vm.delete()
                openstack_utils.resource_removed(
                    cls.nova_client.servers,
                    vm.id,
                    msg="Waiting for the Nova VM {} to be deleted".format(vm.name))
  
    class VMTests(test_utils.OpenStackBaseTest):
        """Encapsulate VM tests."""
  
        @classmethod
        def setUpClass(cls):
            """Run class setup for running tests."""
            super(VMTests, cls).setUpClass()
            zaza.atexit(cleanup_vm)
  
        def test_share(self):
            instance = None
            for vm in cls.nova_client.servers.list():
                if vm.name == 'ins-1':
                    instance = vm
           id instance is None:
                instance = self.launch_guest(
                    guest_name='ins-1')
           fip = neutron_tests.floating_ips_from_instance(instance)[0]
           openstack_utils.ping_response(fip)

In the above example, a VM is spawned on the first pass through
the test case but not cleaned up. The second time through the
test case, the previous VM is used, and the verification is that
the instance is pinged.

When Zaza finishes the entire test run, it will call the atexit
function that was registered and cleanup the server.