### PR TITLE
CI: fix juju crashdump collection

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -52,12 +52,14 @@ jobs:
         set -euxo pipefail
         mkdir logs
         tox -e func | tee logs/tox-output.txt
-        juju status -m $(juju models --format yaml|grep "^- name:.*zaza"|cut -f2 -d/) | tee logs/juju-status.txt
     - name: crashdump on failure
       if: failure()
       run: |
-        set -euxo pipefail
-        juju crashdump -o logs/
+        set -eux
+        juju models
+        model=$(juju models --format yaml|grep "^- name:.*zaza"|cut -f2 -d/)
+        juju status -m $model | tee logs/juju-status.txt
+        juju crashdump -m $model -o logs/
     - name: upload logs on failure
       if: failure()
       uses: actions/upload-artifact@v2

--- a/tox.ini
+++ b/tox.ini
@@ -56,7 +56,7 @@ basepython = python3
 deps = -r{toxinidir}/requirements.txt
 commands =
     {envdir}/bin/python3 setup.py install
-    functest-run-suite --keep-model
+    functest-run-suite --keep-faulty-model
 
 [testenv:func-target]
 basepython = python3


### PR DESCRIPTION
The ``--keep-last-model`` literally only keeps the last model, so
if the failure is in the middle model it will be destroyed.  Use
``--keep-faulty-model`` instead.

The `juju status` command is currently run after tox in the same
job. In the event of non-zero return from tox the shell will stop
execution and subsequently not issue the ``juju status``.  Move
to crashdump job instead.

The ``juju crashdump`` command is currently not scoped to the
Zaza model(s) and subsequently fails to collect data.