### PR TITLE
ci: Add back the functional test and codecov jobs

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -20,8 +20,47 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install tox tox-gh-actions
+        pip install codecov tox tox-gh-actions
     - name: Lint with tox
       run: tox -e pep8
     - name: Test with tox
       run: tox -e py
+    - name: Codecov
+      run: |
+        set -euxo pipefail
+        codecov --verbose --gcov-glob unit_tests/*
+  func:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install dependencies
+      run: |
+        set -euxo pipefail
+        python -m pip install --upgrade pip
+        pip install tox tox-gh-actions
+        sudo snap install --classic juju
+        sudo snap install --classic juju-crashdump
+        sudo lxd init --auto
+        # This is a throw-away CI environment, do not do this at home
+        sudo chmod 666 /var/snap/lxd/common/lxd/unix.socket
+        # until Juju provides stable IPv6-support we unfortunately need this
+        lxc network set lxdbr0 ipv6.address none
+        juju bootstrap --no-gui localhost
+    - name: Functional test
+      run: |
+        set -euxo pipefail
+        mkdir logs
+        tox -e func | tee logs/tox-output.txt
+        juju status -m $(juju models --format yaml|grep "^- name:.*zaza"|cut -f2 -d/) | tee logs/juju-status.txt
+    - name: crashdump on failure
+      if: failure()
+      run: |
+        set -euxo pipefail
+        juju crashdump -o logs/
+    - name: upload logs on failure
+      if: failure()
+      uses: actions/upload-artifact@v2
+      with:
+        name: test-run-logs-and-crashdump
+        path: logs/

--- a/tests/bundles/first.yaml
+++ b/tests/bundles/first.yaml
@@ -1,0 +1,12 @@
+applications:
+  magpie-xenial:
+    series: xenial
+    charm: cs:~openstack-charmers-next/magpie
+    num_units: 2
+  magpie-bionic:
+    series: bionic
+    charm: cs:~openstack-charmers-next/magpie
+    num_units: 2
+  ubuntu:
+    charm: cs:ubuntu
+    num_units: 1

--- a/tests/bundles/magpie-bionic.yaml
+++ b/tests/bundles/magpie-bionic.yaml
@@ -1,8 +1,0 @@
-series: bionic
-applications:
-  magpie:
-    charm: cs:~openstack-charmers-next/magpie
-    num_units: 5
-  ubuntu:
-    charm: cs:ubuntu
-    num_units: 1

--- a/tests/bundles/magpie-focal.yaml
+++ b/tests/bundles/magpie-focal.yaml
@@ -1,8 +1,0 @@
-series: focal
-applications:
-  magpie:
-    charm: cs:~openstack-charmers-next/magpie
-    num_units: 5
-  ubuntu:
-    charm: cs:ubuntu
-    num_units: 1

--- a/tests/bundles/magpie-hirsute.yaml
+++ b/tests/bundles/magpie-hirsute.yaml
@@ -1,9 +1,0 @@
-series: hirsute
-applications:
-  magpie:
-    charm: cs:~openstack-charmers-next/magpie
-    num_units: 5
-  ubuntu:
-    charm: cs:ubuntu
-    num_units: 1
-

--- a/tests/bundles/magpie-xenial.yaml
+++ b/tests/bundles/magpie-xenial.yaml
@@ -1,8 +1,0 @@
-series: xenial
-applications:
-  magpie:
-    charm: cs:~openstack-charmers-next/magpie
-    num_units: 5
-  ubuntu:
-    charm: cs:ubuntu
-    num_units: 1

--- a/tests/bundles/second.yaml
+++ b/tests/bundles/second.yaml
@@ -1,0 +1,16 @@
+applications:
+  magpie-focal:
+    series: focal
+    charm: cs:~openstack-charmers-next/magpie
+    num_units: 2
+  magpie-hirsute:
+    series: hirsute
+    charm: cs:~openstack-charmers-next/magpie
+    num_units: 2
+  magpie-impish:
+    series: impish
+    charm: cs:~openstack-charmers-next/magpie
+    num_units: 2
+  ubuntu:
+    charm: cs:ubuntu
+    num_units: 1

--- a/tests/bundles/second.yaml
+++ b/tests/bundles/second.yaml
@@ -7,10 +7,6 @@ applications:
     series: hirsute
     charm: cs:~openstack-charmers-next/magpie
     num_units: 2
-  magpie-impish:
-    series: impish
-    charm: cs:~openstack-charmers-next/magpie
-    num_units: 2
   ubuntu:
     charm: cs:ubuntu
     num_units: 1

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -1,11 +1,10 @@
 charm_name: none
 gate_bundles:
-- magpie-xenial
-- magpie-bionic
-- magpie-focal
-dev_bundles:
-# magpie isn't hirsute ready yet.
-- magpie-hirsute
+# let's keep this list as short as possible, this is not a gate test for any of
+# the charms in the bundle but a test for Zaza's handling of model deployment/
+# destruction
+- first
+- second
 target_deploy_status:
   magpie:
     workload-status: active
@@ -18,4 +17,4 @@ tests:
 - zaza.charm_tests.noop.tests.NoopTest
 tests_options:
   force_deploy:
-    magpie-hirsute
+    second

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -18,9 +18,6 @@ target_deploy_status:
   magpie-hirsute:
     workload-status: active
     workload-status-message-prefix: icmp ok, local hostname ok
-  magpie-impish:
-    workload-status: active
-    workload-status-message-prefix: icmp ok, local hostname ok
   ubuntu:
     workload-status-message-regex: "^$"
 configure:

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -6,7 +6,19 @@ gate_bundles:
 - first
 - second
 target_deploy_status:
-  magpie:
+  magpie-xenial:
+    workload-status: active
+    workload-status-message-prefix: icmp ok, local hostname ok
+  magpie-bionic:
+    workload-status: active
+    workload-status-message-prefix: icmp ok, local hostname ok
+  magpie-focal:
+    workload-status: active
+    workload-status-message-prefix: icmp ok, local hostname ok
+  magpie-hirsute:
+    workload-status: active
+    workload-status-message-prefix: icmp ok, local hostname ok
+  magpie-impish:
     workload-status: active
     workload-status-message-prefix: icmp ok, local hostname ok
   ubuntu:


### PR DESCRIPTION
We urgenlty had to migrate CI jobs over to GitHub Actions and did
not enable the functional test and codecov jobs as part of the
original migration.

Add them back now.