### PR TITLE
Fix force_deploy being wrong type and crashing zaza

### DIFF
--- a/tests/bundles/second.yaml
+++ b/tests/bundles/second.yaml
@@ -3,10 +3,6 @@ applications:
     series: focal
     charm: cs:~openstack-charmers-next/magpie
     num_units: 2
-  magpie-hirsute:
-    series: hirsute
-    charm: cs:~openstack-charmers-next/magpie
-    num_units: 2
   ubuntu:
     charm: cs:ubuntu
     num_units: 3

--- a/zaza/charm_lifecycle/utils.py
+++ b/zaza/charm_lifecycle/utils.py
@@ -455,7 +455,8 @@ def is_config_deploy_forced_for_bundle(
     config = get_charm_config(yaml_file, fatal)
     try:
         return bundle_name in config['tests_options']['force_deploy']
-    except KeyError:
+    # Type error is if the force_deploy is present, but with no list
+    except (KeyError, TypeError):
         pass
     return False
 


### PR DESCRIPTION
If force_deploy dosn't have a list or iterable, then zaza crashes with a
TypeError.  This patch makes it more robust.

Also remove the hirsute series from the second.yaml bundle to allow
functional tests to pass.

(cherry picked from commit 2f77f39fe899069e2e96132ec321900f1ba1d51a)