### PR TITLE
Add support for ignore_hard_deploy_errors

### DIFF
--- a/unit_tests/test_zaza_charm_lifecycle_deploy.py
+++ b/unit_tests/test_zaza_charm_lifecycle_deploy.py
@@ -414,13 +414,18 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
         self.get_charm_config.return_value = {}
         self.patch_object(lc_deploy, 'deploy_bundle')
         lc_deploy.deploy('bun.yaml', 'newmodel')
-        self.deploy_bundle.assert_called_once_with('bun.yaml', 'newmodel',
-                                                   model_ctxt=None,
-                                                   force=False, trust=False)
+        self.deploy_bundle.assert_called_once_with(
+            'bun.yaml',
+            'newmodel',
+            model_ctxt=None,
+            force=False,
+            trust=False)
         self.wait_for_application_states.assert_called_once_with(
             'newmodel',
             {},
-            timeout=3600, max_resolve_count=0)
+            timeout=3600,
+            max_resolve_count=0,
+            ignore_hard_errors=False)
 
     def test_deploy_bespoke_states(self):
         self.patch_object(lc_deploy.zaza.model, 'wait_for_application_states')
@@ -432,15 +437,20 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
                     'workload-status-message': 'Vault needs to be inited'}}}
         self.patch_object(lc_deploy, 'deploy_bundle')
         lc_deploy.deploy('bun.yaml', 'newmodel')
-        self.deploy_bundle.assert_called_once_with('bun.yaml', 'newmodel',
-                                                   model_ctxt=None,
-                                                   force=False, trust=False)
+        self.deploy_bundle.assert_called_once_with(
+            'bun.yaml',
+            'newmodel',
+            model_ctxt=None,
+            force=False,
+            trust=False)
         self.wait_for_application_states.assert_called_once_with(
             'newmodel',
             {'vault': {
                 'workload-status': 'blocked',
                 'workload-status-message': 'Vault needs to be inited'}},
-            timeout=3600, max_resolve_count=0)
+            timeout=3600,
+            max_resolve_count=0,
+            ignore_hard_errors=False)
 
     def test_deploy_resolve_count(self):
         self.patch_object(lc_deploy.deployment_env, 'get_deployment_context')
@@ -452,13 +462,19 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
         self.get_charm_config.return_value = {}
         self.patch_object(lc_deploy, 'deploy_bundle')
         lc_deploy.deploy('bun.yaml', 'newmodel')
-        self.deploy_bundle.assert_called_once_with('bun.yaml', 'newmodel',
-                                                   model_ctxt=None,
-                                                   force=False, trust=False)
+        self.deploy_bundle.assert_called_once_with(
+            'bun.yaml',
+            'newmodel',
+            model_ctxt=None,
+            force=False,
+            trust=False)
+#            ignore_hard_deploy_errors=False)
         self.wait_for_application_states.assert_called_once_with(
             'newmodel',
             {},
-            timeout=3600, max_resolve_count=3)
+            timeout=3600,
+            max_resolve_count=3,
+            ignore_hard_errors=False)
 
     def test_deploy_nowait(self):
         self.patch_object(lc_deploy.zaza.model, 'wait_for_application_states')

--- a/unit_tests/test_zaza_charm_lifecycle_func_test_runner.py
+++ b/unit_tests/test_zaza_charm_lifecycle_func_test_runner.py
@@ -85,10 +85,12 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
         deploy_calls = [
             mock.call(cwd + '/tests/bundles/bundle1.yaml', 'newmodel',
                       model_ctxt={'default_alias': 'newmodel'},
-                      force=True, test_directory=None, trust=False),
+                      force=True, test_directory=None, trust=False,
+                      ignore_hard_deploy_errors=False),
             mock.call(cwd + '/tests/bundles/bundle2.yaml', 'newmodel',
                       model_ctxt={'default_alias': 'newmodel'},
-                      force=True, test_directory=None, trust=False)]
+                      force=True, test_directory=None, trust=False,
+                      ignore_hard_deploy_errors=False)]
         configure_calls = [
             mock.call('newmodel', [
                 'zaza.charm_tests.mycharm.setup.basic_setup'
@@ -163,20 +165,24 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
         deploy_calls = [
             mock.call(cwd + '/tests/bundles/bundle1.yaml', 'm1',
                       model_ctxt={'default_alias': 'm1'}, force=False,
-                      test_directory=None, trust=False),
+                      test_directory=None, trust=False,
+                      ignore_hard_deploy_errors=False),
             mock.call(cwd + '/tests/bundles/bundle2.yaml', 'm2',
                       model_ctxt={'default_alias': 'm2'}, force=False,
-                      test_directory=None, trust=False),
+                      test_directory=None, trust=False,
+                      ignore_hard_deploy_errors=False),
             mock.call(
                 cwd + '/tests/bundles/bundle5.yaml',
                 'm3',
                 model_ctxt={'model_alias_5': 'm3', 'model_alias_6': 'm4'},
-                force=False, test_directory=None, trust=False),
+                force=False, test_directory=None, trust=False,
+                ignore_hard_deploy_errors=False),
             mock.call(
                 cwd + '/tests/bundles/bundle6.yaml',
                 'm4',
                 model_ctxt={'model_alias_5': 'm3', 'model_alias_6': 'm4'},
-                force=False, test_directory=None, trust=False)]
+                force=False, test_directory=None, trust=False,
+                ignore_hard_deploy_errors=False)]
         configure_calls = [
             mock.call('m1', [
                 'zaza.charm_tests.mycharm.setup.basic_setup',
@@ -251,10 +257,12 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
         deploy_calls = [
             mock.call(cwd + '/tests/bundles/bundle1.yaml', 'newmodel',
                       model_ctxt={'default_alias': 'newmodel'}, force=False,
-                      test_directory=None, trust=False),
+                      test_directory=None, trust=False,
+                      ignore_hard_deploy_errors=False),
             mock.call(cwd + '/tests/bundles/bundle2.yaml', 'newmodel',
                       model_ctxt={'default_alias': 'newmodel'}, force=False,
-                      test_directory=None, trust=False)]
+                      test_directory=None, trust=False,
+                      ignore_hard_deploy_errors=False)]
         before_deploy_calls = [
             mock.call('newmodel', [
                 'zaza.charm_tests.prepare.first',
@@ -312,7 +320,8 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
             mock.call(cwd + '/tests/bundles/bundle2.yaml', 'newmodel',
                       model_ctxt={'default_alias': 'newmodel'},
                       force=False,
-                      test_directory=None, trust=False)]
+                      test_directory=None, trust=False,
+                      ignore_hard_deploy_errors=False)]
         self.deploy.assert_has_calls(deploy_calls)
 
     def test_func_test_runner_dev(self):
