### PR TITLE
Enable resolve of install hooks for network issues

### DIFF
--- a/unit_tests/test_zaza_charm_lifecycle_deploy.py
+++ b/unit_tests/test_zaza_charm_lifecycle_deploy.py
@@ -397,7 +397,7 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
         self.wait_for_application_states.assert_called_once_with(
             'newmodel',
             {},
-            timeout=3600)
+            timeout=3600, max_resolve_count=0)
 
     def test_deploy_bespoke_states(self):
         self.patch_object(lc_deploy.zaza.model, 'wait_for_application_states')
@@ -417,7 +417,25 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
             {'vault': {
                 'workload-status': 'blocked',
                 'workload-status-message': 'Vault needs to be inited'}},
-            timeout=3600)
+            timeout=3600, max_resolve_count=0)
+
+    def test_deploy_resolve_count(self):
+        self.patch_object(lc_deploy.deployment_env, 'get_deployment_context')
+        self.patch_object(lc_deploy.zaza.model, 'wait_for_application_states')
+        self.patch_object(lc_deploy.utils, 'get_charm_config')
+        self.get_deployment_context.return_value = {
+            'TEST_MAX_RESOLVE_COUNT': 3,
+        }
+        self.get_charm_config.return_value = {}
+        self.patch_object(lc_deploy, 'deploy_bundle')
+        lc_deploy.deploy('bun.yaml', 'newmodel')
+        self.deploy_bundle.assert_called_once_with('bun.yaml', 'newmodel',
+                                                   model_ctxt=None,
+                                                   force=False)
+        self.wait_for_application_states.assert_called_once_with(
+            'newmodel',
+            {},
+            timeout=3600, max_resolve_count=3)
 
     def test_deploy_nowait(self):
         self.patch_object(lc_deploy.zaza.model, 'wait_for_application_states')

--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -1157,6 +1157,27 @@ class TestModel(ut_utils.BaseTestCase):
                 self.unit1,
                 regex=r"my\sholiday.$"))
 
