### PR TITLE
Revert "Switch unit.public_address to unit.get_public_address()"

### DIFF
--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -159,24 +159,12 @@ class TestModel(ut_utils.BaseTestCase):
         self.machine3 = mock.MagicMock(status='active')
         self.machine7 = mock.MagicMock(status='active')
         self.unit1 = mock.MagicMock()
-
-        def make_get_public_address(ip):
-            async def _get_public_address():
-                return ip
-
-            return _get_public_address
-
-        def fail_on_use():
-            raise RuntimeError("Don't use this property.")
-
-        self.unit1.public_address = property(fail_on_use)
-        self.unit1.get_public_address = make_get_public_address('ip1')
+        self.unit1.public_address = 'ip1'
         self.unit1.name = 'app/2'
         self.unit1.entity_id = 'app/2'
         self.unit1.machine = self.machine3
         self.unit2 = mock.MagicMock()
-        self.unit2.public_address = property(fail_on_use)
-        self.unit2.get_public_address = make_get_public_address('ip2')
+        self.unit2.public_address = 'ip2'
         self.unit2.name = 'app/4'
         self.unit2.entity_id = 'app/4'
         self.unit2.machine = self.machine7
@@ -534,9 +522,6 @@ class TestModel(ut_utils.BaseTestCase):
         self.assertEqual(
             model.get_lead_unit_name('app', 'model'),
             'app/4')
-
-    def test_get_unit_public_address(self):
-        self.assertEqual(model.get_unit_public_address(self.unit1), 'ip1')
 
     def test_get_lead_unit_ip(self):
         self.patch_object(model, 'get_juju_model', return_value='mname')

--- a/unit_tests/utilities/test_zaza_utilities_juju.py
+++ b/unit_tests/utilities/test_zaza_utilities_juju.py
@@ -43,32 +43,19 @@ class TestJujuUtils(ut_utils.BaseTestCase):
         self.machine2_mock = MachineMock()
         self.machine2_mock[self.key] = self.key_data
 
-        def make_get_public_address(ip):
-            async def _get_public_address():
-                return ip
-
-            return _get_public_address
-
-        def fail_on_use():
-            raise RuntimeError("Don't use this property.")
-
         self.unit0 = "app/0"
         self.unit0_data = {"machine": self.machine0}
         self.unit0_mock = mock.MagicMock()
         self.unit0_mock.entity_id = self.unit0
         self.unit0_mock.data = {'machine-id': self.machine0}
-        self.unit0_mock.public_address = property(fail_on_use)
-        self.unit0_mock.get_public_address = make_get_public_address(
-            '10.0.0.11')
+        self.unit0_mock.public_address = '10.0.0.11'
 
         self.unit1 = "app/1"
         self.unit1_data = {"machine": self.machine1}
         self.unit1_mock = mock.MagicMock()
         self.unit1_mock.entity_id = self.unit1
         self.unit1_mock.data = {'machine-id': self.machine1}
-        self.unit1_mock.public_address = property(fail_on_use)
-        self.unit1_mock.get_public_address = make_get_public_address(
-            '10.0.0.1')
+        self.unit1_mock.public_address = '10.0.0.1'
 
         self.unit2 = "app/2"
         self.unit2_data = {"machine": self.machine2}
@@ -419,7 +406,6 @@ class TestJujuUtils(ut_utils.BaseTestCase):
             juju_utils.get_application_ip('app'),
             '10.0.0.10')
         self.model.get_application_config.return_value = {}
-        self.model.get_unit_public_address.return_value = '10.0.0.1'
         self.assertEqual(
             juju_utils.get_application_ip('app'),
             '10.0.0.1')

--- a/zaza/model.py
+++ b/zaza/model.py
@@ -664,29 +664,7 @@ async def async_get_lead_unit_name(application_name, model_name=None):
 get_lead_unit_name = sync_wrapper(async_get_lead_unit_name)
 
 
-def get_unit_public_address(unit):
-    """Get the public address of a the unit.
-
-    The libjuju library, in theory, supports a unit.public_address attribute
-    that provides the publick address of the unit.  However, when the unit is
-    an OpenStack VM, there is a race and it's possible it will be None.
-    Therefore, there is a 'get_public_address()' funtion on unit that does
-    provide the function.  See [1].
-
-    1. https://github.com/juju/python-libjuju/issues/551
-
-    :param unit: The libjuju unit object to get the public address for.
-    :type unit: juju.Unit
-    :returns: the IP address of the unit.
-    :rtype: str
-    """
-    async def _get(unit_):
-        return await unit_.get_public_address()
-
-    return sync_wrapper(_get)(unit)
-
-
-async def async_get_app_ips(application_name, model_name=None):
+def get_app_ips(application_name, model_name=None):
     """Return public address of all units of an application.
 
     :param model_name: Name of model to query.
@@ -696,11 +674,8 @@ async def async_get_app_ips(application_name, model_name=None):
     :returns: List of ip addresses
     :rtype: [str, str,...]
     """
-    return [await u.get_public_address()
+    return [u.public_address
             for u in get_units(application_name, model_name=model_name)]
-
-
-get_app_ips = sync_wrapper(async_get_app_ips)
 
 
 async def async_get_lead_unit_ip(application_name, model_name=None):
@@ -714,8 +689,8 @@ async def async_get_lead_unit_ip(application_name, model_name=None):
     :rtype: str
     :raises: zaza.utilities.exceptions.JujuError
     """
-    return await (await async_get_lead_unit(
-        application_name, model_name)).get_public_address()
+    return (await async_get_lead_unit(
+        application_name, model_name)).public_address
 
 
 get_lead_unit_ip = sync_wrapper(async_get_lead_unit_ip)

--- a/zaza/utilities/juju.py
+++ b/zaza/utilities/juju.py
@@ -511,5 +511,5 @@ def get_application_ip(application, model_name=None):
         unit = model.get_units(
             application,
             model_name=model_name)[0]
-        ip = model.get_unit_public_address(unit)
+        ip = unit.public_address
     return ip


### PR DESCRIPTION
Reverts openstack-charmers/zaza#468

It looks like  #470 broke zaza is limited and specific ways, and thus it makes sense to revert the patch and work out what I did wrong!