### PR TITLE
Pin dependencies for py36 compatibility [ussuri backport]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,6 +42,19 @@ python-libmaas
 # Documentation requirements
 sphinx
 sphinxcontrib-asyncio
-# https://github.com/go-macaroon-bakery/py-macaroon-bakery/issues/94
-macaroonbakery!=1.3.3
 openstacksdk<=1.5.0; # Pin to a lower version of openstacksdk due to introduced libraries
+# The following pinning is to keep zaza compatible with python 3.6
+#
+# protobuf dropped support for python-3.6 in v3.20.0[0], although it wasn't
+# until 4.21.0 that it became truly incompatible. The pinning used is `<4.21.0`
+#
+# [0] https://github.com/protocolbuffers/protobuf/commit/301d315dc4674d1bc799446644e88eff0af1ac86
+# [1] https://github.com/protocolbuffers/protobuf/issues/10076
+protobuf<4.21.0
+
+# macaroonbakery in v1.3.4 added a constraint of protobuf>=3.20.0[0] which makes it incompatible with python 3.6
+# while v1.3.3 was released in a broken state[1]
+#
+# [0] https://github.com/go-macaroon-bakery/py-macaroon-bakery/commit/7f1fe6a2adb2f80db12bccfb81f629d66d106e03
+# [1] https://github.com/go-macaroon-bakery/py-macaroon-bakery/pull/92
+macaroonbakery < 1.3.3

--- a/setup.py
+++ b/setup.py
@@ -41,9 +41,20 @@ install_require = [
     'PyYAML',
     'tenacity',
     'python-libmaas',
-
-    # https://github.com/go-macaroon-bakery/py-macaroon-bakery/issues/94
-    'macaroonbakery != 1.3.3',
+    # protobuf dropped support for python-3.6 in v3.20.0[0], although it wasn't
+    # until 4.21.0 that it became truly incompatible. The pinning used is
+    # `<4.21.0`
+    #
+    # [0] https://github.com/protocolbuffers/protobuf/commit/301d315dc4674d1bc799446644e88eff0af1ac86  # noqa
+    # [1] https://github.com/protocolbuffers/protobuf/issues/10076
+    'protobuf < 4.21.0',
+    # macaroonbakery in v1.3.4 added a constraint of protobuf>=3.20.0[0] which
+    # makes it incompatible with python 3.6 while v1.3.3 was released in a
+    # broken state[1]
+    #
+    # [0] https://github.com/go-macaroon-bakery/py-macaroon-bakery/commit/7f1fe6a2adb2f80db12bccfb81f629d66d106e03  # noqa
+    # [1] https://github.com/go-macaroon-bakery/py-macaroon-bakery/pull/92
+    'macaroonbakery < 1.3.3',
 ]
 
 tests_require = [


### PR DESCRIPTION
macaroonbakery in version 1.3.4 started depending on protobuf>3.20 which it's not compatible with python 3.6, so this change pins macaroonbakery to 1.3.2 which was the last release compatible with older versions of protobuf.

For more details see:

- https://github.com/go-macaroon-bakery/py-macaroon-bakery/pull/92
- https://github.com/protocolbuffers/protobuf/issues/10076

It's worth to mention that there is no protobuf-4.0, it goes from 3.20 to 4.21 - https://pypi.org/project/protobuf/#history

(cherry picked from commit a8e4de518f32503e788547e78ff2f609c0275dc3) (cherry picked from commit 300c5bbefb1228e20d53226951662074bbb729d4)