### PR TITLE
Pin dependencies for py36 compatibility [train backport]

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 pyparsing<3.0.0  # pin for aodhclient which is held for py35
 aiounittest
 async_generator
-juju<3.0
+# 2.9.45.0 - https://github.com/juju/python-libjuju/pull/993
+juju<3.0,!=2.9.45.0,!=2.9.46.0
 kubernetes<18.0.0; python_version < '3.6' # pined, as juju uses kubernetes
 juju_wait
 PyYAML>=3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,3 +41,18 @@ python-libmaas
 # Documentation requirements
 sphinx
 sphinxcontrib-asyncio
+# The following pinning is to keep zaza compatible with python 3.6
+#
+# protobuf dropped support for python-3.6 in v3.20.0[0], although it wasn't
+# until 4.21.0 that it became truly incompatible. The pinning used is `<4.21.0`
+#
+# [0] https://github.com/protocolbuffers/protobuf/commit/301d315dc4674d1bc799446644e88eff0af1ac86
+# [1] https://github.com/protocolbuffers/protobuf/issues/10076
+protobuf<4.21.0
+
+# macaroonbakery in v1.3.4 added a constraint of protobuf>=3.20.0[0] which makes it incompatible with python 3.6
+# while v1.3.3 was released in a broken state[1]
+#
+# [0] https://github.com/go-macaroon-bakery/py-macaroon-bakery/commit/7f1fe6a2adb2f80db12bccfb81f629d66d106e03
+# [1] https://github.com/go-macaroon-bakery/py-macaroon-bakery/pull/92
+macaroonbakery < 1.3.3

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,20 @@ install_require = [
     'PyYAML',
     'tenacity',
     'python-libmaas',
+    # protobuf dropped support for python-3.6 in v3.20.0[0], although it wasn't
+    # until 4.21.0 that it became truly incompatible. The pinning used is
+    # `<4.21.0`
+    #
+    # [0] https://github.com/protocolbuffers/protobuf/commit/301d315dc4674d1bc799446644e88eff0af1ac86  # noqa
+    # [1] https://github.com/protocolbuffers/protobuf/issues/10076
+    'protobuf < 4.21.0',
+    # macaroonbakery in v1.3.4 added a constraint of protobuf>=3.20.0[0] which
+    # makes it incompatible with python 3.6 while v1.3.3 was released in a
+    # broken state[1]
+    #
+    # [0] https://github.com/go-macaroon-bakery/py-macaroon-bakery/commit/7f1fe6a2adb2f80db12bccfb81f629d66d106e03  # noqa
+    # [1] https://github.com/go-macaroon-bakery/py-macaroon-bakery/pull/92
+    'macaroonbakery < 1.3.3',
 ]
 
 tests_require = [

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,8 @@ install_require = [
 
     'hvac<0.7.0',
     'jinja2',
-    'juju<3.0',
+    # 2.9.45.0 - https://github.com/juju/python-libjuju/pull/993
+    'juju<3.0,!=2.9.45,!=2.9.46',
     'juju-wait',
     'PyYAML',
     'tenacity',


### PR DESCRIPTION
macaroonbakery in version 1.3.4 started depending on protobuf>3.20 which it's not compatible with python 3.6, so this change pins macaroonbakery to 1.3.2 which was the last release compatible with older versions of protobuf.

For more details see:

- https://github.com/go-macaroon-bakery/py-macaroon-bakery/pull/92
- https://github.com/protocolbuffers/protobuf/issues/10076

It's worth to mention that there is no protobuf-4.0, it goes from 3.20 to 4.21 - https://pypi.org/project/protobuf/#history

(cherry picked from commit a8e4de518f32503e788547e78ff2f609c0275dc3) (cherry picked from commit 300c5bbefb1228e20d53226951662074bbb729d4)