### PR TITLE
fix use of test_directory in functest-configure

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,6 @@ deps = -r{toxinidir}/test-requirements.txt
 install_command =
   {toxinidir}/pip.sh install {opts} {packages}
 commands = nosetests --with-coverage --processes=0 --cover-package=zaza {posargs} {toxinidir}/unit_tests
-;commands = nosetests --with-coverage --processes=0 --cover-package=zaza {posargs} {toxinidir}/unit_tests/test_zaza_model.py:TestModel.test_ensure_model_connected_exception
 
 [testenv:py3]
 basepython = python3

--- a/zaza/charm_lifecycle/configure.py
+++ b/zaza/charm_lifecycle/configure.py
@@ -92,9 +92,12 @@ def main():
             if args.configfuncs:
                 funcs = args.configfuncs
             else:
+                # NOTE: get_config_steps need to have test-directory set
+                utils.set_base_test_dir(test_dir=args.test_directory)
                 config_steps = utils.get_config_steps()
                 funcs = config_steps.get(model_alias, [])
-            configure(model_name, funcs)
+
+            configure(model_name, funcs, args.test_directory)
         run_report.output_event_report()
     finally:
         zaza.clean_up_libjuju_thread()


### PR DESCRIPTION
The argument `test_directory` was never used in the `functest-configure`.