### PR TITLE
Fix deploy for templated bundles

### DIFF
--- a/unit_tests/test_zaza_charm_lifecycle_deploy.py
+++ b/unit_tests/test_zaza_charm_lifecycle_deploy.py
@@ -336,6 +336,8 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
             './tests/bundles/bionic.yaml',
             'newmodel',
             force=True)
+        self.render_overlays.assert_called_once_with(
+            './tests/bundles/bionic.yaml', '/tmp/mytmpdir', model_ctxt=None)
         self.check_output_logging.assert_called_once_with(
             ['juju', 'deploy', '-m', 'newmodel', '--force',
              './tests/bundles/bionic.yaml'])
@@ -378,6 +380,8 @@ class TestCharmLifecycleDeploy(ut_utils.BaseTestCase):
             './tests/bundles/bionic.yaml',
             'newmodel',
             force=True)
+        self.render_overlays.assert_called_once_with(
+            '/tmp/mytmpdir/bionic.yaml', '/tmp/mytmpdir', model_ctxt=None)
         self.check_output_logging.assert_called_once_with(
             ['juju', 'deploy', '-m', 'newmodel', '--force',
              '/tmp/mytmpdir/bionic.yaml'])

--- a/zaza/charm_lifecycle/deploy.py
+++ b/zaza/charm_lifecycle/deploy.py
@@ -338,8 +338,8 @@ def deploy_bundle(bundle, model, model_ctxt=None, force=False, trust=False):
         cmd.append('--force')
     if trust:
         cmd.append('--trust')
+    bundle_out = None
     with tempfile.TemporaryDirectory() as tmpdirname:
-        bundle_out = '{}/{}'.format(tmpdirname, os.path.basename(bundle))
         # Bundle templates should only exist in the bundle directory so
         # explicitly set the Jinja2 load path.
         bundle_template = get_template(
@@ -351,11 +351,12 @@ def deploy_bundle(bundle, model, model_ctxt=None, force=False, trust=False):
                     "Found bundle template ({}) and bundle ({})".format(
                         bundle_template.filename,
                         bundle))
+            bundle_out = '{}/{}'.format(tmpdirname, os.path.basename(bundle))
             render_template(bundle_template, bundle_out, model_ctxt=model_ctxt)
             cmd.append(bundle_out)
         else:
             cmd.append(bundle)
-        for overlay in render_overlays(bundle, tmpdirname,
+        for overlay in render_overlays(bundle_out or bundle, tmpdirname,
                                        model_ctxt=model_ctxt):
             logging.info("Deploying overlay '{}' on to '{}' model"
                          .format(overlay, model))


### PR DESCRIPTION
Templated bundle deploys currently do not work due to the check for whether to do local overlay template looking at the wrong file, resulting in a traceback like this:

    Traceback (most recent call last):
      File "/home/frode/src/opendev.org/x/charm-ovn-chassis/src/.tox/func-target/bin/functest-run-suite", line 8, in <module>
        sys.exit(main())
      File "/home/frode/src/opendev.org/x/charm-ovn-chassis/src/.tox/func-target/lib/python3.10/site-packages/zaza/charm_lifecycle/func_test_runner.py", line 404, in main
        func_test_runner(
      File "/home/frode/src/opendev.org/x/charm-ovn-chassis/src/.tox/func-target/lib/python3.10/site-packages/zaza/charm_lifecycle/func_test_runner.py", line 312, in func_test_runner
        run_env_deployment(env_deployment, keep_model=preserve_model,
      File "/home/frode/src/opendev.org/x/charm-ovn-chassis/src/.tox/func-target/lib/python3.10/site-packages/zaza/charm_lifecycle/func_test_runner.py", line 144, in run_env_deployment
        deploy.deploy(
      File "/home/frode/src/opendev.org/x/charm-ovn-chassis/src/.tox/func-target/lib/python3.10/site-packages/zaza/charm_lifecycle/deploy.py", line 396, in deploy
        deploy_bundle(bundle, model, model_ctxt=model_ctxt, force=force,
      File "/home/frode/src/opendev.org/x/charm-ovn-chassis/src/.tox/func-target/lib/python3.10/site-packages/zaza/charm_lifecycle/deploy.py", line 358, in deploy_bundle
        for overlay in render_overlays(bundle, tmpdirname,
      File "/home/frode/src/opendev.org/x/charm-ovn-chassis/src/.tox/func-target/lib/python3.10/site-packages/zaza/charm_lifecycle/deploy.py", line 305, in render_overlays
        if should_render_local_overlay(bundle):
      File "/home/frode/src/opendev.org/x/charm-ovn-chassis/src/.tox/func-target/lib/python3.10/site-packages/zaza/charm_lifecycle/deploy.py", line 287, in should_render_local_overlay
        return is_local_overlay_enabled_in_bundle(bundle)
      File "/home/frode/src/opendev.org/x/charm-ovn-chassis/src/.tox/func-target/lib/python3.10/site-packages/zaza/charm_lifecycle/deploy.py", line 258, in is_local_overlay_enabled_in_bundle
        with open(bundle, 'r') as stream:
    FileNotFoundError: [Errno 2] No such file or directory: '/home/frode/src/opendev.org/x/charm-ovn-chassis/src/tests/bundles/bundle.yaml

This commit fixes that.

Signed-off-by: Frode Nordahl <frode.nordahl@canonical.com>