### PR TITLE
Ensure absolute path to the bundle.

### DIFF
--- a/zaza/charm_lifecycle/deploy.py
+++ b/zaza/charm_lifecycle/deploy.py
@@ -446,7 +446,7 @@ def main():
                      "that this disables juju checks for compatibility.")
     try:
         deploy(
-            args.bundle,
+            os.path.abspath(args.bundle),
             args.model,
             wait=args.wait,
             force=args.force,


### PR DESCRIPTION
Juju expects local bundles to be passed as absolute paths or with the
prefix './', the latter is removed by tox when passed as extra
parameters

$ tox -e venv -- functest-deploy -b './tests/bundles/focal-yoga.yaml' -m mymodel
...
venv run-test: commands[0] | functest-deploy -b tests/bundles/focal-yoga.yaml -m keystone
...
2022-08-16 18:07:18 [INFO] Deploying overlay '/tmp/tmpcl3emk96/local-charm-overlay.yaml' on to 'keystone' model
2022-08-16 18:07:20 [INFO] ERROR The charm or bundle "tests/bundles/focal-yoga.yaml" is ambiguous.
2022-08-16 18:07:20 [INFO] To deploy a local charm or bundle, run `juju deploy ./tests/bundles/focal-yoga.yaml`.

This change expands the path to the bundle passed in the command line to
an absolute path.