### PR TITLE
Add 'model_name' configuration option.

### DIFF
--- a/unit_tests/test_zaza_charm_lifecycle_utils.py
+++ b/unit_tests/test_zaza_charm_lifecycle_utils.py
@@ -162,11 +162,17 @@ class TestCharmLifecycleUtils(ut_utils.BaseTestCase):
                 {'alias': 'bundle'}),
             expect)
 
-    def test_generate_model_name(self):
+    @mock.patch('zaza.utilities.deployment_env.get_setup_file_contents')
+    def test_generate_model_name(self, get_setup_file_contents):
+        get_setup_file_contents.return_value = {}
         self.patch_object(lc_utils.uuid, "uuid4")
         self.uuid4.return_value = "longer-than-12characters"
         self.assertEqual(lc_utils.generate_model_name(),
                          "zaza-12characters")
+
+        get_setup_file_contents.return_value = {'model_name': 'mymodel-$UUID'}
+        self.assertEqual(lc_utils.generate_model_name(),
+                         "mymodel-12characters")
 
     def test_get_charm_config(self):
         self.patch("builtins.open",

--- a/zaza/charm_lifecycle/utils.py
+++ b/zaza/charm_lifecycle/utils.py
@@ -23,7 +23,10 @@ import time
 import sys
 import yaml
 
+from string import Template
+
 import zaza.global_options
+import zaza.utilities.deployment_env as deployment_env
 
 
 BUNDLE_DIR = "./tests/bundles/"
@@ -31,6 +34,7 @@ DEFAULT_TEST_DIR = "./tests"
 DEFAULT_CONFIG_YAML = "tests.yaml"
 DEFAULT_TEST_CONFIG = "./{}/{}".format(DEFAULT_TEST_DIR, DEFAULT_CONFIG_YAML)
 DEFAULT_MODEL_ALIAS = "default_alias"
+DEFAULT_MODEL_NAME = 'zaza-$UUID'
 DEFAULT_DEPLOY_NAME = 'default{}'
 
 RAW_BUNDLE = "raw-bundle"
@@ -486,7 +490,10 @@ def generate_model_name():
     :returns: Model name
     :rtype: str
     """
-    return 'zaza-{}'.format(str(uuid.uuid4())[-12:])
+    model_name_fmt = deployment_env.get_setup_file_contents().get(
+        "model_name", DEFAULT_MODEL_NAME)
+    tpl = Template(model_name_fmt)
+    return tpl.safe_substitute({"UUID": str(uuid.uuid4())[-12:]})
 
 
 def check_output_logging(cmd):


### PR DESCRIPTION
model_name can be set in ~/.zaza.yaml to alter the way zaza names models
created, the format of the string is parsed by string.Template(). This
would allow users to force zaza to use a fixed model name (e.g.
'mymodel') which becomes especially useful when the juju provider used
is LXD since model names are mapped to LXD profiles.