### PR TITLE
Zed overlay ppas

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -5,36 +5,11 @@ on:
   - pull_request
 
 jobs:
-  build_old_versions:
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        python-version: ['3.6']
-
-    steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install codecov tox tox-gh-actions
-    - name: Lint with tox
-      run: tox -e pep8
-    - name: Test with tox
-      run: tox -e py
-    - name: Codecov
-      run: |
-        set -euxo pipefail
-        codecov --verbose --gcov-glob unit_tests/*
-
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.10']
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -5,11 +5,36 @@ on:
   - pull_request
 
 jobs:
+  build_old_versions:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: ['3.6']
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install codecov tox tox-gh-actions
+    - name: Lint with tox
+      run: tox -e pep8
+    - name: Test with tox
+      run: tox -e py
+    - name: Codecov
+      run: |
+        set -euxo pipefail
+        codecov --verbose --gcov-glob unit_tests/*
+
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v1
@@ -35,21 +60,11 @@ jobs:
       fail-fast: false
       matrix:
         juju_channel:
-          - latest/stable
           - 2.9/stable
-          - 2.8/stable
         bundle:
           - first
           - second
           - third
-        exclude:
-          # disable 'first' and 'second' bundles for juju 2.8 since 'magpie'
-          # is not a promulgated charm in the charmstore, only on charmhub
-          # which 2.8 can't talk to.
-          - juju_channel: 2.8/stable
-            bundle: first
-          - juju_channel: 2.8/stable
-            bundle: second
     env:
       TEST_ZAZA_BUG_LP1987332: "on"  # http://pad.lv/1987332
     needs: build
@@ -67,6 +82,8 @@ jobs:
         sudo chmod 666 /var/snap/lxd/common/lxd/unix.socket
         # until Juju provides stable IPv6-support we unfortunately need this
         lxc network set lxdbr0 ipv6.address none
+        sudo iptables -F FORWARD
+        sudo iptables -P FORWARD ACCEPT
         # pull images
         lxc image copy --alias juju/bionic/amd64 --copy-aliases ubuntu-daily:bionic local:
         lxc image copy --alias juju/focal/amd64 --copy-aliases ubuntu-daily:focal local:

--- a/pip.sh
+++ b/pip.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-pip install pip==20.2.3
-pip "$@"

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,5 @@
 aiounittest
-flake8>=2.2.4
+flake8>=5  # Python 3.8 compatibility in pyflakes 2.1.0+
 flake8-docstrings
 flake8-per-file-ignores
 pydocstyle<4.0.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,10 +5,9 @@ flake8-per-file-ignores
 pydocstyle<4.0.0
 coverage
 mock>=1.2
-# For some reason the PyPi distributed wheel of nose differ from the one on
-# GitHub, and it does not work with Python 3.10.
-nose>=1.3.7;python_version<'3.10'
-git+https://github.com/nose-devs/nose.git@release_1.3.7#egg=nose;python_version=='3.10'
+pytest
+pytest-cov
+pytest-asyncio
 
 # TODO: these requirements should be mocked out in unit_tests/__init__.py
 async_generator

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ passenv =
   TEST_*
 deps =
   -r{toxinidir}/test-requirements.txt
-commands = nosetests --with-coverage --processes=0 --cover-package=zaza {posargs} {toxinidir}/unit_tests
+commands = pytest --cov=./zaza/ {posargs} {toxinidir}/unit_tests
 
 [testenv:py3]
 basepython = python3

--- a/tox.ini
+++ b/tox.ini
@@ -2,27 +2,23 @@
 envlist = pep8,py3
 skipsdist = True
 
-# NOTES:
-# * We avoid the new dependency resolver by pinning pip < 20.3, see
-#   https://github.com/pypa/pip/issues/9187
-# * Pinning dependencies requires tox >= 3.2.0, see
-#   https://tox.readthedocs.io/en/latest/config.html#conf-requires
-# * It is also necessary to pin virtualenv as a newer virtualenv would still
-#   lead to fetching the latest pip in the func* tox targets, see
-#   https://stackoverflow.com/a/38133283
-requires = pip < 20.3
-           virtualenv < 20.0
 # NOTE: https://wiki.canonical.com/engineering/OpenStack/InstallLatestToxOnOsci
 minversion = 3.2.0
 
 [testenv]
-setenv = VIRTUAL_ENV={envdir}
-         PYTHONHASHSEED=0
-whitelist_external = juju
-passenv = HOME TERM CS_* OS_* TEST_*
-deps = -r{toxinidir}/test-requirements.txt
-install_command =
-  {toxinidir}/pip.sh install {opts} {packages}
+setenv =
+  VIRTUAL_ENV={envdir}
+  PYTHONHASHSEED=0
+allowlist_external =
+  juju
+passenv =
+  HOME
+  TERM
+  CS_*
+  OS_*
+  TEST_*
+deps =
+  -r{toxinidir}/test-requirements.txt
 commands = nosetests --with-coverage --processes=0 --cover-package=zaza {posargs} {toxinidir}/unit_tests
 
 [testenv:py3]

--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -493,7 +493,9 @@ class TestModel(ut_utils.BaseTestCase):
         with mock.patch.object(zaza, 'RUN_LIBJUJU_IN_THREAD', new=False):
             model.sync_wrapper(self._wrapper)()
         self.Model_mock.disconnect.assert_has_calls([mock.call()])
-        self.Model_mock.connect_model.has_calls([mock.call('modelname')])
+        self.Model_mock.connect_model.assert_has_calls(
+            [mock.call('testmodel')]
+        )
 
     def test_block_until_auto_reconnect_model_disconnected_async(self):
         self._mocks_for_block_until_auto_reconnect_model(
@@ -506,7 +508,9 @@ class TestModel(ut_utils.BaseTestCase):
         with mock.patch.object(zaza, 'RUN_LIBJUJU_IN_THREAD', new=False):
             model.sync_wrapper(self._wrapper)()
         self.Model_mock.disconnect.assert_has_calls([mock.call()])
-        self.Model_mock.connect_model.has_calls([mock.call('modelname')])
+        self.Model_mock.connect_model.assert_has_calls(
+            [mock.call('testmodel')]
+        )
 
     def test_block_until_auto_reconnect_model_blocks_till_true(self):
         self._mocks_for_block_until_auto_reconnect_model(True, True)

--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -32,6 +32,7 @@ import copy
 import concurrent
 import datetime
 import mock
+import pytest
 import yaml
 
 import unit_tests.utils as ut_utils
@@ -100,6 +101,7 @@ EXECUTING_STATUS = {
                                 }}}}}}
 
 
+@pytest.mark.asyncio
 class TestModel(ut_utils.BaseTestCase):
 
     def setUp(self):

--- a/unit_tests/utilities/test_zaza_utilities_generic.py
+++ b/unit_tests/utilities/test_zaza_utilities_generic.py
@@ -254,7 +254,7 @@ class TestGenericUtils(ut_utils.BaseTestCase):
             _unit, _machine_num, origin=_origin,
             to_series=_to_series, from_series=_from_series,
             workaround_script=_workaround_script, files=_files)
-        self.block_until_all_units_idle.called_with()
+        self.block_until_all_units_idle.assert_called_with()
         self.prepare_series_upgrade.assert_called_once_with(
             _machine_num, to_series=_to_series)
         self.wrap_do_release_upgrade.assert_called_once_with(

--- a/zaza/charm_lifecycle/utils.py
+++ b/zaza/charm_lifecycle/utils.py
@@ -498,35 +498,6 @@ def is_config_deploy_trusted_for_bundle(
     return False
 
 
-def get_overlay_ppa(yaml_file=None, fatal=True):
-    """Get overlay_ppa from tests_options.
-
-    In the config file for the tests, the tests_options.overlay_ppa option
-    may be used to specify a PPA that will be enabled for all units in
-    the model.
-
-    The tests_options section needs to look like:
-
-        tests_options:
-          overlay_ppa: ppa:ubuntu-security-proposed/ppa
-
-    :param yaml_file: the YAML file that contains the tests specification
-    :type yaml_file: Optional[str]
-    :param fatal: whether any errors cause an exception or are just logged.
-    :type fatal: bool
-    :returns: overlay PPA name
-    :rtype: str
-    :raises: OSError if the YAML file doesn't exist and fatal=True
-    """
-    config = get_charm_config(yaml_file, fatal)
-    try:
-        return config['tests_options']['overlay_ppa']
-    # Type error is if the force_deploy is present, but with no value
-    except (KeyError, TypeError):
-        pass
-    return None
-
-
 def get_class(class_str):
     """Get the class represented by the given string.
 

--- a/zaza/charm_lifecycle/utils.py
+++ b/zaza/charm_lifecycle/utils.py
@@ -498,6 +498,35 @@ def is_config_deploy_trusted_for_bundle(
     return False
 
 
+def get_overlay_ppa(yaml_file=None, fatal=True):
+    """Get overlay_ppa from tests_options.
+
+    In the config file for the tests, the tests_options.overlay_ppa option
+    may be used to specify a PPA that will be enabled for all units in
+    the model.
+
+    The tests_options section needs to look like:
+
+        tests_options:
+          overlay_ppa: ppa:ubuntu-security-proposed/ppa
+
+    :param yaml_file: the YAML file that contains the tests specification
+    :type yaml_file: Optional[str]
+    :param fatal: whether any errors cause an exception or are just logged.
+    :type fatal: bool
+    :returns: overlay PPA name
+    :rtype: str
+    :raises: OSError if the YAML file doesn't exist and fatal=True
+    """
+    config = get_charm_config(yaml_file, fatal)
+    try:
+        return config['tests_options']['overlay_ppa']
+    # Type error is if the force_deploy is present, but with no value
+    except (KeyError, TypeError):
+        pass
+    return None
+
+
 def get_class(class_str):
     """Get the class represented by the given string.
 

--- a/zaza/utilities/deployment_env.py
+++ b/zaza/utilities/deployment_env.py
@@ -116,18 +116,18 @@ def get_cloudinit_userdata():
     :rtype: str
     """
     cloudinit_userdata = None
-    overlay_ppas = get_overlay_ppas()
     cloud_config = {
         'apt': {
             'sources': {
             }
         }
     }
-    for index, overlay_ppa in enumerate(overlay_ppas):
-        cloud_config['apt']['sources']["overlay-ppa-{}".format(index)] = {
-            'source': overlay_ppa
-        }
-    if cloud_config['apt']['sources']:
+    overlay_ppas = get_overlay_ppas()
+    if overlay_ppas:
+        for index, overlay_ppa in enumerate(overlay_ppas):
+            cloud_config['apt']['sources']["overlay-ppa-{}".format(index)] = {
+                'source': overlay_ppa
+            }
         cloudinit_userdata = "#cloud-config\n{}".format(
             yaml.safe_dump(cloud_config))
     return cloudinit_userdata


### PR DESCRIPTION
Add overlay_ppa to tests_options

This also includes several cherry-picks to get the gate passing for this branch.

Cherry-picks included are:
* Add overlay_ppa to tests_options
(cherry picked from commit https://github.com/openstack-charmers/zaza/commit/0c07920ad8e113bfe0ca3dfd6dd8df1f53c58d4d)
* Updates to overlay_ppa
(cherry picked from commit https://github.com/openstack-charmers/zaza/commit/9cc938af1135f20e6fabf9796dffa3e15ed59962)
* Fix NoneType error in enumerate(overlay_ppas)
(cherry picked from commit https://github.com/openstack-charmers/zaza/commit/986474bdc495fa3d55b633a61185999d448d645a)
* Misc fixes for failing github workflows
(cherry picked from commit https://github.com/openstack-charmers/zaza/commit/9277a94c155da8dabb4d2d60c629bbc7fa9c6ccc)
(cherry picked from commit https://github.com/openstack-charmers/zaza/commit/ee92b9be26d4ae53157878df0a3a0771706a1ebd)
* Drop py36, py37, and py39 from github runners
(cherry picked from commit https://github.com/openstack-charmers/zaza/commit/6122daa374281224da65c79b78fd6d52ade1460e)
* Unpin pip and virtualenv
(cherry picked from commit https://github.com/openstack-charmers/zaza/commit/55c3f3f94ac064eab7755d88b82f641f57bcc4a4)
* Bump up flake8
(cherry picked from commit https://github.com/openstack-charmers/zaza/commit/a9d681259623b915295bdeb2e265d29ed5a4cea2)
* Migrate from nosetest to pytest
(cherry picked from commit https://github.com/openstack-charmers/zaza/commit/4b0d23ec92e1d3084dfaa79373af39a959cbdaa1)