### PR TITLE
Put libjuju asyncio on a background thread

### DIFF
--- a/examples/zaza-events/test.py
+++ b/examples/zaza-events/test.py
@@ -18,6 +18,7 @@ import os
 import pathlib
 import time
 
+import zaza
 import zaza.events
 from zaza.events import Events
 import zaza.events.plugins.logging
@@ -100,6 +101,7 @@ with open("combined.logs", "wt") as f:
 # and really just clean-up now.
 collection.clean_up()
 
+zaza.clean_up_libjuju_thread()
 # Deal with [1] in Python3.5
 # [1] https://bugs.python.org/issue28628
 asyncio.get_event_loop().close()

--- a/test.py
+++ b/test.py
@@ -1,6 +1,7 @@
 import zaza
 import zaza.model
 
-zaza.get_or_create_libjuju_thread()
-print(zaza.model.get_units('ubuntu'))
-zaza.clean_up_libjuju_thread()
+try:
+    print(zaza.model.get_units('ubuntu'))
+finally:
+    zaza.clean_up_libjuju_thread()

--- a/test.py
+++ b/test.py
@@ -1,0 +1,6 @@
+import zaza
+import zaza.model
+
+zaza.get_or_create_libjuju_thread()
+print(zaza.model.get_units('ubuntu'))
+zaza.clean_up_libjuju_thread()

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ deps = -r{toxinidir}/test-requirements.txt
 install_command =
   {toxinidir}/pip.sh install {opts} {packages}
 commands = nosetests --with-coverage --processes=0 --cover-package=zaza {posargs} {toxinidir}/unit_tests
+;commands = nosetests --with-coverage --processes=0 --cover-package=zaza {posargs} {toxinidir}/unit_tests/test_zaza_model.py:TestModel.test_ensure_model_connected_exception
 
 [testenv:py3]
 basepython = python3

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ passenv = HOME TERM CS_* OS_* TEST_*
 deps = -r{toxinidir}/test-requirements.txt
 install_command =
   {toxinidir}/pip.sh install {opts} {packages}
-commands = nosetests --with-coverage --cover-package=zaza {posargs} {toxinidir}/unit_tests
+commands = nosetests --with-coverage --processes=0 --cover-package=zaza {posargs} {toxinidir}/unit_tests
 
 [testenv:py3]
 basepython = python3

--- a/unit_tests/test_zaza_controller.py
+++ b/unit_tests/test_zaza_controller.py
@@ -18,6 +18,11 @@ import unittest
 import unit_tests.utils as ut_utils
 
 import zaza.controller as controller
+import zaza
+
+
+def tearDownModule():
+    zaza.clean_up_libjuju_thread()
 
 
 class TestController(ut_utils.BaseTestCase):

--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -445,7 +445,7 @@ class TestModel(ut_utils.BaseTestCase):
             await model.ensure_model_connected(self.mymodel)
 
         with mock.patch.object(zaza, 'RUN_LIBJUJU_IN_THREAD', new=False):
-            mymodel = model.sync_wrapper(_wrapper)()
+            model.sync_wrapper(_wrapper)()
             self.mymodel.disconnect.assert_called_once_with()
             self.mymodel.connect_model.assert_called_once_with(
                 self.mymodel.info.name)

--- a/unit_tests/utilities/test_zaza_utilities_generic.py
+++ b/unit_tests/utilities/test_zaza_utilities_generic.py
@@ -40,6 +40,10 @@ FAKE_STATUS = {
                                    'charm': 'local:trusty/hacluster-0'}}}}}
 
 
+def tearDownModule():
+    zaza.clean_up_libjuju_thread()
+
+
 class TestGenericUtils(ut_utils.BaseTestCase):
 
     def setUp(self):

--- a/zaza/__init__.py
+++ b/zaza/__init__.py
@@ -30,38 +30,73 @@
 
 """Functions to support converting async function to a sync equivalent."""
 import asyncio
