### PR TITLE
Pin juju upper constraint to <3.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 pyparsing<3.0.0  # pin for aodhclient which is held for py35
 async_generator
 kubernetes<18.0.0; python_version < '3.6' # pined, as juju uses kubernetes
-# pinned until 3.0 regressions are handled: https://github.com/openstack-charmers/zaza/issues/545
-juju<3.0
+juju<3.2
 juju_wait
 PyYAML>=3.0
 pbr==5.6.0

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ install_require = [
 
     'hvac<0.7.0',
     'jinja2',
-    'juju<3.0',
+    'juju<3.2',
     'juju-wait',
     'PyYAML',
     'tenacity',

--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -142,6 +142,7 @@ class TestModel(ut_utils.BaseTestCase):
         self.run_action = mock.MagicMock()
         self.run_action.wait.side_effect = _wait
         self.action = mock.MagicMock()
+        self.action.wait.side_effect = _wait
         self.action.data = {
             'model-uuid': '1a035018-71ff-473e-8aab-d1a8d6b6cda7',
             'id': 'e26ffb69-6626-4e93-8840-07f7e041e99d',
@@ -155,6 +156,9 @@ class TestModel(ut_utils.BaseTestCase):
             'enqueued': '2018-04-11T23:13:42Z',
             'started': '2018-04-11T23:13:42Z',
             'completed': '2018-04-11T23:13:43Z'}
+        self.action.results = {
+            'return-code': '0', 'stderr': '', 'stdout': 'RESULT'
+        }
 
         self.machine3 = mock.MagicMock(status='active')
         self.machine7 = mock.MagicMock(status='active')
@@ -779,7 +783,47 @@ class TestModel(ut_utils.BaseTestCase):
                          expected)
         self.unit1.run.assert_called_once_with(cmd, timeout=None)
 
+    def test_run_on_unit_juju2_x(self):
+        del self.action.results
+        self.patch_object(model, 'get_juju_model', return_value='mname')
+        expected = {
+            'Code': '0',
+            'Stderr': '',
+            'Stdout': 'RESULT',
+            'stderr': '',
+            'stdout': 'RESULT'}
+        self.cmd = cmd = 'somecommand someargument'
+        self.patch_object(model, 'Model')
+        self.patch_object(model, 'get_unit_from_name')
+        self.get_unit_from_name.return_value = self.unit1
+        self.Model.return_value = self.Model_mock
+        self.assertEqual(model.run_on_unit('app/2', cmd),
+                         expected)
+        self.unit1.run.assert_called_once_with(cmd, timeout=None)
+
     def test_run_on_unit_lc_keys(self):
+        self.patch_object(model, 'get_juju_model', return_value='mname')
+        self.action.results = {
+            'return-code': '0',
+            'stdout': 'RESULT',
+            'stderr': 'some error'}
+        expected = {
+            'Code': '0',
+            'Stderr': 'some error',
+            'Stdout': 'RESULT',
+            'stderr': 'some error',
+            'stdout': 'RESULT'}
+        self.cmd = cmd = 'somecommand someargument'
+        self.patch_object(model, 'Model')
+        self.patch_object(model, 'get_unit_from_name')
+        self.get_unit_from_name.return_value = self.unit1
+        self.Model.return_value = self.Model_mock
+        self.assertEqual(model.run_on_unit('app/2', cmd),
+                         expected)
+        self.unit1.run.assert_called_once_with(cmd, timeout=None)
+
+    def test_run_on_unit_lc_keys_juju2_x(self):
+        del self.action.results
         self.patch_object(model, 'get_juju_model', return_value='mname')
         self.action.data['results'] = {
             'Code': '0',
@@ -808,6 +852,25 @@ class TestModel(ut_utils.BaseTestCase):
             'Stdout': 'RESULT',
             'stderr': '',
             'stdout': 'RESULT'}
+        self.action.results = {'return-code': '0', 'stdout': 'RESULT'}
+        self.cmd = cmd = 'somecommand someargument'
+        self.patch_object(model, 'Model')
+        self.patch_object(model, 'get_unit_from_name')
+        self.get_unit_from_name.return_value = self.unit1
+        self.Model.return_value = self.Model_mock
+        self.assertEqual(model.run_on_unit('app/2', cmd),
+                         expected)
+        self.unit1.run.assert_called_once_with(cmd, timeout=None)
+
+    def test_run_on_unit_missing_stderr_juju2_x(self):
+        del self.action.results
+        self.patch_object(model, 'get_juju_model', return_value='mname')
+        expected = {
+            'Code': '0',
+            'Stderr': '',
+            'Stdout': 'RESULT',
+            'stderr': '',
+            'stdout': 'RESULT'}
         self.action.data['results'] = {'Code': '0', 'Stdout': 'RESULT'}
         self.cmd = cmd = 'somecommand someargument'
         self.patch_object(model, 'Model')
