### PR TITLE
Fix functional testing

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -46,6 +46,11 @@ jobs:
         sudo chmod 666 /var/snap/lxd/common/lxd/unix.socket
         # until Juju provides stable IPv6-support we unfortunately need this
         lxc network set lxdbr0 ipv6.address none
+        # pull images
+        lxc image copy --alias juju/bionic/amd64 --copy-aliases ubuntu-daily:bionic local:
+        lxc image copy --alias juju/focal/amd64 --copy-aliases ubuntu-daily:focal local:
+        lxc image copy --alias juju/jammy/amd64 --copy-aliases ubuntu-daily:jammy local:
+        lxc image list
         juju bootstrap --no-gui localhost
     - name: Functional test
       run: |

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ from setuptools.command.test import test as TestCommand
 
 version = "0.0.1.dev1"
 install_require = [
+    'aiohttp<4.0.0',  # aiohttp/_http_parser.c:16227:5: error: lvalue required as increment operand
     'oslo.config<6.12.0',  # pin at stable/train to retain Py3.5 support
     'async_generator',
 

--- a/tests/bundles/first.yaml
+++ b/tests/bundles/first.yaml
@@ -1,7 +1,7 @@
 series: focal
 applications:
-  magpie-xenial:
-    series: xenial
+  magpie-focal:
+    series: focal
     charm: ch:magpie
     channel: latest/edge
     num_units: 2

--- a/tests/bundles/first.yaml
+++ b/tests/bundles/first.yaml
@@ -1,3 +1,4 @@
+series: focal
 applications:
   magpie-xenial:
     series: xenial

--- a/tests/bundles/first.yaml
+++ b/tests/bundles/first.yaml
@@ -1,12 +1,14 @@
 applications:
   magpie-xenial:
     series: xenial
-    charm: cs:~openstack-charmers-next/magpie
+    charm: ch:magpie
+    channel: latest/edge
     num_units: 2
   magpie-bionic:
     series: bionic
-    charm: cs:~openstack-charmers-next/magpie
+    charm: ch:magpie
+    channel: latest/edge
     num_units: 2
   ubuntu:
-    charm: cs:ubuntu
+    charm: ch:ubuntu
     num_units: 3

--- a/tests/bundles/second.yaml
+++ b/tests/bundles/second.yaml
@@ -1,3 +1,4 @@
+series: focal
 applications:
   magpie-focal:
     series: focal

--- a/tests/bundles/second.yaml
+++ b/tests/bundles/second.yaml
@@ -1,8 +1,9 @@
 applications:
   magpie-focal:
     series: focal
-    charm: cs:~openstack-charmers-next/magpie
+    charm: ch:magpie
+    channel: latest/edge
     num_units: 2
   ubuntu:
-    charm: cs:ubuntu
+    charm: ch:ubuntu
     num_units: 3

--- a/tests/bundles/third.yaml
+++ b/tests/bundles/third.yaml
@@ -1,3 +1,4 @@
+series: focal
 applications:
   ubuntu:
     charm: ch:ubuntu

--- a/tests/bundles/third.yaml
+++ b/tests/bundles/third.yaml
@@ -1,5 +1,5 @@
 applications:
   ubuntu:
-    charm: cs:ubuntu
+    charm: ch:ubuntu
     num_units: 10
 

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -7,9 +7,6 @@ gate_bundles:
 - second
 - third
 target_deploy_status:
-  magpie-xenial:
-    workload-status: active
-    workload-status-message-prefix: icmp ok, local hostname ok
   magpie-bionic:
     workload-status: active
     workload-status-message-prefix: icmp ok, local hostname ok
@@ -21,6 +18,9 @@ target_deploy_status:
     workload-status-message-prefix: icmp ok, local hostname ok
   ubuntu:
     workload-status-message-regex: "^$"
+  ntp:
+    workload-status: active
+    workload-status-message-prefix: 'chrony: Ready'
 configure:
 - zaza.charm_tests.noop.setup.basic_setup
 tests:


### PR DESCRIPTION
This patch series fixes the functional testing and adds some improvements to make it more stable.

* Switch away from `cs:` to `ch:`
* Set the default series in the bundles to focal, this allows to get a reliable testing outside the CI system where the default series may be different.
* Add ntp charm as a subordinate of ubuntu to exercise subordinates related functionality.
* Import the LXD images before juju bootstrap, this prevents juju from racing when launching multiple machines of the same series.
* Drop Xenial in favor of Focal (see https://github.com/juju-solutions/charm-ubuntu/issues/45 )
* Pin `aiohttp<4.0.0`, because 4.0.0a1 fails to build on Jammy.