+import concurrent.futures
 import logging
+import time
+import threading
 from pkgutil import extend_path
 from sys import version_info
+
+
 
 
 __path__ = extend_path(__path__, __name__)
 
 
-def run(*steps):
-    """Run the given steps in an asyncio loop.
+# Hold the libjuju thread so we can interact with it.
+_libjuju_thread = None
+_libjuju_loop = None
+_libjuju_run = True
 
-    If the tasks spawns other future (tasks) then these are also cleaned up
-    after each step is performed.
 
-    :returns: The result of the last asyncio.Task
-    :rtype: Any
+def get_or_create_libjuju_thread():
+    """Get (or Create) the thread that libjuju asyncio is running in.
+
+    :returns: the thread that libjuju is running in.
+    :rtype: threading.Thread
     """
-    if not steps:
-        return
+    global _libjuju_thread, _libjuju_loop, _libjuju_run
+    if _libjuju_thread is None:
+        _libjuju_thread = threading.Thread(target=libjuju_thread_run)
+        _libjuju_run = True
+        _libjuju_thread.start()
+        # There's a race hazard for _libjuju_loop becoming available, so let's
+        # wait for that to happen.
+        while _libjuju_loop is None:
+            pass
+    return _libjuju_thread
+
+
+def libjuju_thread_run():
+    """The thread that contains the runtime for libjuju asyncio futures.
+
+    zaza runs libjuju in a background thread so that it can make progress as
+    needed with the model(s) that are connect.  The sync functions run in the
+    foreground thread, and the asyncio libjuju functions run in the background
+    thread. `run_coroutine_threadsafe` is used to cross from sync to asyncio
+    code in the background thread to enable access to the libjuju.
+
+    Note: it's very important that libjuju objects are not updated in the sync
+    thread; it's advisable that they are copied into neutral objects and handed
+    back.  e.g. always use unit_name, rather than handling a libjuju 'unit'
+    object in a sync function.
+    """
+    global _libjuju_loop
+
+    async def looper():
+        global _libjuju_run
+        while _libjuju_run:
+            # short spinner to ensure that foreground tasks 'happen' so that
+            # background tasks can complete (e.g. during model disconnection).
+            # loop.run_forever() doesn't work as there is no foreground async
+            # task to make progress, and thus the background tasks do nothing.
+            await asyncio.sleep(0.1)
+
+    _libjuju_loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(_libjuju_loop)
     try:
-        loop = asyncio.get_running_loop()
-    except RuntimeError:
-        loop = asyncio.new_event_loop()
-    except AttributeError:
-        # Remove once support for Python 3.6 is dropped
-        loop = asyncio.get_event_loop()
-
-    for step in steps:
-        task = loop.create_task(step)
-        loop.run_until_complete(asyncio.wait([task]))
-
-        # Let's also cancel any remaining tasks:
+        _libjuju_loop.run_until_complete(_libjuju_loop.create_task(looper()))
+    finally:
         while True:
             # issue #445 - asyncio.Task.all_tasks() deprecated in 3.7
             if version_info.major == 3 and version_info.minor >= 7:
@@ -80,7 +115,7 @@ def run(*steps):
                 for pending_task in pending_tasks:
                     pending_task.cancel()
                     try:
-                        loop.run_until_complete(pending_task)
+                        _libjuju_loop.run_until_complete(pending_task)
                     except asyncio.CancelledError:
                         pass
                     except Exception as e:
@@ -89,21 +124,72 @@ def run(*steps):
                             .format(str(e)))
             else:
                 break
+    _libjuju_loop.close()
 
-    return task.result()
+
+def join_libjuju_thread():
+    """Stop and cleanup the asyncio tasks on the loop, and then join it.
+    """
+    global _libjuju_thread, _libjuju_loop, _libjuju_run
+    if _libjuju_thread is not None:
+        logging.debug("stopping the event loop")
+        _libjuju_run = False
+        while not(_libjuju_loop.is_closed()):
+            logging.debug("Closing ...")
+            time.sleep(.5)
+        logging.debug("joining the loop")
+        _libjuju_thread.join(timeout=30.0)
+        if _libjuju_thread.is_alive():
+            logging.error("The thread didn't die")
+            raise RuntimeError(
+                "libjuju async thread didn't finish after 30seconds")
 
 
-def sync_wrapper(f):
-    """Convert the given async function into a sync function.
+def clean_up_libjuju_thread():
+    """Clean up the libjuju thread and any models that are still running.
+    """
+    # circular import; tricky to remove
+    from . import model
+    sync_wrapper(model.remove_models_memo)()
+    join_libjuju_thread()
 
