### PR TITLE
21.10 juju 2.9 workaround unit.get_public_address() failures

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,3 +2,5 @@ ignore:
   - "unit_tests/*"
   - "unit_tests/utilities/*"
   - "unit_tests/**/*"
+  - "scripts/*"
+  - "zaza/charm_tests/**/*"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 aiounittest
 async_generator
+kubernetes<18.0.0; python_version < '3.6' # pined, as juju uses kubernetes
 juju
 juju_wait
 PyYAML>=3.0
@@ -18,6 +19,7 @@ Jinja2>=2.6  # BSD License (3 clause)
 six>=1.9.0
 dnspython>=1.12.0
 psutil>=1.1.1,<2.0.0
+oslo.config<6.9.0;python_version < '3.6'  # pin for py3.5 support
 oslo.context<3.0.0;python_version < '3.6'  # pin for py3.5 support
 osprofiler<3.0.0;python_version < '3.6'  # pin for py3.5 support
 python-openstackclient>=3.14.0

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,5 @@
+# Scripts sub-directory
+
+The scripts in this directory are for regression/manual testing of the
+libjuju unit.get_public_address() function.  The tox target 'third' can
+also be used for regression testing.

--- a/scripts/bash_tester.sh
+++ b/scripts/bash_tester.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+_dir="$( cd "$(dirname "${BASH_SOURCE[0]}" )" && pwd)"
+runner="${_dir}/fetch1.py"
+
+# loop 10 times and fetch an instance address
+i=0
+while [ $i -ne 10 ];
+do
+    printf "\n\n\n!!!!!!"
+    printf "\n\n\nDoing number $i"
+    printf "\n\n"
+    $runner $i
+    i=$(($i+1))
+done

--- a/scripts/fetch1.py
+++ b/scripts/fetch1.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+
+from juju.model import Model
+import asyncio
+import sys
+
+# set to use something other than the current model
+MODEL=None
+
+
+async def get_units():
+    model = Model()
+    if MODEL is None:
+        await model.connect()
+    else:
+        await model.connect_model(MODEL)
+    units = sorted(model.applications['ubuntu'].units, key=lambda u: u.name)
+    await model.disconnect()
+    return units
+
+
+async def get_address(unit):
+    model = Model()
+    await model.connect_model(MODEL)
+    print("{} Address: .public_address {}".format(unit.name, unit.public_address))
+    while True:
+        try:
+            print("{} Address: get_public_address() {}".format(unit.name, await unit.get_public_address()))
+            break
+        except Exception as e:
+            print("Exception was: %s", e)
+            await asyncio.sleep(.25)
+            await ensure_model_connected(model)
+    print("{} Address: .public_address {}".format(unit.name, unit.public_address))
+    print("\n")
+    await model.disconnect()
+
+
+def run_it(step):
+    loop = asyncio.get_event_loop()
+    task = loop.create_task(step)
+    loop.run_until_complete(asyncio.wait([task], loop=loop))
+    result = task.result()
+    return result
+
+
+async def get_unit(n):
+    units = await get_units()
+    print("units", units)
+    await get_address(units[n])
+
+
+def is_model_disconnected(model):
+    """Return True if the model is disconnected.
+
+    :param model: the model to check
+    :type model: :class:'juju.Model'
+    :returns: True if disconnected
+    :rtype: bool
+    """
+    print("is_model_disconnected?: %s, %s", model.is_connected(), model.connection().is_open)
+    return not (model.is_connected() and model.connection().is_open)
+
+
+async def ensure_model_connected(model):
+    """Ensure that the model is connected.
+
+    If model is disconnected then reconnect it.
+
+    :param model: the model to check
+    :type model: :class:'juju.Model'
+    """
+    if is_model_disconnected(model):
+        model_name = model.info.name
+        print(
+            "model: %s has disconnected, forcing full disconnection "
+            "and then reconnecting ...", model_name)
+        try:
+            await model.disconnect()
+        except Exception:
+            # We don't care if disconnect fails; we're much more
+            # interested in re-connecting, and this is just to clean up
+            # anything that might be left over (i.e.
+            # model.is_connected() might be true, but
+            # model.connection().is_open may be false
+            pass
+        print("Attempting to reconnect model %s", model_name)
+        await model.connect_model(model_name)
+
+
+if __name__ == '__main__':
+    unit_num = 0
+    if len(sys.argv) > 1:
+        unit_num = int(sys.argv[1])
+
+    run_it(get_unit(unit_num))
+    asyncio.get_event_loop().close()
+

