### PR TITLE
Add method to return model info

### DIFF
--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -518,6 +518,13 @@ class TestModel(ut_utils.BaseTestCase):
             model.sync_wrapper(self._wrapper)()
         self.mock_sleep.assert_awaited_with(1.5)
 
+    def test_get_model_info(self):
+        model_info = mock.Mock()
+        self.Model_mock.info = model_info
+        self.patch_object(model, 'Model')
+        self.Model.return_value = self.Model_mock
+        self.assertEqual(model.get_model_info(), model_info)
+
     def test_scp_to_unit(self):
         self.patch_object(model, 'get_juju_model', return_value='mname')
         self.patch_object(model, 'Model')

--- a/zaza/model.py
+++ b/zaza/model.py
@@ -414,6 +414,24 @@ async def block_until_auto_reconnect_model(*conditions,
     await asyncio.wait_for(_block(), timeout)
 
 
+async def async_get_model_info(model_name=None):
+    """Get information about the model.
+
+    Useful keys in the ModelInfo object include:
+        'agent-version', 'cloud-region', 'name', 'owner-tag', 'provider-type',
+        'type'
+
+    :param model_name: Name of model to gather information on.
+    :type model_name: str
+    :returns: The Model info object
+    :rtype: juju.client._definitions.ModelInfo
+    """
+    model = await get_model(model_name)
+    return model.info
+
+get_model_info = sync_wrapper(async_get_model_info)
+
+
 async def async_scp_to_unit(unit_name, source, destination, model_name=None,
                             user='ubuntu', proxy=False, scp_opts=''):
     """Transfer files to unit_name in model_name.


### PR DESCRIPTION
The model info object contains useful information like the provider type without relying on a local copy of the clouds definition file.