### PR TITLE
Misc fixes for failing github workflows (queens)

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -55,10 +55,11 @@ jobs:
         set -euxo pipefail
         codecov --verbose --gcov-glob unit_tests/*
   func:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
+        python-version: ['3.6.15']
         juju_channel:
           - 2.9/stable
         bundle:
@@ -86,8 +87,6 @@ jobs:
         sudo iptables -P FORWARD ACCEPT
         # pull images
         lxc image copy --alias juju/bionic/amd64 --copy-aliases ubuntu-daily:bionic local:
-        lxc image copy --alias juju/focal/amd64 --copy-aliases ubuntu-daily:focal local:
-        lxc image copy --alias juju/jammy/amd64 --copy-aliases ubuntu-daily:jammy local:
         lxc image list
         juju bootstrap --no-gui localhost
     - name: Functional test

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -5,11 +5,36 @@ on:
   - pull_request
 
 jobs:
+  build_old_versions:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: ['3.6']
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install codecov tox tox-gh-actions
+    - name: Lint with tox
+      run: tox -e pep8
+    - name: Test with tox
+      run: tox -e py
+    - name: Codecov
+      run: |
+        set -euxo pipefail
+        codecov --verbose --gcov-glob unit_tests/*
+
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
 
     steps:
     - uses: actions/checkout@v1
@@ -31,6 +56,17 @@ jobs:
         codecov --verbose --gcov-glob unit_tests/*
   func:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        juju_channel:
+          - 2.9/stable
+        bundle:
+          - first
+          - second
+          - third
+    env:
+      TEST_ZAZA_BUG_LP1987332: "on"  # http://pad.lv/1987332
     needs: build
     steps:
     - uses: actions/checkout@v1
@@ -46,6 +82,13 @@ jobs:
         sudo chmod 666 /var/snap/lxd/common/lxd/unix.socket
         # until Juju provides stable IPv6-support we unfortunately need this
         lxc network set lxdbr0 ipv6.address none
+        sudo iptables -F FORWARD
+        sudo iptables -P FORWARD ACCEPT
+        # pull images
+        lxc image copy --alias juju/bionic/amd64 --copy-aliases ubuntu-daily:bionic local:
+        lxc image copy --alias juju/focal/amd64 --copy-aliases ubuntu-daily:focal local:
+        lxc image copy --alias juju/jammy/amd64 --copy-aliases ubuntu-daily:jammy local:
+        lxc image list
         juju bootstrap --no-gui localhost
     - name: Functional test
       run: |

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ['3.6']
+        python-version: ['3.6.15']
 
     steps:
     - uses: actions/checkout@v1
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
+        python-version: ['3.6.15', '3.7.15', '3.8.15', '3.9.15', '3.10.10']
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ['3.6.15', '3.7.15', '3.8.15', '3.9.15', '3.10.10']
+        python-version: ['3.6.15', '3.7.15', '3.8.15', '3.9.15']
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -31,7 +31,7 @@ jobs:
         codecov --verbose --gcov-glob unit_tests/*
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: ['3.6.15', '3.7.15', '3.8.15', '3.9.15', '3.10.10']

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pyparsing<3.0.0  # pin for aodhclient which is held for py35
 aiounittest
 async_generator
 kubernetes<18.0.0; python_version < '3.6' # pined, as juju uses kubernetes
-juju
+juju<3
 juju_wait
 PyYAML>=3.0
 flake8>=2.2.4

--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -37,7 +37,6 @@ import unit_tests.utils as ut_utils
 from juju import loop
 
 import zaza.model as model
-import zaza
 
 
 FAKE_STATUS = {
@@ -432,12 +431,12 @@ class TestModel(ut_utils.BaseTestCase):
         self._mocks_for_block_until_auto_reconnect_model([False, True], True)
         self._wrapper_block_until_auto_reconnect_model(
             lambda: True)
-        with mock.patch.object(zaza, 'RUN_LIBJUJU_IN_THREAD', new=False):
-            model.sync_wrapper(self._wrapper)()
-        self.Model_mock.disconnect.assert_has_calls([mock.call()])
-        self.Model_mock.connect_model.assert_has_calls(
-            [mock.call('testmodel')]
-        )
+        loop.run(self._wrapper())
+        # model.disconnect and model.connect should've each have been called
+        # twice, once for run_in_model, and once each for the disconnection.
+        self.Model_mock.disconnect.assert_has_calls([mock.call(), mock.call()])
+        self.Model_mock.connect_model.has_calls([mock.call('modelname'),
+                                                 mock.call('modelname')])
 
     def test_block_until_auto_reconnect_model_disconnected_async(self):
         self._mocks_for_block_until_auto_reconnect_model(
@@ -447,12 +446,12 @@ class TestModel(ut_utils.BaseTestCase):
             return True
         self._wrapper_block_until_auto_reconnect_model(
             aconditions=[_async_true])
-        with mock.patch.object(zaza, 'RUN_LIBJUJU_IN_THREAD', new=False):
-            model.sync_wrapper(self._wrapper)()
-        self.Model_mock.disconnect.assert_has_calls([mock.call()])
-        self.Model_mock.connect_model.assert_has_calls(
-            [mock.call('testmodel')]
-        )
+        loop.run(self._wrapper())
+        # model.disconnect and model.connect should've each have been called
+        # twice, once for run_in_model, and once each for the disconnection.
+        self.Model_mock.disconnect.assert_has_calls([mock.call(), mock.call()])
+        self.Model_mock.connect_model.has_calls([mock.call('modelname'),
+                                                 mock.call('modelname')])
 
     def test_block_until_auto_reconnect_model_blocks_till_true(self):
         self._mocks_for_block_until_auto_reconnect_model(True, True)

--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -431,12 +431,12 @@ class TestModel(ut_utils.BaseTestCase):
         self._mocks_for_block_until_auto_reconnect_model([False, True], True)
         self._wrapper_block_until_auto_reconnect_model(
             lambda: True)
-        loop.run(self._wrapper())
-        # model.disconnect and model.connect should've each have been called
-        # twice, once for run_in_model, and once each for the disconnection.
-        self.Model_mock.disconnect.assert_has_calls([mock.call(), mock.call()])
-        self.Model_mock.connect_model.has_calls([mock.call('modelname'),
-                                                 mock.call('modelname')])
+        with mock.patch.object(zaza, 'RUN_LIBJUJU_IN_THREAD', new=False):
+            model.sync_wrapper(self._wrapper)()
+        self.Model_mock.disconnect.assert_has_calls([mock.call()])
+        self.Model_mock.connect_model.assert_has_calls(
+            [mock.call('testmodel')]
+        )
 
     def test_block_until_auto_reconnect_model_disconnected_async(self):
         self._mocks_for_block_until_auto_reconnect_model(
@@ -446,12 +446,12 @@ class TestModel(ut_utils.BaseTestCase):
             return True
         self._wrapper_block_until_auto_reconnect_model(
             aconditions=[_async_true])
-        loop.run(self._wrapper())
-        # model.disconnect and model.connect should've each have been called
-        # twice, once for run_in_model, and once each for the disconnection.
-        self.Model_mock.disconnect.assert_has_calls([mock.call(), mock.call()])
-        self.Model_mock.connect_model.has_calls([mock.call('modelname'),
-                                                 mock.call('modelname')])
+        with mock.patch.object(zaza, 'RUN_LIBJUJU_IN_THREAD', new=False):
+            model.sync_wrapper(self._wrapper)()
+        self.Model_mock.disconnect.assert_has_calls([mock.call()])
+        self.Model_mock.connect_model.assert_has_calls(
+            [mock.call('testmodel')]
+        )
 
     def test_block_until_auto_reconnect_model_blocks_till_true(self):
         self._mocks_for_block_until_auto_reconnect_model(True, True)

--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -435,8 +435,8 @@ class TestModel(ut_utils.BaseTestCase):
         # model.disconnect and model.connect should've each have been called
         # twice, once for run_in_model, and once each for the disconnection.
         self.Model_mock.disconnect.assert_has_calls([mock.call(), mock.call()])
-        self.Model_mock.connect_model.has_calls([mock.call('modelname'),
-                                                 mock.call('modelname')])
+        self.Model_mock.connect_model.assert_has_calls(
+            [mock.call('modelname'), mock.call('modelname')])
 
     def test_block_until_auto_reconnect_model_disconnected_async(self):
         self._mocks_for_block_until_auto_reconnect_model(
@@ -450,8 +450,8 @@ class TestModel(ut_utils.BaseTestCase):
         # model.disconnect and model.connect should've each have been called
         # twice, once for run_in_model, and once each for the disconnection.
         self.Model_mock.disconnect.assert_has_calls([mock.call(), mock.call()])
-        self.Model_mock.connect_model.has_calls([mock.call('modelname'),
-                                                 mock.call('modelname')])
+        self.Model_mock.connect_model.assert_has_calls(
+            [mock.call('modelname'), mock.call('modelname')])
 
     def test_block_until_auto_reconnect_model_blocks_till_true(self):
         self._mocks_for_block_until_auto_reconnect_model(True, True)

--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -436,7 +436,7 @@ class TestModel(ut_utils.BaseTestCase):
         # twice, once for run_in_model, and once each for the disconnection.
         self.Model_mock.disconnect.assert_has_calls([mock.call(), mock.call()])
         self.Model_mock.connect_model.assert_has_calls(
-            [mock.call('modelname'), mock.call('modelname')])
+            [mock.call('modelname'), mock.call('testmodel')])
 
     def test_block_until_auto_reconnect_model_disconnected_async(self):
         self._mocks_for_block_until_auto_reconnect_model(
@@ -451,7 +451,7 @@ class TestModel(ut_utils.BaseTestCase):
         # twice, once for run_in_model, and once each for the disconnection.
         self.Model_mock.disconnect.assert_has_calls([mock.call(), mock.call()])
         self.Model_mock.connect_model.assert_has_calls(
-            [mock.call('modelname'), mock.call('modelname')])
+            [mock.call('modelname'), mock.call('testmodel')])
 
     def test_block_until_auto_reconnect_model_blocks_till_true(self):
         self._mocks_for_block_until_auto_reconnect_model(True, True)

--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -37,6 +37,7 @@ import unit_tests.utils as ut_utils
 from juju import loop
 
 import zaza.model as model
+import zaza
 
 
 FAKE_STATUS = {
@@ -2273,7 +2274,7 @@ class AsyncModelTests(aiounittest.AsyncTestCase):
             return_value=model_mock
         ):
             idle = await model.async_check_if_subordinates_idle('app', 'app/0')
-        assert(idle)
+        assert idle
 
     async def test_async_get_agent_status_busy(self):
         model_mock = mock.MagicMock()
@@ -2300,7 +2301,7 @@ class AsyncModelTests(aiounittest.AsyncTestCase):
     async def test_async_check_if_subordinates_idle_missing(self):
         model_mock = mock.MagicMock()
         status = copy.deepcopy(EXECUTING_STATUS)
-        del(status['units']['app/0']['subordinates'])
+        del status['units']['app/0']['subordinates']
         model_mock.applications.__getitem__.return_value = status
         with mock.patch.object(
             model,
@@ -2308,7 +2309,7 @@ class AsyncModelTests(aiounittest.AsyncTestCase):
             return_value=model_mock
         ):
             idle = await model.async_check_if_subordinates_idle('app', 'app/0')
-        assert(idle)
+        assert idle
 
     async def test_async_get_principle_sub_map(self):
         model_mock = mock.MagicMock()

--- a/unit_tests/utilities/test_zaza_utilities_generic.py
+++ b/unit_tests/utilities/test_zaza_utilities_generic.py
@@ -243,7 +243,7 @@ class TestGenericUtils(ut_utils.BaseTestCase):
             _unit, _machine_num, origin=_origin,
             to_series=_to_series, from_series=_from_series,
             workaround_script=_workaround_script, files=_files)
-        self.block_until_all_units_idle.called_with()
+        self.block_until_all_units_idle.assert_called_with()
         self.prepare_series_upgrade.assert_called_once_with(
             _machine_num, to_series=_to_series)
         self.wrap_do_release_upgrade.assert_called_once_with(

--- a/zaza/charm_lifecycle/func_test_runner.py
+++ b/zaza/charm_lifecycle/func_test_runner.py
@@ -195,7 +195,8 @@ def destroy_models(model_aliases, destroy):
 def func_test_runner(keep_last_model=False, keep_all_models=False,
                      keep_faulty_model=False, smoke=False, dev=False,
                      bundles=None, force=False, test_directory=None):
-    """Deploy the bundles and run the tests as defined by the charms tests.yaml.
+    """
+    Deploy the bundles and run the tests as defined by the charms tests.yaml.
 
     :param keep_last_model: Whether to destroy last model at end of run
     :type keep_last_model: boolean

--- a/zaza/model.py
+++ b/zaza/model.py
@@ -1498,13 +1498,13 @@ async def async_wait_for_application_states(model_name=None, states=None,
                                 unit_state=unit.workload_status_message,
                                 approved_states=prefixes))
                 # if not all states are okay, continue to the next one.
-                if not(all_okay):
+                if not all_okay:
                     continue
 
                 applications_left.remove(application)
                 logging.info("Application %s is ready.", application)
 
-            if not(applications_left):
+            if not applications_left:
                 logging.info("All applications reached approved status, "
                              "number of units (where relevant), and workload"
                              " status message checks.")
@@ -1789,7 +1789,7 @@ async def async_block_until_machine_status_is(
                                          interval=interval,
                                          refresh=refresh)
         equals = _status["machines"][machine].agent_status["status"] == status
-        return not(equals) if invert_check else equals
+        return not equals if invert_check else equals
 
     async with run_in_model(model_name):
         await async_block_until(_check_machine_status, timeout=timeout)
@@ -2280,7 +2280,7 @@ async def async_block_until_wl_status_info_starts_with(
                     if k.split('/')[0] == app]
         g = (s.startswith(status) for s in wl_infos)
         if negate_match:
-            return not(any(g))
+            return not any(g)
         else:
             return all(g)
 
@@ -2401,7 +2401,7 @@ async def async_get_relation_id(application_name, remote_application_name,
             if remote_interface_name is not None:
                 spec += ':{}'.format(remote_interface_name)
             if rel.matches(spec):
-                return(rel.id)
+                return rel.id
 
 get_relation_id = sync_wrapper(async_get_relation_id)
 


### PR DESCRIPTION
Add separate workflow for testing on Python 3.6 as this requires an older Ubuntu release.

Fixup unit tests for compatibility with newer versions of mock.

Drop latest/stable functional test targets - this is actually 2.9.x of Juju and is already covered by the 2.9 targets and we want to avoid suddenly picking up a new Juju version because this will break with the new approach to version alignment in the Python module for Juju.

Drop 2.8 functional test target - its broken and we don't really support this version any longer.

Fixup iptables forwarding issues from LXD containers with a flush and re-create of rules.