--- a/scripts/tester.py
+++ b/scripts/tester.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+from juju.model import Model
+import asyncio
+
+# set to use something other than the current model
+MODEL=None
+
+
+async def get_units():
+    model = Model()
+    if MODEL is None:
+        await model.connect()
+    else:
+        await model.connect_model(MODEL)
+    units = sorted(model.applications['ubuntu'].units, key=lambda u: u.name)
+    await model.disconnect()
+    return units
+
+
+async def get_address(unit):
+    model = Model()
+    await model.connect_model(MODEL)
+    print("{} Address: .public_address {}".format(unit.name, unit.public_address))
+    print("{} Address: get_public_address() {}".format(unit.name, await unit.get_public_address()))
+    print("{} Address: .public_address {}".format(unit.name, unit.public_address))
+    print("\n")
+    await model.disconnect()
+
+
+def run_it(step):
+    loop = asyncio.get_event_loop()
+    task = loop.create_task(step)
+    loop.run_until_complete(asyncio.wait([task], loop=loop))
+    result = task.result()
+    return result
+
+
+def get_all_units():
+    units = run_it(get_units())
+    print("units", units)
+    for unit in units:
+        run_it(get_address(unit))
+
+
+get_all_units()
+asyncio.get_event_loop().close()

--- a/tests/bundles/first.yaml
+++ b/tests/bundles/first.yaml
@@ -9,4 +9,4 @@ applications:
     num_units: 2
   ubuntu:
     charm: cs:ubuntu
-    num_units: 1
+    num_units: 3

--- a/tests/bundles/second.yaml
+++ b/tests/bundles/second.yaml
@@ -9,4 +9,4 @@ applications:
     num_units: 2
   ubuntu:
     charm: cs:ubuntu
-    num_units: 1
+    num_units: 3

--- a/tests/bundles/third.yaml
+++ b/tests/bundles/third.yaml
@@ -1,0 +1,5 @@
+applications:
+  ubuntu:
+    charm: cs:ubuntu
+    num_units: 10
+

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -24,6 +24,7 @@ configure:
 - zaza.charm_tests.noop.setup.basic_setup
 tests:
 - zaza.charm_tests.noop.tests.NoopTest
+- zaza.charm_tests.libjuju.tests.RegressionTest
 tests_options:
   force_deploy:
     second

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -5,6 +5,7 @@ gate_bundles:
 # destruction
 - first
 - second
+- third
 target_deploy_status:
   magpie-xenial:
     workload-status: active

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -28,3 +28,4 @@ tests:
 tests_options:
   force_deploy:
     second
+    third

--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -159,12 +159,24 @@ class TestModel(ut_utils.BaseTestCase):
         self.machine3 = mock.MagicMock(status='active')
         self.machine7 = mock.MagicMock(status='active')
         self.unit1 = mock.MagicMock()
-        self.unit1.public_address = 'ip1'
+
+        def make_get_public_address(ip):
+            async def _get_public_address():
+                return ip
+
+            return _get_public_address
+
+        def fail_on_use():
+            raise RuntimeError("Don't use this property.")
+
+        self.unit1.public_address = property(fail_on_use)
+        self.unit1.get_public_address = make_get_public_address('ip1')
         self.unit1.name = 'app/2'
         self.unit1.entity_id = 'app/2'
         self.unit1.machine = self.machine3
         self.unit2 = mock.MagicMock()
-        self.unit2.public_address = 'ip2'
+        self.unit2.public_address = property(fail_on_use)
+        self.unit2.get_public_address = make_get_public_address('ip2')
         self.unit2.name = 'app/4'
         self.unit2.entity_id = 'app/4'
         self.unit2.machine = self.machine7

--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -556,8 +556,12 @@ class TestModel(ut_utils.BaseTestCase):
 
     def test_get_app_ips(self):
         self.patch_object(model, 'get_juju_model', return_value='mname')
-        self.patch_object(model, 'get_units')
-        self.get_units.return_value = self.units
+        self.patch_object(model, 'async_get_units')
+
+        async def mock_async_aget_units(*args, **kwargs):
+            return self.units
+
+        self.async_get_units.side_effect = mock_async_aget_units
         self.assertEqual(model.get_app_ips('model', 'app'), ['ip1', 'ip2'])
 
     def test_run_on_unit(self):

--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -513,6 +513,9 @@ class TestModel(ut_utils.BaseTestCase):
             model.get_lead_unit_name('app', 'model'),
             'app/4')
 
