### PR TITLE
Pin pyparsing to < 3.0 for aodhclient

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+pyparsing<3.0.0  # pin for aodhclient which is held for py35
 aiounittest
 async_generator
 kubernetes<18.0.0; python_version < '3.6' # pined, as juju uses kubernetes


### PR DESCRIPTION
aodhclient is pinned to <1.4.  Pin pyparsing here so that if
zaza-openstack-tests is installed, aodhclient (pinned) will get the
right client.

Cherry-pick of b63337874