### PR TITLE
[xena] Capture enough lines for troubleshooting

### DIFF
--- a/zaza/charm_lifecycle/func_test_runner.py
+++ b/zaza/charm_lifecycle/func_test_runner.py
@@ -51,7 +51,7 @@ def failure_report(model_aliases, show_juju_status=False):
     :type show_juju_status: bool
     """
     logging.error(model_aliases)
-    error_lines = 20
+    error_lines = 200
     for model_alias, model_name in model_aliases.items():
         logging.error("Model {} ({})".format(model_alias, model_name))
         status = zaza.model.get_status(model_name=model_name)


### PR DESCRIPTION
Follow-up of 9159cf5dbace4b6b6851cd79f2efe4bf35b688d1

20 lines are not enough sometimes to capture the real error or failure.
By having 200 lines we can cover most of the output from a single hook
execution. For example, the real DNS failure wasn't captured in Zaza
output but the full juju crashdump had to be downloaded to see those
lines.

unit.mysql-innodb-cluster/2.install logger.go:60 W: Failed to fetch
http://archive.ubuntu.com/ubuntu/dists/focal/InRelease Temporary failure
resolving 'archive.ubuntu.com'

unit.mysql-innodb-cluster/2.install logger.go:60
subprocess.CalledProcessError: Command '['apt-get',
'--option=Dpkg::Options::=--force-confold', '--assume-yes', 'install',
'python3-pip', 'python3-setuptools', 'python3-yaml', 'python3-dev',
'python3-wheel', 'build-essential']' returned non-zero exit status 100.

(cherry picked from commit b6a5ab782dcd1f3b7ba4b1c50a87d3d6c95e1012)