-    This is only to be called from sync code and it runs all tasks (and cancels
-    all tasks at the end of each run) for the code that is being given.
 
+def sync_wrapper(f, timeout=None):
+    """Convert the async function into one that runs in the async thread.
+
+    This is only to be called from sync code.  It wraps the given async
+    co-routine in some sync logic that allows it to be injected into the async
+    libjuju thread.  This is then waited until there is a result, in which case
+    the result is returned.
+
+    :param f: The async co-routine to wrap.
+    :type f: Coroutine
+    :param timeout: The timeout to apply, None for no timeout
+    :type timeout: Optional[float]
     :returns: The de-async'd function
     :rtype: function
     """
     def _wrapper(*args, **kwargs):
-        async def _run_it():
+        global _libjuju_loop
+        async def _runner():
             return await f(*args, **kwargs)
-        return run(_run_it())
+
+        # ensure that the thread is created
+        assert _libjuju_loop is not None and _libjuju_loop.is_running(), \
+            ("Background thread must be running, was "
+             "get_or_create_libjuju_thread() called?")
+
+        # Submit the coroutine to a given loop
+        future = asyncio.run_coroutine_threadsafe(_runner(), _libjuju_loop)
+        try:
+            return future.result(timeout)
+        except concurrent.futures.TimeoutError:
+            logging.error(
+                'The coroutine took too long, cancelling the task...')
+            future.cancel()
+            raise
+        except Exception as exc:
+            logging.error(f'The coroutine raised an exception: {exc!r}')
+            raise
+
     return _wrapper

--- a/zaza/__init__.py
+++ b/zaza/__init__.py
@@ -50,7 +50,7 @@ _libjuju_loop = None
 _libjuju_run = False
 
 # Timeout for loop to close.  This is set to 30 seconds.  If there is a non
-# async all in the async thread then it could stall the thread for more than 30
+# async call in the async thread then it could stall the thread for more than 30
 # seconds (e.g. an errant subprocess call).  This will cause a runtime error if
 # the timeout is exceeded.  This shouldn't normally be the case as there is
 # only one 'start' and 'stop' of the thread during a zaza runtime

--- a/zaza/__init__.py
+++ b/zaza/__init__.py
@@ -50,9 +50,9 @@ _libjuju_loop = None
 _libjuju_run = False
 
 # Timeout for loop to close.  This is set to 30 seconds.  If there is a non
-# async call in the async thread then it could stall the thread for more than 30
-# seconds (e.g. an errant subprocess call).  This will cause a runtime error if
-# the timeout is exceeded.  This shouldn't normally be the case as there is
+# async call in the async thread then it could stall the thread for more than
+# 30 seconds (e.g. an errant subprocess call).  This will cause a runtime error
+# if the timeout is exceeded.  This shouldn't normally be the case as there is
 # only one 'start' and 'stop' of the thread during a zaza runtime
 LOOP_CLOSE_TIMEOUT = 30.0
 
@@ -89,7 +89,7 @@ def libjuju_thread_run():
     The thread that contains the runtime for libjuju asyncio futures.
 
     zaza runs libjuju in a background thread so that it can make progress as
