### PR TITLE
Add Python 3.11 support

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v1

--- a/pip.sh
+++ b/pip.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-pip install pip==20.2.3
-pip "$@"

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ python-neutronclient
 python-novaclient
 python-octaviaclient
 python-swiftclient
-tenacity
+tenacity>8.2.0
 paramiko
 python-libmaas
 requests<2.26  # pin for py3.5 support

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ install_require = [
     'juju<3.0',
     'juju-wait',
     'PyYAML',
-    'tenacity',
+    'tenacity>8.2.0',
     'python-libmaas',
 ]
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,5 @@
 aiounittest
-flake8>=2.2.4
+flake8>=5  # Python 3.8 compatibility in pyflakes 2.1.0+
 flake8-docstrings
 flake8-per-file-ignores
 pydocstyle<4.0.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,10 +5,9 @@ flake8-per-file-ignores
 pydocstyle<4.0.0
 coverage
 mock>=1.2
-# For some reason the PyPi distributed wheel of nose differ from the one on
-# GitHub, and it does not work with Python 3.10.
-nose>=1.3.7;python_version<'3.10'
-git+https://github.com/nose-devs/nose.git@release_1.3.7#egg=nose;python_version=='3.10'
+pytest
+pytest-cov
+pytest-asyncio
 
 # TODO: these requirements should be mocked out in unit_tests/__init__.py
 async_generator

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -16,6 +16,6 @@ jinja2
 keystoneauth1
 oslo.config
 python-novaclient
-tenacity
+tenacity>8.2.0
 # pinned until 3.0 regressions are handled: https://github.com/openstack-charmers/zaza/issues/545
 juju<3.0

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ passenv =
   TEST_*
 deps =
   -r{toxinidir}/test-requirements.txt
-commands = nosetests --with-coverage --processes=0 --cover-package=zaza {posargs} {toxinidir}/unit_tests
+commands = pytest --cov=./zaza/ {posargs} {toxinidir}/unit_tests
 
 [testenv:py3]
 basepython = python3

--- a/tox.ini
+++ b/tox.ini
@@ -2,27 +2,23 @@
 envlist = pep8,py3
 skipsdist = True
 
-# NOTES:
-# * We avoid the new dependency resolver by pinning pip < 20.3, see
-#   https://github.com/pypa/pip/issues/9187
-# * Pinning dependencies requires tox >= 3.2.0, see
-#   https://tox.readthedocs.io/en/latest/config.html#conf-requires
-# * It is also necessary to pin virtualenv as a newer virtualenv would still
-#   lead to fetching the latest pip in the func* tox targets, see
-#   https://stackoverflow.com/a/38133283
-requires = pip < 20.3
-           virtualenv < 20.0
 # NOTE: https://wiki.canonical.com/engineering/OpenStack/InstallLatestToxOnOsci
 minversion = 3.2.0
 
 [testenv]
-setenv = VIRTUAL_ENV={envdir}
-         PYTHONHASHSEED=0
-whitelist_external = juju
-passenv = HOME TERM CS_* OS_* TEST_*
-deps = -r{toxinidir}/test-requirements.txt
-install_command =
-  {toxinidir}/pip.sh install {opts} {packages}
+setenv =
+  VIRTUAL_ENV={envdir}
+  PYTHONHASHSEED=0
+allowlist_external =
+  juju
+passenv =
+  HOME
+  TERM
+  CS_*
+  OS_*
+  TEST_*
+deps =
+  -r{toxinidir}/test-requirements.txt
 commands = nosetests --with-coverage --processes=0 --cover-package=zaza {posargs} {toxinidir}/unit_tests
 
 [testenv:py3]

--- a/unit_tests/test_zaza_controller.py
+++ b/unit_tests/test_zaza_controller.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import mock
+import pytest
 import unittest
 
 import unit_tests.utils as ut_utils
@@ -25,6 +26,7 @@ def tearDownModule():
     zaza.clean_up_libjuju_thread()
 
 
+@pytest.mark.asyncio
 class TestController(ut_utils.BaseTestCase):
 
     def setUp(self):

--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -32,6 +32,7 @@ import copy
 import concurrent
 import datetime
 import mock
+import pytest
 import yaml
 
 import unit_tests.utils as ut_utils
@@ -100,6 +101,7 @@ EXECUTING_STATUS = {
                                 }}}}}}
 
 
+@pytest.mark.asyncio
 class TestModel(ut_utils.BaseTestCase):
 
     def setUp(self):


### PR DESCRIPTION
Summary of changes:

- Bump up lower constraint on tenacity
- Add python 3.11 to the testing matrix
- Unpin pip and virtualenv
- Bump up tenacity to a version compatible with py311
- Migrate from nosetest to pytest
- Bump up flake8