### PR TITLE
Avoid broken macaroonbakery release

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -5,11 +5,36 @@ on:
   - pull_request
 
 jobs:
+  build_old_versions:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: ['3.6', '3.7']
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install codecov tox tox-gh-actions
+    - name: Lint with tox
+      run: tox -e pep8
+    - name: Test with tox
+      run: tox -e py
+    - name: Codecov
+      run: |
+        set -euxo pipefail
+        codecov --verbose --gcov-glob unit_tests/*
+
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v1
@@ -35,21 +60,11 @@ jobs:
       fail-fast: false
       matrix:
         juju_channel:
-          - latest/stable
           - 2.9/stable
-          - 2.8/stable
         bundle:
           - first
           - second
           - third
-        exclude:
-          # disable 'first' and 'second' bundles for juju 2.8 since 'magpie'
-          # is not a promulgated charm in the charmstore, only on charmhub
-          # which 2.8 can't talk to.
-          - juju_channel: 2.8/stable
-            bundle: first
-          - juju_channel: 2.8/stable
-            bundle: second
     env:
       TEST_ZAZA_BUG_LP1987332: "on"  # http://pad.lv/1987332
     needs: build
@@ -67,6 +82,8 @@ jobs:
         sudo chmod 666 /var/snap/lxd/common/lxd/unix.socket
         # until Juju provides stable IPv6-support we unfortunately need this
         lxc network set lxdbr0 ipv6.address none
+        sudo iptables -F FORWARD
+        sudo iptables -P FORWARD ACCEPT
         # pull images
         lxc image copy --alias juju/bionic/amd64 --copy-aliases ubuntu-daily:bionic local:
         lxc image copy --alias juju/focal/amd64 --copy-aliases ubuntu-daily:focal local:

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -5,36 +5,11 @@ on:
   - pull_request
 
 jobs:
-  build_old_versions:
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        python-version: ['3.6', '3.7']
-
-    steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install codecov tox tox-gh-actions
-    - name: Lint with tox
-      run: tox -e pep8
-    - name: Test with tox
-      run: tox -e py
-    - name: Codecov
-      run: |
-        set -euxo pipefail
-        codecov --verbose --gcov-glob unit_tests/*
-
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.8]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -34,6 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        python-version: [3.8]
         juju_channel:
           - 2.9/stable
         bundle:
@@ -45,6 +46,10 @@ jobs:
     needs: build
     steps:
     - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         set -euxo pipefail

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,3 +43,4 @@ sphinx
 sphinxcontrib-asyncio
 # https://github.com/go-macaroon-bakery/py-macaroon-bakery/issues/94
 macaroonbakery!=1.3.3
+openstacksdk<=1.5.0; # Pin to a lower version of openstacksdk due to introduced libraries

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,3 +41,5 @@ python-libmaas
 # Documentation requirements
 sphinx
 sphinxcontrib-asyncio
+# https://github.com/go-macaroon-bakery/py-macaroon-bakery/issues/94
+macaroonbakery!=1.3.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 pyparsing<3.0.0  # pin for aodhclient which is held for py35
 aiounittest
 async_generator
-juju<3.0
+juju<2.9.45.0; python_version < '3.8'
+juju<3.0; python_version >= '3.8'
 kubernetes<18.0.0; python_version < '3.6' # pined, as juju uses kubernetes
 juju_wait
 PyYAML>=3.0

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,9 @@ install_require = [
     'PyYAML',
     'tenacity',
     'python-libmaas',
+
+    # https://github.com/go-macaroon-bakery/py-macaroon-bakery/issues/94
+    'macaroonbakery != 1.3.3',
 ]
 
 tests_require = [

--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -435,8 +435,9 @@ class TestModel(ut_utils.BaseTestCase):
         # model.disconnect and model.connect should've each have been called
         # twice, once for run_in_model, and once each for the disconnection.
         self.Model_mock.disconnect.assert_has_calls([mock.call(), mock.call()])
-        self.Model_mock.connect_model.has_calls([mock.call('modelname'),
-                                                 mock.call('modelname')])
+        self.Model_mock.connect_model.assert_has_calls(
+            [mock.call('modelname'), mock.call('testmodel')]
+        )
 
     def test_block_until_auto_reconnect_model_disconnected_async(self):
         self._mocks_for_block_until_auto_reconnect_model(
@@ -450,8 +451,9 @@ class TestModel(ut_utils.BaseTestCase):
         # model.disconnect and model.connect should've each have been called
         # twice, once for run_in_model, and once each for the disconnection.
         self.Model_mock.disconnect.assert_has_calls([mock.call(), mock.call()])
-        self.Model_mock.connect_model.has_calls([mock.call('modelname'),
-                                                 mock.call('modelname')])
+        self.Model_mock.connect_model.assert_has_calls(
+            [mock.call('modelname'), mock.call('testmodel')]
+        )
 
     def test_block_until_auto_reconnect_model_blocks_till_true(self):
         self._mocks_for_block_until_auto_reconnect_model(True, True)

--- a/unit_tests/utilities/test_zaza_utilities_generic.py
+++ b/unit_tests/utilities/test_zaza_utilities_generic.py
@@ -243,7 +243,7 @@ class TestGenericUtils(ut_utils.BaseTestCase):
             _unit, _machine_num, origin=_origin,
             to_series=_to_series, from_series=_from_series,
             workaround_script=_workaround_script, files=_files)
-        self.block_until_all_units_idle.called_with()
+        self.block_until_all_units_idle.assert_called_with()
         self.prepare_series_upgrade.assert_called_once_with(
             _machine_num, to_series=_to_series)
         self.wrap_do_release_upgrade.assert_called_once_with(


### PR DESCRIPTION
macaroonbakery 1.3.3 has a broken protobuf dependency, add a requirement to avoid that specific release:
https://github.com/go-macaroon-bakery/py-macaroon-bakery/issues/94

Conflicts:
    test-requirements.txt

Also drop py36 from github workflow as it is no longer available
on ubuntu-latest and not needed for xena which is focal based.

(cherry picked from commit 8be49486c880b99c40253520dfcf110d5bf89c88)