### PR TITLE
Add option to deploy models with --trust

### DIFF
--- a/unit_tests/test_zaza_charm_lifecycle_func_test_runner.py
+++ b/unit_tests/test_zaza_charm_lifecycle_func_test_runner.py
@@ -85,10 +85,10 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
         deploy_calls = [
             mock.call(cwd + '/tests/bundles/bundle1.yaml', 'newmodel',
                       model_ctxt={'default_alias': 'newmodel'},
-                      force=True, test_directory=None),
+                      force=True, test_directory=None, trust=False),
             mock.call(cwd + '/tests/bundles/bundle2.yaml', 'newmodel',
                       model_ctxt={'default_alias': 'newmodel'},
-                      force=True, test_directory=None)]
+                      force=True, test_directory=None, trust=False)]
         configure_calls = [
             mock.call('newmodel', [
                 'zaza.charm_tests.mycharm.setup.basic_setup'
@@ -163,20 +163,20 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
         deploy_calls = [
             mock.call(cwd + '/tests/bundles/bundle1.yaml', 'm1',
                       model_ctxt={'default_alias': 'm1'}, force=False,
-                      test_directory=None),
+                      test_directory=None, trust=False),
             mock.call(cwd + '/tests/bundles/bundle2.yaml', 'm2',
                       model_ctxt={'default_alias': 'm2'}, force=False,
-                      test_directory=None),
+                      test_directory=None, trust=False),
             mock.call(
                 cwd + '/tests/bundles/bundle5.yaml',
                 'm3',
                 model_ctxt={'model_alias_5': 'm3', 'model_alias_6': 'm4'},
-                force=False, test_directory=None),
+                force=False, test_directory=None, trust=False),
             mock.call(
                 cwd + '/tests/bundles/bundle6.yaml',
                 'm4',
                 model_ctxt={'model_alias_5': 'm3', 'model_alias_6': 'm4'},
-                force=False, test_directory=None)]
+                force=False, test_directory=None, trust=False)]
         configure_calls = [
             mock.call('m1', [
                 'zaza.charm_tests.mycharm.setup.basic_setup',
@@ -251,10 +251,10 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
         deploy_calls = [
             mock.call(cwd + '/tests/bundles/bundle1.yaml', 'newmodel',
                       model_ctxt={'default_alias': 'newmodel'}, force=False,
-                      test_directory=None),
+                      test_directory=None, trust=False),
             mock.call(cwd + '/tests/bundles/bundle2.yaml', 'newmodel',
                       model_ctxt={'default_alias': 'newmodel'}, force=False,
-                      test_directory=None)]
+                      test_directory=None, trust=False)]
         before_deploy_calls = [
             mock.call('newmodel', [
                 'zaza.charm_tests.prepare.first',
@@ -312,7 +312,7 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
             mock.call(cwd + '/tests/bundles/bundle2.yaml', 'newmodel',
                       model_ctxt={'default_alias': 'newmodel'},
                       force=False,
-                      test_directory=None)]
+                      test_directory=None, trust=False)]
         self.deploy.assert_has_calls(deploy_calls)
 
     def test_func_test_runner_dev(self):
@@ -344,10 +344,10 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
         deploy_calls = [
             mock.call(cwd + '/tests/bundles/bundle3.yaml', 'newmodel',
                       model_ctxt={'default_alias': 'newmodel'}, force=False,
-                      test_directory=None),
+                      test_directory=None, trust=False),
             mock.call(cwd + '/tests/bundles/bundle4.yaml', 'newmodel',
                       model_ctxt={'default_alias': 'newmodel'}, force=False,
-                      test_directory=None)]
+                      test_directory=None, trust=False)]
         self.deploy.assert_has_calls(deploy_calls)
 
     def test_func_test_runner_specify_bundle(self):
@@ -382,7 +382,7 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
                 'newmodel',
                 model_ctxt={'default_alias': 'newmodel'},
                 force=False,
-                test_directory=None)]
+                test_directory=None, trust=False)]
         self.deploy.assert_has_calls(deploy_calls)
 
     def test_func_test_runner_specify_bundle_with_alias(self):
@@ -418,7 +418,7 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
                 'newmodel',
                 model_ctxt={'alias': 'newmodel'},
                 force=False,