-    needed with the model(s) that are connect.  The sync functions run in the
+    needed with the model(s) that are connected.  The sync functions run in the
     foreground thread, and the asyncio libjuju functions run in the background
     thread. `run_coroutine_threadsafe` is used to cross from sync to asyncio
     code in the background thread to enable access to the libjuju.

--- a/zaza/charm_lifecycle/before_deploy.py
+++ b/zaza/charm_lifecycle/before_deploy.py
@@ -91,4 +91,5 @@ def main():
     funcs = args.configfuncs or utils.get_charm_config()['before_deploy']
     before_deploy(args.model_name, funcs, test_directory=args.test_directory)
     run_report.output_event_report()
+    zaza.clean_up_libjuju_thread()
     asyncio.get_event_loop().close()

--- a/zaza/charm_lifecycle/before_deploy.py
+++ b/zaza/charm_lifecycle/before_deploy.py
@@ -89,7 +89,9 @@ def main():
     args = parse_args(sys.argv[1:])
     cli_utils.setup_logging(log_level=args.loglevel.upper())
     funcs = args.configfuncs or utils.get_charm_config()['before_deploy']
-    before_deploy(args.model_name, funcs, test_directory=args.test_directory)
-    run_report.output_event_report()
-    zaza.clean_up_libjuju_thread()
-    asyncio.get_event_loop().close()
+    try:
+        before_deploy(args.model_name, funcs, test_directory=args.test_directory)
+        run_report.output_event_report()
+    finally:
+        zaza.clean_up_libjuju_thread()
+        asyncio.get_event_loop().close()

--- a/zaza/charm_lifecycle/before_deploy.py
+++ b/zaza/charm_lifecycle/before_deploy.py
@@ -90,7 +90,8 @@ def main():
     cli_utils.setup_logging(log_level=args.loglevel.upper())
     funcs = args.configfuncs or utils.get_charm_config()['before_deploy']
     try:
-        before_deploy(args.model_name, funcs, test_directory=args.test_directory)
+        before_deploy(
+            args.model_name, funcs, test_directory=args.test_directory)
         run_report.output_event_report()
     finally:
         zaza.clean_up_libjuju_thread()

--- a/zaza/charm_lifecycle/configure.py
+++ b/zaza/charm_lifecycle/configure.py
@@ -95,4 +95,5 @@ def main():
             funcs = config_steps.get(model_alias, [])
         configure(model_name, funcs)
     run_report.output_event_report()
+    zaza.clean_up_libjuju_thread()
     asyncio.get_event_loop().close()

--- a/zaza/charm_lifecycle/configure.py
+++ b/zaza/charm_lifecycle/configure.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 """Run configuration phase."""
-import asyncio
 import argparse
+import asyncio
 import sys
 
 import zaza.model

--- a/zaza/charm_lifecycle/configure.py
+++ b/zaza/charm_lifecycle/configure.py
@@ -87,13 +87,15 @@ def main():
     """
     args = parse_args(sys.argv[1:])
     cli_utils.setup_logging(log_level=args.loglevel.upper())
-    for model_alias, model_name in args.model.items():
-        if args.configfuncs:
-            funcs = args.configfuncs
-        else:
-            config_steps = utils.get_config_steps()
-            funcs = config_steps.get(model_alias, [])
-        configure(model_name, funcs)
-    run_report.output_event_report()
-    zaza.clean_up_libjuju_thread()
-    asyncio.get_event_loop().close()
+    try:
+        for model_alias, model_name in args.model.items():
+            if args.configfuncs:
+                funcs = args.configfuncs
+            else:
+                config_steps = utils.get_config_steps()
+                funcs = config_steps.get(model_alias, [])
+            configure(model_name, funcs)
+        run_report.output_event_report()
+    finally:
+        zaza.clean_up_libjuju_thread()
+        asyncio.get_event_loop().close()

--- a/zaza/charm_lifecycle/deploy.py
+++ b/zaza/charm_lifecycle/deploy.py
@@ -450,3 +450,4 @@ def main():
         force=args.force,
         test_directory=args.test_directory)
     run_report.output_event_report()
+    zaza.clean_up_libjuju_thread()

--- a/zaza/charm_lifecycle/deploy.py
+++ b/zaza/charm_lifecycle/deploy.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Run deploy phase."""
+import asyncio
 import argparse
 import jinja2
 import logging

