### PR TITLE
Fix Code becoming integer.

### DIFF
--- a/zaza/model.py
+++ b/zaza/model.py
@@ -546,7 +546,7 @@ def _normalise_action_results(results):
             elif results.get(old_key) and not results.get(key):
                 results[key] = results[old_key]
         if 'return-code' in results:
-            results['Code'] = results.get('return-code')
+            results['Code'] = str(results.get('return-code'))
             del results['return-code']
         return results
     else:


### PR DESCRIPTION
Value of the Code key in the returned Dict is str in master branch. However while trying to get compatible with juju 3.x series it became int. Now it is not conforming to the function signature. Also there are usages in some tests so it reverted back to str.