@@ -344,10 +353,12 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
         deploy_calls = [
             mock.call(cwd + '/tests/bundles/bundle3.yaml', 'newmodel',
                       model_ctxt={'default_alias': 'newmodel'}, force=False,
-                      test_directory=None, trust=False),
+                      test_directory=None, trust=False,
+                      ignore_hard_deploy_errors=False),
             mock.call(cwd + '/tests/bundles/bundle4.yaml', 'newmodel',
                       model_ctxt={'default_alias': 'newmodel'}, force=False,
-                      test_directory=None, trust=False)]
+                      test_directory=None, trust=False,
+                      ignore_hard_deploy_errors=False)]
         self.deploy.assert_has_calls(deploy_calls)
 
     def test_func_test_runner_specify_bundle(self):
@@ -382,7 +393,8 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
                 'newmodel',
                 model_ctxt={'default_alias': 'newmodel'},
                 force=False,
-                test_directory=None, trust=False)]
+                test_directory=None, trust=False,
+                ignore_hard_deploy_errors=False)]
         self.deploy.assert_has_calls(deploy_calls)
 
     def test_func_test_runner_specify_bundle_with_alias(self):
@@ -418,7 +430,8 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
                 'newmodel',
                 model_ctxt={'alias': 'newmodel'},
                 force=False,
-                test_directory=None, trust=False)]
+                test_directory=None, trust=False,
+                ignore_hard_deploy_errors=False)]
         self.deploy.assert_has_calls(deploy_calls)
 
     def test_func_test_runner_specify_bundle_with_implicit_alias(self):
@@ -447,7 +460,8 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
                 'newmodel',
                 model_ctxt={'alias': 'newmodel'},
                 force=False,
-                test_directory=None, trust=False)]
+                test_directory=None, trust=False,
+                ignore_hard_deploy_errors=False)]
         self.deploy.assert_has_calls(deploy_calls)
 
     def test_func_test_runner_cmr_specify_bundle_with_alias(self):
@@ -485,14 +499,16 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
                 model_ctxt={'alias': 'newmodel1',
                             'another_alias': 'newmodel2'},
                 force=False,
-                test_directory=None, trust=False),
+                test_directory=None, trust=False,
+                ignore_hard_deploy_errors=False),
             mock.call(
                 cwd + '/tests/bundles/maverick-things.yaml',
                 'newmodel2',
                 model_ctxt={'alias': 'newmodel1',
                             'another_alias': 'newmodel2'},
                 force=False,
-                test_directory=None, trust=False)]
+                test_directory=None, trust=False,
+                ignore_hard_deploy_errors=False)]
         self.deploy.assert_has_calls(deploy_calls)
 
     def test_main_smoke_dev_ambiguous(self):

--- a/unit_tests/test_zaza_charm_lifecycle_utils.py
+++ b/unit_tests/test_zaza_charm_lifecycle_utils.py
@@ -256,6 +256,30 @@ class TestCharmLifecycleUtils(ut_utils.BaseTestCase):
         }
         self.assertTrue(lc_utils.is_config_deploy_forced_for_bundle('x'))
 