--- a/zaza/charm_lifecycle/deploy.py
+++ b/zaza/charm_lifecycle/deploy.py
@@ -443,11 +443,14 @@ def main():
     if args.force:
         logging.warn("Using the --force argument for 'juju deploy'. Note "
                      "that this disables juju checks for compatibility.")
-    deploy(
-        args.bundle,
-        args.model,
-        wait=args.wait,
-        force=args.force,
-        test_directory=args.test_directory)
-    run_report.output_event_report()
-    zaza.clean_up_libjuju_thread()
+    try:
+        deploy(
+            args.bundle,
+            args.model,
+            wait=args.wait,
+            force=args.force,
+            test_directory=args.test_directory)
+        run_report.output_event_report()
+    finally:
+        zaza.clean_up_libjuju_thread()
+        asyncio.get_event_loop().close()

--- a/zaza/charm_lifecycle/destroy.py
+++ b/zaza/charm_lifecycle/destroy.py
@@ -64,3 +64,4 @@ def main():
     args = parse_args(sys.argv[1:])
     cli_utils.setup_logging(log_level=args.loglevel.upper())
     destroy(args.model_name)
+    zaza.clean_up_libjuju_thread()

--- a/zaza/charm_lifecycle/destroy.py
+++ b/zaza/charm_lifecycle/destroy.py
@@ -63,5 +63,8 @@ def main():
     """Cleanup after test run."""
     args = parse_args(sys.argv[1:])
     cli_utils.setup_logging(log_level=args.loglevel.upper())
-    destroy(args.model_name)
-    zaza.clean_up_libjuju_thread()
+    try:
+        destroy(args.model_name)
+    finally:
+        zaza.clean_up_libjuju_thread()
+        asyncio.get_event_loop().close()

--- a/zaza/charm_lifecycle/destroy.py
+++ b/zaza/charm_lifecycle/destroy.py
@@ -14,6 +14,7 @@
 
 """Run destroy phase."""
 import argparse
+import asyncio
 import sys
 
 import zaza.controller

--- a/zaza/charm_lifecycle/func_test_runner.py
+++ b/zaza/charm_lifecycle/func_test_runner.py
@@ -20,6 +20,7 @@ import os
 import sys
 import yaml
 
+import zaza
 import zaza.charm_lifecycle.before_deploy as before_deploy
 import zaza.charm_lifecycle.configure as configure
 import zaza.charm_lifecycle.destroy as destroy
@@ -381,4 +382,5 @@ def main():
         force=args.force,
         test_directory=args.test_directory)
     run_report.output_event_report()
+    zaza.clean_up_libjuju_thread()
     asyncio.get_event_loop().close()

--- a/zaza/charm_lifecycle/prepare.py
+++ b/zaza/charm_lifecycle/prepare.py
@@ -72,3 +72,4 @@ def main():
     logging.info('model_name: {}'.format(args.model_name))
     prepare(args.model_name, test_directory=args.test_directory)
     run_report.output_event_report()
+    zaza.clean_up_libjuju_thread()

--- a/zaza/charm_lifecycle/prepare.py
+++ b/zaza/charm_lifecycle/prepare.py
@@ -70,6 +70,9 @@ def main():
     args = parse_args(sys.argv[1:])
     cli_utils.setup_logging(log_level=args.loglevel.upper())
     logging.info('model_name: {}'.format(args.model_name))
