### PR TITLE
Remove Groovy from the test matrix

### DIFF
--- a/tests/bundles/magpie-groovy.yaml
+++ b/tests/bundles/magpie-groovy.yaml
@@ -1,8 +1,0 @@
-series: groovy
-applications:
-  magpie:
-    charm: cs:~openstack-charmers-next/magpie
-    num_units: 5
-  ubuntu:
-    charm: cs:ubuntu
-    num_units: 1

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -3,7 +3,6 @@ gate_bundles:
 - magpie-xenial
 - magpie-bionic
 - magpie-focal
-- magpie-groovy
 dev_bundles:
 # magpie isn't hirsute ready yet.
 - magpie-hirsute


### PR DESCRIPTION
Groovy is EoL and no longer has images published.