### PR TITLE
Set pin-priority for proposed pocket to 500

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -84,3 +84,6 @@ jobs:
       with:
         name: test-run-logs-and-crashdump
         path: logs/
+    - name: consider debugging
+      uses: lhotari/action-upterm@v1
+      if: failure()

--- a/unit_tests/utilities/test_deployment_env.py
+++ b/unit_tests/utilities/test_deployment_env.py
@@ -68,7 +68,26 @@ class TestUtilitiesDeploymentEnv(ut_utils.BaseTestCase):
 
     def test_get_cloudinit_userdata(self):
         with mock.patch.object(deployment_env, 'get_overlay_ppas',
+                               return_value=None):
+            preferences_file = "/etc/apt/preferences.d/proposed-updates"
+            cloud_config = {
+                'apt': {
+                    'sources': {}
+                },
+                'preruncmd': [
+                    f"echo 'Package: *' >> {preferences_file}",
+                    f"echo 'Pin: release a=*-proposed' >> {preferences_file}",
+                    f"echo 'Pin-Priority: 500' >> {preferences_file}",
+                ]
+            }
+            cloudinit_userdata = "#cloud-config\n{}".format(
+                yaml.safe_dump(cloud_config))
+            self.assertEqual(
+                deployment_env.get_cloudinit_userdata(),
+                cloudinit_userdata)
+        with mock.patch.object(deployment_env, 'get_overlay_ppas',
                                return_value=['ppa:ppa0', 'ppa:ppa1']):
+            preferences_file = "/etc/apt/preferences.d/proposed-updates"
             cloud_config = {
                 'apt': {
                     'sources': {
@@ -79,7 +98,12 @@ class TestUtilitiesDeploymentEnv(ut_utils.BaseTestCase):
                             'source': 'ppa:ppa1'
                         }
                     }
-                }
+                },
+                'preruncmd': [
+                    f"echo 'Package: *' >> {preferences_file}",
+                    f"echo 'Pin: release a=*-proposed' >> {preferences_file}",
+                    f"echo 'Pin-Priority: 500' >> {preferences_file}",
+                ]
             }
             cloudinit_userdata = "#cloud-config\n{}".format(
                 yaml.safe_dump(cloud_config))

--- a/zaza/utilities/deployment_env.py
+++ b/zaza/utilities/deployment_env.py
@@ -116,11 +116,17 @@ def get_cloudinit_userdata():
     :rtype: str
     """
     cloudinit_userdata = None
+    preferences_file = "/etc/apt/preferences.d/proposed-updates"
     cloud_config = {
         'apt': {
             'sources': {
             }
-        }
+        },
+        'preruncmd': [
+            f"echo 'Package: *' >> {preferences_file}",
+            f"echo 'Pin: release a=*-proposed' >> {preferences_file}",
+            f"echo 'Pin-Priority: 500' >> {preferences_file}",
+        ]
     }
     overlay_ppas = get_overlay_ppas()
     if overlay_ppas:
@@ -128,8 +134,8 @@ def get_cloudinit_userdata():
             cloud_config['apt']['sources']["overlay-ppa-{}".format(index)] = {
                 'source': overlay_ppa
             }
-        cloudinit_userdata = "#cloud-config\n{}".format(
-            yaml.safe_dump(cloud_config))
+    cloudinit_userdata = "#cloud-config\n{}".format(
+        yaml.safe_dump(cloud_config))
     return cloudinit_userdata
 
 


### PR DESCRIPTION
As of lunar, a lower pin priority is set by default for the proposed pocket [1]. The lower pin-priority prevents installation of proposed packages, unless they are selectively installed per package [2]. This is the case even if the proposed package version is greater than any other available versions.

This change restores the previous behavior. By creating an apt preferences file that sets the pin-priority of the proposed pocket to 500, all proposed packages will be installed when proposed is enabled, assuming the proposed package version is greater than any other available versions.

[1] https://lists.ubuntu.com/archives/ubuntu-devel/2022-November/042338.html
[2] sudo apt-get install packagename/lunar-proposed