### PR TITLE
Use local-overlay when there is an explicit local overlay file.

### DIFF
--- a/unit_tests/test_zaza_charm_lifecycle_deploy.py
+++ b/unit_tests/test_zaza_charm_lifecycle_deploy.py
@@ -253,7 +253,7 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
 
         # File exists bundle overrides False
         self.is_local_overlay_enabled_in_bundle.return_value = False
-        self.assertFalse(lc_deploy.should_render_local_overlay(_bundle))
+        self.assertTrue(lc_deploy.should_render_local_overlay(_bundle))
 
         # No file, charm_name present
         self.isfile.return_value = False
@@ -313,6 +313,11 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
         self.render_local_overlay.return_value = '/tmp/local-overlay.yaml'
         self.patch_object(lc_deploy, 'render_overlay')
         self.render_overlay.side_effect = lambda x, y, model_ctxt: RESP[x]
+        self.patch_object(
+            lc_deploy.os.path,
+            'isfile',
+            return_value=True)
+        self.isfile.return_value = False
         self.assertEqual(
             lc_deploy.render_overlays('mybundles/mybundle.yaml', '/tmp'),
             ['/tmp/mybundle.yaml'])

--- a/zaza/charm_lifecycle/deploy.py
+++ b/zaza/charm_lifecycle/deploy.py
@@ -276,7 +276,10 @@ def should_render_local_overlay(bundle):
         DEFAULT_OVERLAY_TEMPLATE_DIR,
         "{}.j2".format(LOCAL_OVERLAY_TEMPLATE_NAME))
     charm_name = utils.get_charm_config().get('charm_name', None)
-    if os.path.isfile(overlay) or charm_name:
+    if os.path.isfile(overlay):
+        # If there is an explicit local overlay template file, use it.
+        return True
+    if charm_name:
         # Check for an override in the bundle.
         # Note: the default is True if the LOCAL_OVERLAY_ENABLED_KEY
         # is not present.


### PR DESCRIPTION
The local-overlay-enabled key in a bundle is used to disable
automatic local-oerlay generation that overwrites the charm-
under-test to a local path version, but was also disabling
explicit local overlays.