@@ -819,6 +882,22 @@ class TestModel(ut_utils.BaseTestCase):
         self.unit1.run.assert_called_once_with(cmd, timeout=None)
 
     def test_run_on_leader(self):
+        self.patch_object(model, 'get_juju_model', return_value='mname')
+        expected = {
+            'Code': '0',
+            'Stderr': '',
+            'Stdout': 'RESULT',
+            'stderr': '',
+            'stdout': 'RESULT'}
+        self.cmd = cmd = 'somecommand someargument'
+        self.patch_object(model, 'Model')
+        self.Model.return_value = self.Model_mock
+        self.assertEqual(model.run_on_leader('app', cmd),
+                         expected)
+        self.unit2.run.assert_called_once_with(cmd, timeout=None)
+
+    def test_run_on_leader_juju2_x(self):
+        del self.action.results
         self.patch_object(model, 'get_juju_model', return_value='mname')
         expected = {
             'Code': '0',
@@ -1009,7 +1088,7 @@ class TestModel(ut_utils.BaseTestCase):
             return units[x]
 
         self.async_get_unit_from_name.side_effect = _async_get_unit_from_name
-        self.run_action.status = 'completed'
+        self.run_action.data = {'status': 'completed'}
         model.run_action_on_units(
             ['app/1', 'app/2'],
             'backup',
@@ -1027,7 +1106,7 @@ class TestModel(ut_utils.BaseTestCase):
         self.Model.return_value = self.Model_mock
         self.patch_object(model, 'get_unit_from_name')
         self.get_unit_from_name.return_value = self.unit1
-        self.run_action.status = 'running'
+        self.run_action.data = {'status': 'running'}
         with self.assertRaises(AsyncTimeoutError):
             model.run_action_on_units(
                 ['app/2'],
@@ -1045,7 +1124,7 @@ class TestModel(ut_utils.BaseTestCase):
         self.Model.return_value = self.Model_mock
         self.patch_object(model, 'get_unit_from_name')
         self.get_unit_from_name.return_value = self.unit1
-        self.run_action.status = 'failed'
+        self.run_action.data = {'status': 'failed'}
         with self.assertRaises(model.ActionFailed):
             model.run_action_on_units(
                 ['app/2'],
@@ -1502,6 +1581,25 @@ class TestModel(ut_utils.BaseTestCase):
         self.assertEqual(model.get_current_model(), self.model_name)
 
     def test_file_contents_success(self):
+        self.action.results = {
+            'return-code': '0',
+            'stderr': '',
+            'stdout': 'somestring'
+        }
+
+        self.patch_object(model, 'Model')
+        self.Model.return_value = self.Model_mock
+        self.patch_object(model, 'get_juju_model', return_value='mname')
+        contents = model.file_contents(
+            'app/2',
+            '/tmp/src/myfile.txt',
+            timeout=0.1)
+        self.unit1.run.assert_called_once_with(
+            'cat /tmp/src/myfile.txt', timeout=0.1)
+        self.assertEqual('somestring', contents)
+
+    def test_file_contents_success_juju2_x(self):
+        del self.action.results
         self.action.data = {
             'results': {'Code': '0', 'Stderr': '', 'Stdout': 'somestring'}
         }
@@ -1518,6 +1616,23 @@ class TestModel(ut_utils.BaseTestCase):
         self.assertEqual('somestring', contents)
 
     def test_file_contents_fault(self):
+        self.action.results = {
+            'return-code': '0',
+            'stderr': 'fault',
+            'stdout': ''
+        }
+
+        self.patch_object(model, 'Model')
+        self.Model.return_value = self.Model_mock
+        self.patch_object(model, 'get_juju_model', return_value='mname')
+        with self.assertRaises(model.RemoteFileError) as ctxtmgr:
+            model.file_contents('app/2', '/tmp/src/myfile.txt', timeout=0.1)
+        self.unit1.run.assert_called_once_with(
+            'cat /tmp/src/myfile.txt', timeout=0.1)
+        self.assertEqual(ctxtmgr.exception.args, ('fault',))
+
+    def test_file_contents_fault_juju2_x(self):
+        del self.action.results
         self.action.data = {
             'results': {'Code': '0', 'Stderr': 'fault', 'Stdout': ''}
         }
@@ -1532,6 +1647,33 @@ class TestModel(ut_utils.BaseTestCase):
         self.assertEqual(ctxtmgr.exception.args, ('fault',))
 
     def test_block_until_file_has_contents(self):
+        self.action.results = {
+            'return-code': '0',
+            'stderr': '',
+            'stdout': 'somestring'
+        }
+
+        self.patch_object(model, 'Model')
+        self.Model.return_value = self.Model_mock
+        self.patch_object(model, 'get_juju_model', return_value='mname')
+        self.patch("builtins.open",
+                   new_callable=mock.mock_open(),
+                   name="_open")
+        _fileobj = mock.MagicMock()
+        _fileobj.__enter__().read.return_value = "somestring"
+        self._open.return_value = _fileobj
+        model.block_until_file_has_contents(
+            'app',
+            '/tmp/src/myfile.txt',
+            'somestring',
+            timeout=0.1)
+        self.unit1.run.assert_called_once_with(
+            'cat /tmp/src/myfile.txt')
+        self.unit2.run.assert_called_once_with(
+            'cat /tmp/src/myfile.txt')
+
+    def test_block_until_file_has_contents_juju2_x(self):
+        del self.action.results
         self.action.data = {
             'results': {'Code': '0', 'Stderr': '', 'Stdout': 'somestring'}
         }
@@ -1556,6 +1698,29 @@ class TestModel(ut_utils.BaseTestCase):
             'cat /tmp/src/myfile.txt')
 
     def test_block_until_file_has_no_contents(self):
+        self.action.results = {'return-code': '0', 'stderr': ''}
+
+        self.patch_object(model, 'Model')
+        self.Model.return_value = self.Model_mock
+        self.patch_object(model, 'get_juju_model', return_value='mname')
+        self.patch("builtins.open",
+                   new_callable=mock.mock_open(),
+                   name="_open")
+        _fileobj = mock.MagicMock()
+        _fileobj.__enter__().read.return_value = ""
+        self._open.return_value = _fileobj
+        model.block_until_file_has_contents(
+            'app',
+            '/tmp/src/myfile.txt',
+            '',
+            timeout=0.1)
+        self.unit1.run.assert_called_once_with(
+            'cat /tmp/src/myfile.txt')
+        self.unit2.run.assert_called_once_with(
+            'cat /tmp/src/myfile.txt')
+
+    def test_block_until_file_has_no_contents_juju2_x(self):
+        del self.action.results
         self.action.data = {
             'results': {'Code': '0', 'Stderr': ''}
         }
@@ -1601,6 +1766,19 @@ class TestModel(ut_utils.BaseTestCase):
         self.patch_object(model, 'Model')
         self.Model.return_value = self.Model_mock
         self.patch_object(model, 'get_juju_model', return_value='mname')
+        self.action.results = {'stdout': "1"}
+        model.block_until_file_missing(
+            'app',
+            '/tmp/src/myfile.txt',
+            timeout=0.1)
+        self.unit1.run.assert_called_once_with(
+            'test -e "/tmp/src/myfile.txt"; echo $?')
+
+    def test_block_until_file_missing_juju2_x(self):
+        self.patch_object(model, 'Model')
+        self.Model.return_value = self.Model_mock
+        self.patch_object(model, 'get_juju_model', return_value='mname')
+        del self.action.results
         self.action.data['results']['Stdout'] = "1"
         model.block_until_file_missing(
             'app',
@@ -1621,6 +1799,27 @@ class TestModel(ut_utils.BaseTestCase):
                 timeout=0.1)
 
     def test_block_until_file_matches_re(self):
+        self.action.results = {
+            'return-code': '0',
+            'stderr': '',
+            'stdout': 'somestring'
+        }
+
+        self.patch_object(model, 'Model')
+        self.Model.return_value = self.Model_mock
+        self.patch_object(model, 'get_juju_model', return_value='mname')
+        model.block_until_file_matches_re(
+            'app',
+            '/tmp/src/myfile.txt',
+            's.*string',
+            timeout=0.1)
+        self.unit1.run.assert_called_once_with(
+            'cat /tmp/src/myfile.txt')
+        self.unit2.run.assert_called_once_with(
+            'cat /tmp/src/myfile.txt')
+
+    def test_block_until_file_matches_re_juju2_x(self):
+        del self.action.results
         self.action.data = {
             'results': {'Code': '0', 'Stderr': '', 'Stdout': 'somestring'}
         }
@@ -1902,6 +2101,24 @@ class TestModel(ut_utils.BaseTestCase):
 
     def block_until_oslo_config_entries_match_base(self, file_contents,
                                                    expected_contents):
+        self.action.results = {
+            'return-code': '0',
+            'stderr': '',
+            'stdout': file_contents
+        }
+        self.patch_object(model, 'Model')
+        self.patch_object(model, 'get_juju_model', return_value='mname')
+        self.Model.return_value = self.Model_mock
+        model.block_until_oslo_config_entries_match(
+            'app',
+            '/tmp/src/myfile.txt',
+            expected_contents,
+            timeout=0.1)
+
+    def block_until_oslo_config_entries_match_base_juju2_x(self,
+                                                           file_contents,
+                                                           expected_contents):
+        del self.action.results
         self.action.data = {
             'results': {'Code': '0', 'Stderr': '', 'Stdout': file_contents}
         }


### PR DESCRIPTION
Juju is pinned to <3.0 earlier. This
patch pins the juju version to <3.2
so that libjuju 3.1 version is used.

Modified run_on_unit to wait for
completion and update results based
on output.