### PR TITLE
Misc fixes for failing github workflows

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -5,11 +5,36 @@ on:
   - pull_request
 
 jobs:
+  build_old_versions:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: ['3.6']
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install codecov tox tox-gh-actions
+    - name: Lint with tox
+      run: tox -e pep8
+    - name: Test with tox
+      run: tox -e py
+    - name: Codecov
+      run: |
+        set -euxo pipefail
+        codecov --verbose --gcov-glob unit_tests/*
+
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v1
@@ -35,21 +60,11 @@ jobs:
       fail-fast: false
       matrix:
         juju_channel:
-          - latest/stable
           - 2.9/stable
-          - 2.8/stable
         bundle:
           - first
           - second
           - third
-        exclude:
-          # disable 'first' and 'second' bundles for juju 2.8 since 'magpie'
-          # is not a promulgated charm in the charmstore, only on charmhub
-          # which 2.8 can't talk to.
-          - juju_channel: 2.8/stable
-            bundle: first
-          - juju_channel: 2.8/stable
-            bundle: second
     env:
       TEST_ZAZA_BUG_LP1987332: "on"  # http://pad.lv/1987332
     needs: build
@@ -67,6 +82,8 @@ jobs:
         sudo chmod 666 /var/snap/lxd/common/lxd/unix.socket
         # until Juju provides stable IPv6-support we unfortunately need this
         lxc network set lxdbr0 ipv6.address none
+        sudo iptables -F FORWARD
+        sudo iptables -P FORWARD ACCEPT
         # pull images
         lxc image copy --alias juju/bionic/amd64 --copy-aliases ubuntu-daily:bionic local:
         lxc image copy --alias juju/focal/amd64 --copy-aliases ubuntu-daily:focal local:

--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -493,7 +493,9 @@ class TestModel(ut_utils.BaseTestCase):
         with mock.patch.object(zaza, 'RUN_LIBJUJU_IN_THREAD', new=False):
             model.sync_wrapper(self._wrapper)()
         self.Model_mock.disconnect.assert_has_calls([mock.call()])
-        self.Model_mock.connect_model.has_calls([mock.call('modelname')])
+        self.Model_mock.connect_model.assert_has_calls(
+            [mock.call('testmodel')]
+        )
 
     def test_block_until_auto_reconnect_model_disconnected_async(self):
         self._mocks_for_block_until_auto_reconnect_model(
@@ -506,7 +508,9 @@ class TestModel(ut_utils.BaseTestCase):
         with mock.patch.object(zaza, 'RUN_LIBJUJU_IN_THREAD', new=False):
             model.sync_wrapper(self._wrapper)()
         self.Model_mock.disconnect.assert_has_calls([mock.call()])
-        self.Model_mock.connect_model.has_calls([mock.call('modelname')])
+        self.Model_mock.connect_model.assert_has_calls(
+            [mock.call('testmodel')]
+        )
 
     def test_block_until_auto_reconnect_model_blocks_till_true(self):
         self._mocks_for_block_until_auto_reconnect_model(True, True)

--- a/unit_tests/utilities/test_zaza_utilities_generic.py
+++ b/unit_tests/utilities/test_zaza_utilities_generic.py
@@ -254,7 +254,7 @@ class TestGenericUtils(ut_utils.BaseTestCase):
             _unit, _machine_num, origin=_origin,
             to_series=_to_series, from_series=_from_series,
             workaround_script=_workaround_script, files=_files)
-        self.block_until_all_units_idle.called_with()
+        self.block_until_all_units_idle.assert_called_with()
         self.prepare_series_upgrade.assert_called_once_with(
             _machine_num, to_series=_to_series)
         self.wrap_do_release_upgrade.assert_called_once_with(


### PR DESCRIPTION
Add separate workflow for testing on Python 3.6 as this requires an older Ubuntu release.

Fixup unit tests for compatibility with newer versions of mock.

Drop latest/stable functional test targets - this is actually 2.9.x of Juju and is already covered by the 2.9 targets and we want to avoid suddenly picking up a new Juju version because this will break with the new approach to version alignment in the Python module for Juju.

Drop 2.8 functional test target - its broken and we don't really support this version any longer.

Fixup iptables forwarding issues from LXD containers with a flush and re-create of rules.

(cherry picked from commit 9277a94c155da8dabb4d2d60c629bbc7fa9c6ccc)