### PR TITLE
Avoid broken macaroonbakery release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,3 +34,5 @@ requests<2.26  # pin for py3.5 support
 # Documentation requirements
 sphinx
 sphinxcontrib-asyncio
+# https://github.com/go-macaroon-bakery/py-macaroon-bakery/issues/94
+macaroonbakery!=1.3.3

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,9 @@ install_require = [
     'PyYAML',
     'tenacity',
     'python-libmaas',
+
+    # https://github.com/go-macaroon-bakery/py-macaroon-bakery/issues/94
+    'macaroonbakery != 1.3.3',
 ]
 
 tests_require = [

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -19,3 +19,5 @@ python-novaclient
 tenacity
 # Fix upper version to ensure compatibility with Juju 3.1
 juju<3.2
+# https://github.com/go-macaroon-bakery/py-macaroon-bakery/issues/94
+macaroonbakery!=1.3.3


### PR DESCRIPTION
macaroonbakery 1.3.3 has a broken protobuf dependency, add a requirement to avoid that specific release:
https://github.com/go-macaroon-bakery/py-macaroon-bakery/issues/94

(cherry picked from commit 8be49486c880b99c40253520dfcf110d5bf89c88)