-    prepare(args.model_name, test_directory=args.test_directory)
-    run_report.output_event_report()
-    zaza.clean_up_libjuju_thread()
+    try:
+        prepare(args.model_name, test_directory=args.test_directory)
+        run_report.output_event_report()
+    finally:
+        zaza.clean_up_libjuju_thread()
+        asyncio.get_event_loop().close()

--- a/zaza/charm_lifecycle/prepare.py
+++ b/zaza/charm_lifecycle/prepare.py
@@ -14,6 +14,7 @@
 
 """Run prepare phase."""
 import argparse
+import asyncio
 import logging
 import sys
 

--- a/zaza/charm_lifecycle/test.py
+++ b/zaza/charm_lifecycle/test.py
@@ -198,4 +198,5 @@ def main():
             tests,
             test_directory=args.test_directory)
     run_report.output_event_report()
+    zaza.clean_up_libjuju_thread()
     asyncio.get_event_loop().close()

--- a/zaza/charm_lifecycle/test.py
+++ b/zaza/charm_lifecycle/test.py
@@ -187,16 +187,18 @@ def main():
     if args.config:
         for config_item in args.config:
             add_config_option(config_item)
-    for model_alias, model_name in args.model.items():
-        if args.tests:
-            tests = args.tests
-        else:
-            test_steps = utils.get_test_steps()
-            tests = test_steps.get(model_alias, [])
-        test(
-            model_name,
-            tests,
-            test_directory=args.test_directory)
-    run_report.output_event_report()
-    zaza.clean_up_libjuju_thread()
-    asyncio.get_event_loop().close()
+    try:
+        for model_alias, model_name in args.model.items():
+            if args.tests:
+                tests = args.tests
+            else:
+                test_steps = utils.get_test_steps()
+                tests = test_steps.get(model_alias, [])
+            test(
+                model_name,
+                tests,
+                test_directory=args.test_directory)
+        run_report.output_event_report()
+    finally:
+        zaza.clean_up_libjuju_thread()
+        asyncio.get_event_loop().close()

--- a/zaza/charm_lifecycle/test.py
+++ b/zaza/charm_lifecycle/test.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 """Run test phase."""
-import asyncio
 import argparse
+import asyncio
 import logging
-import unittest
 import sys
+import unittest
 
 import zaza.model
 import zaza.global_options as global_options

--- a/zaza/utilities/__init__.py
+++ b/zaza/utilities/__init__.py
@@ -17,8 +17,29 @@
 
 from functools import wraps
 import json
+import logging
 import os
 import types
+
+
+# Keep a copy of what we've already deprecated
+deprecations = set()
+
+
+def deprecate():
+    """Add a deprecation warning to wrapped function."""
+    def wrap(f):
+
+        @wraps(f)
+        def wrapped_f(*args, **kwargs):
+            global deprecations
+            if f not in deprecations:
+                msg = "{} is deprecated. ".format(f.__name__)
+                logging.warning(msg)
+                deprecations.add(f)
+            return f(*args, **kwargs)
+        return wrapped_f
+    return wrap
 
 
 class ConfigurableMixin:


### PR DESCRIPTION
This PR is a piece of work to:

1. Put the asyncio libjuju API interface code on a background thread.
2. Re work `sync-wrapper` to inject calls into the background thread's asyncio event loop, allow it to process, and retrieve the results.
3. Re-work `run_in_model` and related functions so that a libjuju Model is maintained so that the libjuju objects attached to models remaining 'current' and can be used *between* sync calls (from the front thread) for a more consistent and functional sync code experience.

The background asyncio thread is kept running to allow libjuju data structures to be updated independently of the front thread.  The GIL enables thread-safe data sharing between the threads so that libjuju objects can be read/updated from the sync code thread.

This should solve a bunch of errors including disconnects, slow operations (continuing to re-connect to the model multiple times during a run), memory issues, etc.