### PR TITLE
Avoid broken macaroonbakery release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,3 +35,5 @@ requests<2.26  # pin for py3.5 support
 # Documentation requirements
 sphinx
 sphinxcontrib-asyncio
+# https://github.com/go-macaroon-bakery/py-macaroon-bakery/issues/94
+macaroonbakery!=1.3.3

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,9 @@ install_require = [
     'PyYAML',
     'tenacity>8.2.0',
     'python-libmaas',
+
+    # https://github.com/go-macaroon-bakery/py-macaroon-bakery/issues/94
+    'macaroonbakery != 1.3.3',
 ]
 
 tests_require = [

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -18,3 +18,5 @@ python-novaclient
 tenacity>8.2.0
 # pinned until 3.0 regressions are handled: https://github.com/openstack-charmers/zaza/issues/545
 juju<3.0
+# https://github.com/go-macaroon-bakery/py-macaroon-bakery/issues/94
+macaroonbakery!=1.3.3


### PR DESCRIPTION
macaroonbakery 1.3.3 has a broken protobuf dependency, add a requirement to avoid that specific release:
https://github.com/go-macaroon-bakery/py-macaroon-bakery/issues/94

(cherry picked from commit 8be49486c880b99c40253520dfcf110d5bf89c88)