+    def test_is_unit_errored_from_install_hook(self):
+        self._application_states_setup({
+            'workload-status': 'error',
+            'workload-status-message': 'hook failed: "install"'})
+        self.assertTrue(
+            model.is_unit_errored_from_install_hook(self.unit1))
+
+    def test_is_unit_errored_from_install_hook_not_install_hook(self):
+        self._application_states_setup({
+            'workload-status': 'error',
+            'workload-status-message': 'hook failed: "config-changed"'})
+        self.assertFalse(
+            model.is_unit_errored_from_install_hook(self.unit1))
+
+    def test_is_unit_errored_from_install_hook_not_error(self):
+        self._application_states_setup({
+            'workload-status': 'blocked',
+            'workload-status-message': 'waiting on the sunset'})
+        self.assertFalse(
+            model.is_unit_errored_from_install_hook(self.unit1))
+
     def test_wait_for_application_states(self):
         self._application_states_setup({
             'workload-status': 'active',
@@ -1171,6 +1192,84 @@ class TestModel(ut_utils.BaseTestCase):
         with self.assertRaises(model.UnitError):
             model.wait_for_application_states('modelname', timeout=1)
             self.assertFalse(self.system_ready)
+
+    def test_wait_for_application_states_retries_no_success(self):
+        self.patch_object(model, 'check_model_for_hard_errors')
+        self.patch_object(model, 'async_resolve_units')
+        self.patch_object(model, 'check_unit_workload_status')
+
+        def unit_wl_status(_model, unit, states):
+            # There are two units. Only raise an error for the first unit
+            # so we can test scenarios where one unit is okay, the other
+            # unit is not okay.
+            if unit.name == 'app/2':
+                raise model.UnitError([unit])
+
+        self.check_unit_workload_status.side_effect = unit_wl_status
+        self._application_states_setup({
+            'workload-status': 'error',
+            'workload-status-message': 'hook failed: "install"'})
+        type(self.unit2).workload_status = 'active'
+        type(self.unit2).workload_status_message = 'Unit is ready'
+        with self.assertRaises(model.UnitError):
+            model.wait_for_application_states('modelname', timeout=1,
+                                              max_resolve_count=3)
+            self.assertFalse(self.system_ready)
+        self.assertEquals(self.async_resolve_units.call_count, 3)
+
+    def test_wait_for_application_states_retries_non_retryable(self):
+        self.patch_object(model, 'check_model_for_hard_errors')
+        self.patch_object(model, 'async_resolve_units')
+        self.patch_object(model, 'check_unit_workload_status')
+
+        def unit_wl_status(_model, unit, states):
+            # There are two units. Only raise an error for the first unit
+            # so we can test scenarios where one unit is okay, the other
+            # unit is not okay.
+            if unit.name == 'app/2':
+                raise model.UnitError([unit])
+
+        self.check_unit_workload_status.side_effect = unit_wl_status
+        self._application_states_setup({
+            'workload-status': 'error',
+            'workload-status-message': 'hook failed: "config-changed"'})
+        type(self.unit2).workload_status = 'active'
+        type(self.unit2).workload_status_message = 'Unit is ready'
+        with self.assertRaises(model.UnitError):
+            model.wait_for_application_states('modelname', timeout=1,
+                                              max_resolve_count=3)
+            self.assertFalse(self.system_ready)
+        self.async_resolve_units.assert_not_called()
+
+    def test_wait_for_application_states_retries_with_success(self):
+        self.patch_object(model, 'check_model_for_hard_errors')
+        self.patch_object(model, 'async_resolve_units')
+        self.patch_object(model, 'check_unit_workload_status')
+        count = 0
+
+        def unit_wl_status(_model, unit, states):
+            # After a couple of retries, we want to simulate the unit going
+            # into the active state, so tweak the state.
+            if unit.name == 'app/2':
+                nonlocal count
+                count += 1
+                if count < 3:
+                    raise model.UnitError([unit])
+                # Mutate the state for the desired behavior :-/
+                type(unit).workload_status = 'active'
+                type(unit).workload_status_message = 'Unit is ready'
+            return True
+
+        self.check_unit_workload_status.side_effect = unit_wl_status
+        self._application_states_setup({
+            'workload-status': 'error',
+            'workload-status-message': 'hook failed: "install"'})
+        type(self.unit2).workload_status = 'active'
+        type(self.unit2).workload_status_message = 'Unit is ready'
+
+        model.wait_for_application_states('modelname', timeout=500,
+                                          max_resolve_count=3)
+        self.assertEquals(self.async_resolve_units.call_count, 2)
 
     def test_wait_for_application_states_blocked_ok(self):
         self._application_states_setup({

--- a/zaza/charm_lifecycle/deploy.py
+++ b/zaza/charm_lifecycle/deploy.py
@@ -386,13 +386,16 @@ def deploy(bundle, model, wait=True, model_ctxt=None, force=False,
         zaza.model.set_juju_model(model)
         deploy_ctxt = deployment_env.get_deployment_context()
         timeout = int(deploy_ctxt.get('TEST_DEPLOY_TIMEOUT', '3600'))
+        max_resolve_count = int(deploy_ctxt.get('TEST_MAX_RESOLVE_COUNT', 0))
         logging.info("Timeout for deployment to settle set to: {}".format(
             timeout))
+        logging.info("Maximum resolve count for deployment set to: {}".format(
+            max_resolve_count))
         with notify_around(NotifyEvents.WAIT_MODEL_SETTLE, model=model):
             zaza.model.wait_for_application_states(
                 model,
                 test_config.get('target_deploy_status', {}),
-                timeout=timeout)
+                timeout=timeout, max_resolve_count=max_resolve_count)
         run_report.register_event_finish('Wait for Deployment')
 
 


### PR DESCRIPTION
Allow for failed install hooks to be resolved in order to provide a set
of tolerance for various network blips and dns issues that may occur in
the networks of the testing substrates.

This introduces environment variable TEST_MAX_RESOLVE_COUNT which
specifies the maximum number of attempts to resolve an install hook
failure. This defaults to 0 and is should be an integer value.

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>