### PR TITLE
Correct get_application_ip on k8s with missing app

### DIFF
--- a/zaza/utilities/juju.py
+++ b/zaza/utilities/juju.py
@@ -533,7 +533,10 @@ def get_application_ip(application, model_name=None):
     :rtype: str
     """
     if is_k8s_deployment():
-        ip = get_k8s_ingress_ip(application, model_name=model_name)
+        try:
+            ip = get_k8s_ingress_ip(application, model_name=model_name)
+        except KeyError:
+            return ''
     else:
         try:
             app_config = model.get_application_config(


### PR DESCRIPTION
Fix get_application_ip so that it returns an empty string if the application is missing with the k8s provider. This makes it consistent with the non-k8s version.