### PR TITLE
Also normalise the action results in the action object.

### DIFF
--- a/zaza/model.py
+++ b/zaza/model.py
@@ -1102,7 +1102,7 @@ def _normalise_action_object(action_obj):
     try:
         # libjuju 3.x
         action_obj.data['status'] = action_obj._status
-        action_obj.data['results'] = action_obj.results
+        action_obj.data['results'] = _normalise_action_results(action_obj.results)
     except (AttributeError, KeyError):
         # libjuju 2.x format, no changes needed
         pass


### PR DESCRIPTION
The `run_action` and `run_action_on_leader` will not return with the normalised action results: `action.results` or `action.data["results"]`. So the results is not compatible with libjuju 2.x and libjuju 3.x .

Note: this is targeted to "libjuju-3.1" branch