### PR TITLE
Add async sleep after resolving units

### DIFF
--- a/zaza/model.py
+++ b/zaza/model.py
@@ -1582,6 +1582,9 @@ async def async_wait_for_application_states(model_name=None, states=None,
                                 application_name=unit.application,
                                 erred_hook='install'
                             )
+                            # now we sleep to allow some time for libjuju
+                            # async tasks to catch up.
+                            await asyncio.sleep(5)
 
                         all_okay = False
 


### PR DESCRIPTION
Allow libjuju async tasks to proceed after resolving a unit.

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>