### PR TITLE
Switch the local overlay default to False

### DIFF
--- a/unit_tests/test_zaza_charm_lifecycle_deploy.py
+++ b/unit_tests/test_zaza_charm_lifecycle_deploy.py
@@ -209,7 +209,7 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
         _filename = "filename"
         self.yaml_read_patch(_yaml, _yaml_dict)
 
-        self.assertTrue(
+        self.assertFalse(
             lc_deploy.is_local_overlay_enabled_in_bundle(_filename))
         self._open.assert_called_once_with(_filename, "r")
         self.yaml.safe_load.assert_called_once_with(_yaml)

--- a/zaza/charm_lifecycle/deploy.py
+++ b/zaza/charm_lifecycle/deploy.py
@@ -240,9 +240,14 @@ def is_local_overlay_enabled_in_bundle(bundle):
     """Check the bundle to see if a local overlay should be applied.
 
     Read the bundle and look for LOCAL_OVERLAY_ENABLED_KEY and return
-    its value if present otherwise return True. This allows a bundle
-    to disable adding the local overlay which points the bundle at
+    its value if present otherwise return False. This allows a bundle
+    to enable adding the local overlay which points the bundle at
     the local charm.
+
+    NOTE: this has changed; it used to default to True when most bundles didn't
+    explicitly specify the charm for the local charm being tested.  Now, every
+    bundle needs to be explicit about whether to enable the local overlay, or
+    specify the charm by directory or charmcraft .charm file.
 
     :param bundle: Name of bundle being deployed
     :type bundle: str
@@ -250,7 +255,7 @@ def is_local_overlay_enabled_in_bundle(bundle):
     :rtype: bool
     """
     with open(bundle, 'r') as stream:
-        return yaml.safe_load(stream).get(LOCAL_OVERLAY_ENABLED_KEY, True)
+        return yaml.safe_load(stream).get(LOCAL_OVERLAY_ENABLED_KEY, False)
 
 
 def should_render_local_overlay(bundle):


### PR DESCRIPTION
When zaza was first implemented, every bundle was local to a charm, and
it was convenient to assume that the local charm under test should be
used automatically.

Since then, the space has changed, charmcraft has introduced built
artifacts (<name>.charm) and automatic overlays get in the way of this.

This patch switches the default for the local overlay to be False.  This
means that bundles that *want* to use a local overlay have to be
explicit and enable it using "local_overlay_enabled: true".

This means that *most* overlays don't need the key (going forwards).