-                test_directory=None)]
+                test_directory=None, trust=False)]
         self.deploy.assert_has_calls(deploy_calls)
 
     def test_func_test_runner_specify_bundle_with_implicit_alias(self):
@@ -447,7 +447,7 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
                 'newmodel',
                 model_ctxt={'alias': 'newmodel'},
                 force=False,
-                test_directory=None)]
+                test_directory=None, trust=False)]
         self.deploy.assert_has_calls(deploy_calls)
 
     def test_func_test_runner_cmr_specify_bundle_with_alias(self):
@@ -485,14 +485,14 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
                 model_ctxt={'alias': 'newmodel1',
                             'another_alias': 'newmodel2'},
                 force=False,
-                test_directory=None),
+                test_directory=None, trust=False),
             mock.call(
                 cwd + '/tests/bundles/maverick-things.yaml',
                 'newmodel2',
                 model_ctxt={'alias': 'newmodel1',
                             'another_alias': 'newmodel2'},
                 force=False,
-                test_directory=None)]
+                test_directory=None, trust=False)]
         self.deploy.assert_has_calls(deploy_calls)
 
     def test_main_smoke_dev_ambiguous(self):

--- a/unit_tests/test_zaza_charm_lifecycle_utils.py
+++ b/unit_tests/test_zaza_charm_lifecycle_utils.py
@@ -256,6 +256,30 @@ class TestCharmLifecycleUtils(ut_utils.BaseTestCase):
         }
         self.assertTrue(lc_utils.is_config_deploy_forced_for_bundle('x'))
 
+    def test_is_config_deploy_trusted_for_bundle(self):
+        self.patch_object(lc_utils, 'get_charm_config')
+        # test that no options at all returns value
+        self.get_charm_config.return_value = {}
+        self.assertFalse(lc_utils.is_config_deploy_trusted_for_bundle('x'))
+        # test that if options exist but no bundle
+        self.get_charm_config.return_value = {
+            'tests_options': {}
+        }
+        self.assertFalse(lc_utils.is_config_deploy_trusted_for_bundle('x'))
+        self.get_charm_config.return_value = {
+            'tests_options': {
+                'trust': []
+            }
+        }
+        self.assertFalse(lc_utils.is_config_deploy_trusted_for_bundle('x'))
+        # verify that it returns True if the bundle is mentioned
+        self.get_charm_config.return_value = {
+            'tests_options': {
+                'trust': ['x']
+            }
+        }
+        self.assertTrue(lc_utils.is_config_deploy_trusted_for_bundle('x'))
+
     def test_get_class(self):
         self.assertEqual(
             type(lc_utils.get_class('unit_tests.'

--- a/zaza/charm_lifecycle/utils.py
+++ b/zaza/charm_lifecycle/utils.py
@@ -466,6 +466,38 @@ def is_config_deploy_forced_for_bundle(
     return False
 
 
+def is_config_deploy_trusted_for_bundle(
+        bundle_name, yaml_file=None, fatal=True):
+    """Ask the config if the bundle_name should be deployed with --trust.
+
+    The tests_options section needs to look like:
+
+        tests_options:
+          trust:
+            - focal-ussuri
+
+    e.g. trust is a list of bundle names; if the bundle is mentioned
+    then that bundle will be deployed with --trust.
+
+    :param bundle_name: the bundle to check in the trust list
+    :type bundle_name: str
+    :param yaml_file: the YAML file that contains the tests specification
+    :type yaml_file: Optional[str]
+    :param fatal: whether any errors cause an exception or are just logged.
+    :type fatal: bool
+    :returns: True if the config option is set for the bundle
+    :rtype: bool
+    :raises: OSError if the YAML file doesn't exist and fatal=True
+    """
+    config = get_charm_config(yaml_file, fatal)
+    try:
+        return bundle_name in config['tests_options']['trust']
+    # Type error is if the trust is present, but with no list
+    except (KeyError, TypeError):
+        pass
+    return False
+
+
 def get_class(class_str):
     """Get the class represented by the given string.
 


### PR DESCRIPTION
This will be required if we use zaza
for testing sunbeam and any other k8s operator charms that require trust.