+    def test_get_unit_public_address(self):
+        self.assertEqual(model.get_unit_public_address(self.unit1), 'ip1')
+
     def test_get_lead_unit_ip(self):
         self.patch_object(model, 'get_juju_model', return_value='mname')
         self.patch_object(model, 'get_units')

--- a/unit_tests/utilities/test_zaza_utilities_juju.py
+++ b/unit_tests/utilities/test_zaza_utilities_juju.py
@@ -43,7 +43,6 @@ class TestJujuUtils(ut_utils.BaseTestCase):
         self.machine2_mock = MachineMock()
         self.machine2_mock[self.key] = self.key_data
 
-
         def make_get_public_address(ip):
             async def _get_public_address():
                 return ip

--- a/unit_tests/utilities/test_zaza_utilities_juju.py
+++ b/unit_tests/utilities/test_zaza_utilities_juju.py
@@ -43,19 +43,33 @@ class TestJujuUtils(ut_utils.BaseTestCase):
         self.machine2_mock = MachineMock()
         self.machine2_mock[self.key] = self.key_data
 
+
+        def make_get_public_address(ip):
+            async def _get_public_address():
+                return ip
+
+            return _get_public_address
+
+        def fail_on_use():
+            raise RuntimeError("Don't use this property.")
+
         self.unit0 = "app/0"
         self.unit0_data = {"machine": self.machine0}
         self.unit0_mock = mock.MagicMock()
         self.unit0_mock.entity_id = self.unit0
         self.unit0_mock.data = {'machine-id': self.machine0}
-        self.unit0_mock.public_address = '10.0.0.11'
+        self.unit0_mock.public_address = property(fail_on_use)
+        self.unit0_mock.get_public_address = make_get_public_address(
+            '10.0.0.11')
 
         self.unit1 = "app/1"
         self.unit1_data = {"machine": self.machine1}
         self.unit1_mock = mock.MagicMock()
         self.unit1_mock.entity_id = self.unit1
         self.unit1_mock.data = {'machine-id': self.machine1}
-        self.unit1_mock.public_address = '10.0.0.1'
+        self.unit1_mock.public_address = property(fail_on_use)
+        self.unit1_mock.get_public_address = make_get_public_address(
+            '10.0.0.1')
 
         self.unit2 = "app/2"
         self.unit2_data = {"machine": self.machine2}
@@ -406,6 +420,7 @@ class TestJujuUtils(ut_utils.BaseTestCase):
             juju_utils.get_application_ip('app'),
             '10.0.0.10')
         self.model.get_application_config.return_value = {}
+        self.model.get_unit_public_address.return_value = '10.0.0.1'
         self.assertEqual(
             juju_utils.get_application_ip('app'),
             '10.0.0.1')

--- a/zaza/charm_tests/libjuju/__init__.py
+++ b/zaza/charm_tests/libjuju/__init__.py
@@ -1,0 +1,16 @@
+# Copyright 2022 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Collection of regression tests checking zaza/libjuju integration."""
+

--- a/zaza/charm_tests/libjuju/__init__.py
+++ b/zaza/charm_tests/libjuju/__init__.py
@@ -13,4 +13,3 @@
 # limitations under the License.
 
 """Collection of regression tests checking zaza/libjuju integration."""
-

--- a/zaza/charm_tests/libjuju/tests.py
+++ b/zaza/charm_tests/libjuju/tests.py
@@ -39,4 +39,3 @@ class RegressionTest(unittest.TestCase):
         ips = zaza.model.get_app_ips('ubuntu')
         for ip in ips:
             self.assertIsNotNone(ip)
-

--- a/zaza/charm_tests/libjuju/tests.py
+++ b/zaza/charm_tests/libjuju/tests.py
@@ -25,17 +25,28 @@ import zaza.model
 class RegressionTest(unittest.TestCase):
     """Regression Tests."""
 
-    def test_get_unit_public_address(self):
+    @classmethod
+    def setUpClass(cls):
+        """Run class setup."""
+        super().setUpClass()
+        cls._model = zaza.model.get_juju_model()
+        logging.info("model is %s", cls._model)
+
+    def test_01_get_app_ips(self):
+        """Verify that get_app_ips() doesn't invoke to async loops."""
+        logging.info('Verify that get_app_ips() works.')
+        ips = zaza.model.get_app_ips('ubuntu', model_name=self._model)
+        for ip in ips:
+            logging.info("Ip found %s", ip)
+            self.assertIsNotNone(ip)
+
+    def test_02_get_unit_public_address(self):
         """Verify get_unit_public_address()."""
         logging.info('Verify that get_unit_public_address() function works.')
         units = zaza.model.get_units('ubuntu')