+    def test_ignore_hard_deploy_errors(self):
+        self.patch_object(lc_utils, 'get_charm_config')
+        # test that no options at all returns value
+        self.get_charm_config.return_value = {}
+        self.assertFalse(lc_utils.ignore_hard_deploy_errors('x'))
+        # test that if options exist but no bundle
+        self.get_charm_config.return_value = {
+            'tests_options': {}
+        }
+        self.assertFalse(lc_utils.ignore_hard_deploy_errors('x'))
+        self.get_charm_config.return_value = {
+            'tests_options': {
+                'ignore_hard_deploy_errors': []
+            }
+        }
+        self.assertFalse(lc_utils.ignore_hard_deploy_errors('x'))
+        # verify that it returns True if the bundle is mentioned
+        self.get_charm_config.return_value = {
+            'tests_options': {
+                'ignore_hard_deploy_errors': ['x']
+            }
+        }
+        self.assertTrue(lc_utils.ignore_hard_deploy_errors('x'))
+
     def test_is_config_deploy_trusted_for_bundle(self):
         self.patch_object(lc_utils, 'get_charm_config')
         # test that no options at all returns value

--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -1274,6 +1274,20 @@ class TestModel(ut_utils.BaseTestCase):
                 model.wait_for_application_states('modelname', timeout=1)
                 self.assertFalse(self.system_ready)
 
+    def test_wait_for_application_states_errored_unit_ignore(self):
+        self._application_states_setup({
+            'workload-status': 'error',
+            'workload-status-message': 'Unit is ready'})
+        with mock.patch.object(zaza, 'RUN_LIBJUJU_IN_THREAD', new=False):
+            # Expect a model timeout as the error state is not fatal
+            # but is not the required state.
+            with self.assertRaises(model.ModelTimeout):
+                model.wait_for_application_states(
+                    'modelname',
+                    timeout=1,
+                    ignore_hard_errors=True)
+                self.assertFalse(self.system_ready)
+
     def test_wait_for_application_states_retries_no_success(self):
         self.patch_object(model, 'check_model_for_hard_errors')
         self.patch_object(model, 'async_resolve_units')

--- a/zaza/charm_lifecycle/deploy.py
+++ b/zaza/charm_lifecycle/deploy.py
@@ -369,7 +369,7 @@ def deploy_bundle(bundle, model, model_ctxt=None, force=False, trust=False):
 
 
 def deploy(bundle, model, wait=True, model_ctxt=None, force=False,
-           test_directory=None, trust=False):
+           test_directory=None, trust=False, ignore_hard_deploy_errors=False):
     """Run all steps to complete deployment.
 
     :param bundle: Path to bundle file
@@ -385,6 +385,9 @@ def deploy(bundle, model, wait=True, model_ctxt=None, force=False,
     :type force: Boolean
     :param test_directory: Set the directory containing tests.yaml and bundles.
     :type test_directory: str
+    :param ignore_hard_deploy_error: Whether to ignore chrms going into an
+                                     error state during deployment.
+    :type ignore_hard_deploy_error: Boolean
     """
     utils.set_base_test_dir(test_dir=test_directory)
     run_report.register_event_start('Deploy Bundle')
@@ -409,7 +412,9 @@ def deploy(bundle, model, wait=True, model_ctxt=None, force=False,
             zaza.model.wait_for_application_states(
                 model,
                 test_config.get('target_deploy_status', {}),
-                timeout=timeout, max_resolve_count=max_resolve_count)
+                timeout=timeout,
+                max_resolve_count=max_resolve_count,
+                ignore_hard_errors=ignore_hard_deploy_errors)
         run_report.register_event_finish('Wait for Deployment')
 
 

--- a/zaza/charm_lifecycle/utils.py
+++ b/zaza/charm_lifecycle/utils.py
@@ -498,6 +498,36 @@ def is_config_deploy_trusted_for_bundle(
     return False
 
 
+def ignore_hard_deploy_errors(
+        bundle_name, yaml_file=None, fatal=True):
+    """Ask the config if charms in an error state can be ignored during deploy.
+
+    The tests_options section needs to look like:
+
+        tests_options:
+          ignore_hard_deploy_errors:
+            - focal-ussuri
+
+    :param bundle_name: bundle to check in the ignore_hard_deploy_errors list
+    :type bundle_name: str
+    :param yaml_file: the YAML file that contains the tests specification
+    :type yaml_file: Optional[str]
+    :param fatal: whether any errors cause an exception or are just logged.
+    :type fatal: bool
+    :returns: True if the config option is set for the bundle
+    :rtype: bool
+    :raises: OSError if the YAML file doesn't exist and fatal=True
+    """
+    config = get_charm_config(yaml_file, fatal)
+    try:
+        return bundle_name in config['tests_options'][
+            'ignore_hard_deploy_errors']
+    # Type error is if the trust is present, but with no list
+    except (KeyError, TypeError):
+        pass
+    return False
+
+
 def get_class(class_str):
     """Get the class represented by the given string.
 


### PR DESCRIPTION
Add support for the ignore_hard_deploy_errors option. If this is set to true then charms going into an error state during deployment will not be fatal. This is useful with k8s charms which can transition into an error state if a container image takes time to download.