### PR TITLE
Pin libjuju < 3.0 for stable branches

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 pyparsing<3.0.0  # pin for aodhclient which is held for py35
 aiounittest
 async_generator
+juju<3.0
 kubernetes<18.0.0; python_version < '3.6' # pined, as juju uses kubernetes
-juju
 juju_wait
 PyYAML>=3.0
 flake8>=2.2.4

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ install_require = [
 
     'hvac<0.7.0',
     'jinja2',
-    'juju',
+    'juju<3.0',
     'juju-wait',
     'PyYAML',
     'tenacity',


### PR DESCRIPTION
The stable versions of zaza & zaza-openstack-tests may break
compatibility with libjuju (import juju) over time, so pin to < 3.0
which is known to work. It's definitely broken with the stable/ussuri
branch of zaza.