-        ips = [zaza.model.get_unit_public_address(unit) for unit in units]
+        logging.info('units found: %s', units)
+        ips = [zaza.model.get_unit_public_address(unit, model_name=self._model)
+               for unit in units]
         for ip in ips:
-            self.assertIsNotNone(ip)
-
-    def test_get_app_ips(self):
-        """Verify that get_app_ips() doesn't invoke to async loops."""
-        logging.info('Verify that get_app_ips() works.')
-        ips = zaza.model.get_app_ips('ubuntu')
-        for ip in ips:
+            logging.info("Ip found %s", ip)
             self.assertIsNotNone(ip)

--- a/zaza/charm_tests/libjuju/tests.py
+++ b/zaza/charm_tests/libjuju/tests.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+
+# Copyright 2018 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test regression libjuju / zaza integration."""
+
+import logging
+import unittest
+
+import zaza.model
+
+
+class RegressionTest(unittest.TestCase):
+    """Regression Tests."""
+
+    def test_get_unit_public_address(self):
+        """Verify get_unit_public_address()."""
+        logging.info('Verify that get_unit_public_address() function works.')
+        units = zaza.model.get_units('ubuntu')
+        ips = [zaza.model.get_unit_public_address(unit) for unit in units]
+        for ip in ips:
+            self.assertIsNotNone(ip)
+
+    def test_get_app_ips(self):
+        """Verify that get_app_ips() doesn't invoke to async loops."""
+        logging.info('Verify that get_app_ips() works.')
+        ips = zaza.model.get_app_ips('ubuntu')
+        for ip in ips:
+            self.assertIsNotNone(ip)
+

--- a/zaza/model.py
+++ b/zaza/model.py
@@ -653,8 +653,34 @@ async def async_get_lead_unit_name(application_name, model_name=None):
 get_lead_unit_name = sync_wrapper(async_get_lead_unit_name)
 
 
-def get_unit_public_address(unit):
-    """Get the public address of a the unit.
+async def async_get_unit_public_address(unit, model_name=None):
+    """Get the public address of a unit.
+
+    Based on a feature flag "ZAZA_FEATURE_BUG472" existing, the function will
+    call `get_unit_public_address__libjuju()`.  Otherwise, it will fall back to
+    using `get_unit_public_address__fallback()` so that the public address can
+    be extracted.
+
+    Bug: https://github.com/openstack-charmers/zaza/issues/472
+
+    :param unit: The libjuju unit object to get the public address for.
+    :type unit: juju.Unit
+    :returns: the IP address of the unit, or None
+    :rtype: Optional(str)
+    """
+    if os.environ.get('ZAZA_FEATURE_BUG472', None):
+        return await async_get_unit_public_address__libjuju(
+            unit, model_name=model_name)
+    else:
+        return await async_get_unit_public_address__fallback(
+            unit, model_name=model_name)
+
+
+get_unit_public_address = sync_wrapper(async_get_unit_public_address)
+
+
+async def async_get_unit_public_address__libjuju(unit, model_name=None):
+    """Get the public address of a unit.
 
     The libjuju library, in theory, supports a unit.public_address attribute
     that provides the publick address of the unit.  However, when the unit is
@@ -662,17 +688,47 @@ def get_unit_public_address(unit):
     Therefore, there is a 'get_public_address()' funtion on unit that does
     provide the function.  See [1].
 
+    Note, if the underlying provider hasn't provided an address (yet) then this
+    will return None.
+
     1. https://github.com/juju/python-libjuju/issues/551
 
     :param unit: The libjuju unit object to get the public address for.
     :type unit: juju.Unit
     :returns: the IP address of the unit.
