### PR TITLE
Add model alias support to overlay_ppas

### DIFF
--- a/unit_tests/test_zaza_charm_lifecycle_func_test_runner.py
+++ b/unit_tests/test_zaza_charm_lifecycle_func_test_runner.py
@@ -79,8 +79,8 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
         lc_func_test_runner.func_test_runner(
             force=True)
         prepare_calls = [
-            mock.call('newmodel', test_directory=None),
-            mock.call('newmodel', test_directory=None)]
+            mock.call('newmodel', 'default_alias', test_directory=None),
+            mock.call('newmodel', 'default_alias', test_directory=None)]
         cwd = os.getcwd()
         deploy_calls = [
             mock.call(cwd + '/tests/bundles/bundle1.yaml', 'newmodel',
@@ -157,10 +157,10 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
                      'zaza.charm_tests.ks.test.project_create2']}]}
         lc_func_test_runner.func_test_runner()
         prepare_calls = [
-            mock.call('m1', test_directory=None),
-            mock.call('m2', test_directory=None),
-            mock.call('m3', test_directory=None),
-            mock.call('m4', test_directory=None)]
+            mock.call('m1', 'default_alias', test_directory=None),
+            mock.call('m2', 'default_alias', test_directory=None),
+            mock.call('m3', 'model_alias_5', test_directory=None),
+            mock.call('m4', 'model_alias_6', test_directory=None)]
         cwd = os.getcwd()
         deploy_calls = [
             mock.call(cwd + '/tests/bundles/bundle1.yaml', 'm1',
@@ -252,8 +252,8 @@ class TestCharmLifecycleFuncTestRunner(ut_utils.BaseTestCase):
         lc_func_test_runner.func_test_runner()
         cwd = os.getcwd()
         prepare_calls = [
-            mock.call('newmodel', test_directory=None),
-            mock.call('newmodel', test_directory=None)]
+            mock.call('newmodel', 'default_alias', test_directory=None),
+            mock.call('newmodel', 'default_alias', test_directory=None)]
         deploy_calls = [
             mock.call(cwd + '/tests/bundles/bundle1.yaml', 'newmodel',
                       model_ctxt={'default_alias': 'newmodel'}, force=False,

--- a/unit_tests/test_zaza_charm_lifecycle_prepare.py
+++ b/unit_tests/test_zaza_charm_lifecycle_prepare.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import mock
+
 import zaza.charm_lifecycle.prepare as lc_prepare
 import unit_tests.utils as ut_utils
 
@@ -53,3 +55,30 @@ class TestCharmLifecyclePrepare(ut_utils.BaseTestCase):
         # Using args
         args = lc_prepare.parse_args(['-m', 'model', '--log', 'DEBUG'])
         self.assertEqual(args.loglevel, 'DEBUG')
+
+    def test_main(self):
+        self.patch_object(lc_prepare.sys, "argv")
+        self.patch_object(lc_prepare, "cli_utils")
+        mock_args = mock.MagicMock()
+        self.patch_object(lc_prepare, "parse_args", return_value=mock_args)
+        self.patch_object(lc_prepare, "prepare")
+
+        # model
+        mock_args.model_name = "test_model"
+        mock_args.test_directory = None
+
+        lc_prepare.main()
+        self.prepare.assert_called_once_with("test_model", "default_alias",
+                                             test_directory=None)
+        mock_args.reset_mock()
+        self.prepare.reset_mock()
+
+        # alias:model
+        mock_args.model_name = "test_alias:test_model"
+        mock_args.test_directory = None
+
+        lc_prepare.main()
+        self.prepare.assert_called_once_with("test_model", "test_alias",
+                                             test_directory=None)
+        mock_args.reset_mock()
+        self.prepare.reset_mock()

--- a/unit_tests/utilities/test_deployment_env.py
+++ b/unit_tests/utilities/test_deployment_env.py
@@ -62,6 +62,12 @@ class TestUtilitiesDeploymentEnv(ut_utils.BaseTestCase):
             self.assertEqual(deployment_env.get_overlay_ppas(),
                              ro_types.ReadOnlyList(['ppa:ppa1', 'ppa:ppa2']))
 
+            config = collections.OrderedDict({'model_alias': {'overlay_ppas':
+                                              ['ppa:ppa1', 'ppa:ppa2']}})
+            get_options_mock.return_value = ro_types.resolve_immutable(config)
+            self.assertEqual(deployment_env.get_overlay_ppas('model_alias'),
+                             ro_types.ReadOnlyList(['ppa:ppa1', 'ppa:ppa2']))
+
             config = collections.OrderedDict({'force_deploy': 'x-y'})
             get_options_mock.return_value = ro_types.resolve_immutable(config)
             self.assertEqual(deployment_env.get_overlay_ppas(), None)

--- a/zaza/charm_lifecycle/func_test_runner.py
+++ b/zaza/charm_lifecycle/func_test_runner.py
@@ -124,6 +124,7 @@ def run_env_deployment(env_deployment, keep_model=DESTROY_MODEL, force=False,
     for deployment in env_deployment.model_deploys:
         prepare.prepare(
             deployment.model_name,
+            deployment.model_alias,
             test_directory=test_directory)
 
     for deployment in env_deployment.model_deploys:

--- a/zaza/charm_lifecycle/prepare.py
+++ b/zaza/charm_lifecycle/prepare.py
@@ -29,10 +29,12 @@ import zaza.utilities.deployment_env as deployment_env
 
 
 @run_report.register_event_wrapper('Prepare Environment')
-def prepare(model_name, test_directory=None):
+def prepare(model_name, model_alias='default_alias', test_directory=None):
     """Run all steps to prepare the environment before a functional test run.
 
     :param model: Name of model to add
+    :type bundle: str
+    :param model: Name of model alias
     :type bundle: str
     :param test_directory: Set the directory containing tests.yaml and bundles.
     :type test_directory: str
@@ -41,7 +43,7 @@ def prepare(model_name, test_directory=None):
     utils.set_base_test_dir(test_dir=test_directory)
     zaza.controller.add_model(
         model_name,
-        config=deployment_env.get_model_settings(),
+        config=deployment_env.get_model_settings(model_alias),
         cloud_name=deployment_env.get_cloud_name(),
         region=deployment_env.get_cloud_region())
     zaza.model.set_model_constraints(
@@ -70,10 +72,15 @@ def parse_args(args):
 def main():
     """Add a new model."""
     args = parse_args(sys.argv[1:])
+    model_alias = 'default_alias'
+    model_name = args.model_name
+    if ':' in model_name:
+        model_alias, model_name = args.model_name.split(':')
     cli_utils.setup_logging(log_level=args.loglevel.upper())
-    logging.info('model_name: {}'.format(args.model_name))
+    logging.info('model_name: {}'.format(model_name))
+    logging.info('model_alias: {}'.format(model_alias))
     try:
-        prepare(args.model_name, test_directory=args.test_directory)
+        prepare(model_name, model_alias, test_directory=args.test_directory)
         run_report.output_event_report()
     finally:
         zaza.clean_up_libjuju_thread()

--- a/zaza/utilities/deployment_env.py
+++ b/zaza/utilities/deployment_env.py
@@ -85,7 +85,7 @@ def parse_option_list_string(option_list, delimiter=None):
     return settings
 
 
-def get_overlay_ppas():
+def get_overlay_ppas(model_alias='default_alias'):
     """Get overlay_ppas from global_config.
 
     In the config file for the tests, the tests_options.overlay_ppa option
@@ -98,6 +98,8 @@ def get_overlay_ppas():
           overlay_ppas:
             - ppa:ubuntu-security-proposed/ppa
 
+    :param model: Name of model alias
+    :type bundle: str
     :returns: List of overlay PPAs
     :rtype: list[str]
     """
@@ -106,12 +108,18 @@ def get_overlay_ppas():
         return config.overlay_ppas
     except KeyError:
         pass
+    try:
+        return config[model_alias].overlay_ppas
+    except KeyError:
+        pass
     return None
 
 
-def get_cloudinit_userdata():
+def get_cloudinit_userdata(model_alias='default_alias'):
     """Return cloudinit_userdata based on tests_options config.
 
+    :param model: Name of model alias
+    :type bundle: str
     :returns: YAML-formatted string of cloudinit_userdata
     :rtype: str
     """
@@ -128,7 +136,7 @@ def get_cloudinit_userdata():
             f"echo 'Pin-Priority: 500' >> {preferences_file}",
         ]
     }
-    overlay_ppas = get_overlay_ppas()
+    overlay_ppas = get_overlay_ppas(model_alias)
     if overlay_ppas:
         for index, overlay_ppa in enumerate(overlay_ppas):
             cloud_config['apt']['sources']["overlay-ppa-{}".format(index)] = {
@@ -139,9 +147,11 @@ def get_cloudinit_userdata():
     return cloudinit_userdata
 
 
-def get_model_settings():
+def get_model_settings(model_alias='default_alias'):
     """Return model settings from defaults, config file and env variables.
 
+    :param model: Name of model alias
+    :type bundle: str
     :returns: Settings to use for model
     :rtype: Dict
     """
@@ -149,7 +159,7 @@ def get_model_settings():
     model_settings.update(get_setup_file_section(MODEL_SETTINGS_SECTION))
     env_settings = os.environ.get('MODEL_SETTINGS', '')
     test_env_settings = os.environ.get('TEST_MODEL_SETTINGS', '')
-    cloudinit_userdata = get_cloudinit_userdata()
+    cloudinit_userdata = get_cloudinit_userdata(model_alias)
     if cloudinit_userdata:
         if 'cloudinit-userdata' in test_env_settings:
             logging.warn('TEST_MODEL_SETTINGS contains cloudinit-userdata '

--- a/zaza/utilities/deployment_env.py
+++ b/zaza/utilities/deployment_env.py
@@ -98,6 +98,13 @@ def get_overlay_ppas(model_alias='default_alias'):
           overlay_ppas:
             - ppa:ubuntu-security-proposed/ppa
 
+     or:
+
+        tests_options:
+          model_alias:
+            overlay_ppas:
+              - ppa:ubuntu-security-proposed/ppa
+
     :param model: Name of model alias
     :type bundle: str
     :returns: List of overlay PPAs
@@ -105,13 +112,12 @@ def get_overlay_ppas(model_alias='default_alias'):
     """
     config = zaza.global_options.get_options()
     try:
-        return config.overlay_ppas
-    except KeyError:
-        pass
-    try:
         return config[model_alias].overlay_ppas
     except KeyError:
-        pass
+        try:
+            return config.overlay_ppas
+        except KeyError:
+            pass
     return None
 
 


### PR DESCRIPTION
There currently isn't model alias support for the overlay_ppas tests option:

tests_options:
   overlay_ppas:
     - ppa:ubuntu-security-proposed/ppa

This results in a lack of flexibility where a single tests.yaml will use the overlay_ppas for every deployment that it defines.

Adding model alias support allows more flexibility by only setting up the overlay_ppas for a specified model alias:

tests_options:
  model_alias_name:
     overlay_ppas:
       - ppa:ubuntu-security-proposed/ppa