### PR TITLE
Set user agent.

### DIFF
--- a/unit_tests/test_zaza_utilities_openstack_provider.py
+++ b/unit_tests/test_zaza_utilities_openstack_provider.py
@@ -103,10 +103,13 @@ class TestOpenStackUtils(ut_utils.BaseTestCase):
         session_mock = mock.MagicMock()
         self.patch_object(openstack_provider.novaclient_client, "Client")
         openstack_provider.get_nova_session_client(session_mock)
-        self.Client.assert_called_once_with(2, session=session_mock)
+        self.Client.assert_called_once_with(
+            2, session=session_mock, user_agent=openstack_provider.USER_AGENT)
         self.Client.reset_mock()
         openstack_provider.get_nova_session_client(session_mock, version=2.56)
-        self.Client.assert_called_once_with(2.56, session=session_mock)
+        self.Client.assert_called_once_with(
+            2.56, session=session_mock,
+            user_agent=openstack_provider.USER_AGENT)
 
     def test__resource_removed(self):
         resource_mock = mock.MagicMock()
@@ -185,7 +188,8 @@ class TestOpenStackUtils(ut_utils.BaseTestCase):
             "OS_TENANT_NAME": "tenant",
         }
         openstack_provider.get_keystone_session(_openrc)
-        self.session.Session.assert_called_once_with(auth=_auth, verify=None)
+        self.session.Session.assert_called_once_with(
+            auth=_auth, verify=None, user_agent=openstack_provider.USER_AGENT)
 
     def test_get_keystone_session_tls(self):
         self.patch_object(openstack_provider, "session")
@@ -202,4 +206,5 @@ class TestOpenStackUtils(ut_utils.BaseTestCase):
         }
         openstack_provider.get_keystone_session(_openrc)
         self.session.Session.assert_called_once_with(
-            auth=_auth, verify=_cacert)
+            auth=_auth, verify=_cacert,
+            user_agent=openstack_provider.USER_AGENT)

--- a/zaza/utilities/openstack_provider.py
+++ b/zaza/utilities/openstack_provider.py
@@ -26,6 +26,9 @@ from keystoneauth1.identity import (
 from novaclient import client as novaclient_client
 
 
+USER_AGENT = 'zaza'
+
+
 class MissingOSAthenticationException(Exception):
     """Exception when some data needed to authenticate is missing."""
 
@@ -66,7 +69,8 @@ def get_keystone_session(openrc_creds, scope='PROJECT', verify=None):
         auth = v2.Password(**keystone_creds)
     else:
         auth = v3.Password(**keystone_creds)
-    return session.Session(auth=auth, verify=verify)
+    return session.Session(auth=auth, verify=verify,
+                           user_agent=USER_AGENT)
 
 
 def get_ks_creds(cloud_creds, scope='PROJECT'):
@@ -191,7 +195,8 @@ def get_nova_session_client(session, version=2):
     :returns: Authenticated novaclient
     :rtype: novaclient.Client object
     """
-    return novaclient_client.Client(version, session=session)
+    return novaclient_client.Client(version, session=session,
+                                    user_agent=USER_AGENT)
 
 
 # Manage resources


### PR DESCRIPTION
Set the user agent in the clients to identify requests issued by zaza
more easily.