-    :rtype: str
+    :rtype: Optional(str)
     """
-    async def _get(unit_):
-        return await unit_.get_public_address()
+    return await unit.get_public_address()
 
-    return sync_wrapper(_get)(unit)
+
+async def async_get_unit_public_address__fallback(unit, model_name=None):
+    """Get the public address of a unit via juju status shell command.
+
+    Due to bug [1], this function calls juju status and extracts the public
+    address as provided by the juju go client, as libjuju is unreliable.
+    This is a stop-gap solution to work around the bug.  If the IP address
+    can't be found, then None is returned.
+
+    [1]: https://github.com/juju/python-libjuju/issues/615
+
+    :param unit: The libjuju unit object to get the public address for.
+    :type unit: juju.Unit
+    :returns: the IP address of the unit.
+    :rtype: Optional[str]
+    """
+    if model_name is None:
+        model_name = await async_get_juju_model()
+    cmd = "juju status --format=yaml -m {}".format(model_name)
+    result = await generic_utils.check_output(
+        cmd.split(), log_stderr=False, log_stdout=False)
+    status = yaml.safe_load(result['Stdout'])
+    try:
+        app = unit.name.split('/')[0]
+        return (
+            status['applications'][app]['units'][unit.name]['public-address'])
+    except KeyError:
+        logging.warn("Public address not found for %s", unit.name)
+        return None
 
 
 async def async_get_app_ips(application_name, model_name=None):
@@ -687,7 +743,8 @@ async def async_get_app_ips(application_name, model_name=None):
     """
     addresses = []
     for u in await async_get_units(application_name, model_name=model_name):
-        addresses.append(await u.get_public_address())
+        addresses.append(
+            await async_get_unit_public_address(u, model_name=model_name))
     return addresses
 
 
@@ -705,8 +762,8 @@ async def async_get_lead_unit_ip(application_name, model_name=None):
     :rtype: str
     :raises: zaza.utilities.exceptions.JujuError
     """
-    return await (await async_get_lead_unit(
-        application_name, model_name)).get_public_address()
+    return await async_get_unit_public_address(await async_get_lead_unit(
+        application_name, model_name))
 
 
 get_lead_unit_ip = sync_wrapper(async_get_lead_unit_ip)

--- a/zaza/model.py
+++ b/zaza/model.py
@@ -686,7 +686,8 @@ async def async_get_app_ips(application_name, model_name=None):
     :rtype: [str, str,...]
     """
     return [await u.get_public_address()
-            for u in get_units(application_name, model_name=model_name)]
+            for u in await async_get_units(
+                application_name, model_name=model_name)]
 
 
 get_app_ips = sync_wrapper(async_get_app_ips)

--- a/zaza/model.py
+++ b/zaza/model.py
@@ -685,9 +685,10 @@ async def async_get_app_ips(application_name, model_name=None):
     :returns: List of ip addresses
     :rtype: [str, str,...]
     """
-    return [await u.get_public_address()
-            for u in await async_get_units(
-                application_name, model_name=model_name)]
+    addresses = []
+    for u in await async_get_units(application_name, model_name=model_name):
+        addresses.append(await u.get_public_address())
+    return addresses
 
 
 get_app_ips = sync_wrapper(async_get_app_ips)

--- a/zaza/model.py
+++ b/zaza/model.py
@@ -653,7 +653,29 @@ async def async_get_lead_unit_name(application_name, model_name=None):
 get_lead_unit_name = sync_wrapper(async_get_lead_unit_name)
 
 
-def get_app_ips(application_name, model_name=None):
+def get_unit_public_address(unit):
+    """Get the public address of a the unit.
+
+    The libjuju library, in theory, supports a unit.public_address attribute
+    that provides the publick address of the unit.  However, when the unit is
+    an OpenStack VM, there is a race and it's possible it will be None.
+    Therefore, there is a 'get_public_address()' funtion on unit that does
+    provide the function.  See [1].
+
+    1. https://github.com/juju/python-libjuju/issues/551
+
+    :param unit: The libjuju unit object to get the public address for.
+    :type unit: juju.Unit
+    :returns: the IP address of the unit.
+    :rtype: str
+    """
+    async def _get(unit_):
+        return await unit_.get_public_address()
+
+    return sync_wrapper(_get)(unit)
+
+
+async def async_get_app_ips(application_name, model_name=None):
     """Return public address of all units of an application.
 
     :param model_name: Name of model to query.
@@ -663,8 +685,11 @@ def get_app_ips(application_name, model_name=None):
     :returns: List of ip addresses
     :rtype: [str, str,...]
     """
-    return [u.public_address
+    return [await u.get_public_address()
             for u in get_units(application_name, model_name=model_name)]
+
+
+get_app_ips = sync_wrapper(async_get_app_ips)
 
 
 async def async_get_lead_unit_ip(application_name, model_name=None):
@@ -678,8 +703,8 @@ async def async_get_lead_unit_ip(application_name, model_name=None):
     :rtype: str
     :raises: zaza.utilities.exceptions.JujuError
     """
-    return (await async_get_lead_unit(
-        application_name, model_name)).public_address
+    return await (await async_get_lead_unit(
+        application_name, model_name)).get_public_address()
 
 
 get_lead_unit_ip = sync_wrapper(async_get_lead_unit_ip)

--- a/zaza/utilities/generic.py
+++ b/zaza/utilities/generic.py
@@ -657,7 +657,7 @@ def validate_unit_process_ids(expected, actual):
     return True
 
 
-async def check_call(cmd):
+async def check_call(cmd, log_stdout=True, log_stderr=True):
     """Asynchronous function to check a subprocess call.
 
     :param cmd: Command to execute
@@ -666,10 +666,10 @@ async def check_call(cmd):
     :rtype: None
     :raises: subprocess.CalledProcessError if returncode !=0
     """
-    await check_output(cmd)
+    await check_output(cmd, log_stdout=log_stdout, log_stderr=log_stderr)
 
 
-async def check_output(cmd):
+async def check_output(cmd, log_stdout=True, log_stderr=True):
     """Asynchronous function to run a subprocess and get the output.
 
     Note, as the code raises an Exception on returncode != 0, 'Code' in the
@@ -677,6 +677,10 @@ async def check_output(cmd):
 
     :param cmd: Command to execute
     :type cmd: List[str]
+    :param log_stdout: Whether to log stdout on success, defaults to True
+    :type log_stdout: bool
+    :param log_stderr: Whether to log stderr on success, defaults to True
+    :type log_stderr: bool
     :returns: {'Code': '', 'Stderr': '', 'Stdout': ''}
     :rtype: dict
     :raises: subprocess.CalledProcessError if returncode !=0
@@ -691,11 +695,15 @@ async def check_output(cmd):
     if proc.returncode != 0:
         logging.warn("STDOUT: {}".format(stdout))
         logging.warn("STDERR: {}".format(stderr))
-        raise subprocess.CalledProcessError(proc.returncode, cmd)
+        raise subprocess.CalledProcessError(
+            returncode=proc.returncode,
+            cmd=cmd,
+            output=stdout,
+            stderr=stderr)
     else:
-        if stderr:
+        if stderr and log_stderr:
             logging.info("STDERR: {} ({})".format(stderr, ' '.join(cmd)))
-        if stdout:
+        if stdout and log_stdout:
             logging.info("STDOUT: {} ({})".format(stdout, ' '.join(cmd)))
     return {
         'Code': str(proc.returncode),

--- a/zaza/utilities/juju.py
+++ b/zaza/utilities/juju.py
@@ -511,5 +511,5 @@ def get_application_ip(application, model_name=None):
         unit = model.get_units(
             application,
             model_name=model_name)[0]
-        ip = unit.public_address
+        ip = model.get_unit_public_address(unit)
     return ip


### PR DESCRIPTION
This is a cherry-pick from the master branch of the following commits:

* 41b736a 2022-01-13 Add scripts and zaza/charm_tests/ to codecov ignore
* 0d7212a 2022-01-13 Add fallback for unit.get_public_address()
* 5457dc3 2022-01-11 Fix code for py3.5 and add a regression test
* c510eb4 2022-01-11 Resolve 'double' async loop issue with get_app_ips()
* 1e926f5 2022-01-10 Increase test coverage by providing test
* c0a699c 2022-01-07 Fix pep8 issue
* 0c89117 2022-01-07 Switch unit.public_address to unit.get_public_address()


Notes:

Due to the bug [1] on OpenStack providers, unit.public_address doesn't
actually work reliably.  The fix [2] is only for the async function
unit.get_public_address().  Sadly, zaza relied on unit.public_address
and so it needs this patch for juju 2.9 support on OpenStack providers.

Due to bug [3], it seems that there is a issue with libjuju
communicating with the Juju controller which causes a permanent
model disconnect that libjuju doesn't resolve.  Thus, for zaza, this
patch wraps unit.get_public.address() with a wrapper that can choose,
based on the environment variable `ZAZA_FEATURE_BUG472` to use a
subprocess shell call to the `juju status` command to get the public
address. This should always succeed.

The feature environment variable `ZAZA_FEATURE_BUG472` was added so that
the library can switch between the native libjuju function and the
fallback wrapper to enable testing of the issue as libjuju continues to
evolve.

By default, the wrapper function is used, to enable zaza to interoperate
with libjuju with Juju 2.9 on OpenStack providers.

The implementation is slightly complicated because an async version of
the wrapper `get_unit_public_address()` is needed as it is called from
async code.

[1]: juju/python-libjuju#551
[2]: juju/python-libjuju#600
[3]: juju/python-libjuju#615