### PR TITLE
Add provision to configure credentials via .zaza.yaml

### DIFF
--- a/doc/source/runningcharmtests.rst
+++ b/doc/source/runningcharmtests.rst
@@ -58,6 +58,7 @@ via a .zaza.yaml file, eg.::
     ---
     region: my-region-name
     cloud: my-cloud
+    credential: my-credential
 
 The above configuration is required to run Zaza on a multi cloud / region Juju
 controller.

--- a/unit_tests/test_zaza_charm_lifecycle_prepare.py
+++ b/unit_tests/test_zaza_charm_lifecycle_prepare.py
@@ -26,6 +26,7 @@ class TestCharmLifecyclePrepare(ut_utils.BaseTestCase):
         self.patch_object(lc_prepare.deployment_env, 'get_model_constraints')
         self.patch_object(lc_prepare.deployment_env, 'get_cloud_region')
         self.patch_object(lc_prepare.deployment_env, 'get_cloud_name')
+        self.patch_object(lc_prepare.deployment_env, 'get_credential_name')
         self.patch_object(lc_prepare.zaza.model, 'set_model_constraints')
         self.get_model_settings.return_value = {'default-series': 'hardy'}
         self.get_model_constraints.return_value = {'image-stream': 'released'}
@@ -35,6 +36,7 @@ class TestCharmLifecyclePrepare(ut_utils.BaseTestCase):
             config={
                 'default-series': 'hardy'},
             cloud_name=None,
+            credential_name=None,
             region=None)
         self.set_model_constraints.assert_called_once_with(
             constraints={'image-stream': 'released'},

--- a/unit_tests/utilities/test_deployment_env.py
+++ b/unit_tests/utilities/test_deployment_env.py
@@ -350,6 +350,25 @@ class TestUtilitiesDeploymentEnv(ut_utils.BaseTestCase):
             deployment_env.get_cloud_name(),
             None)
 
+    def test_get_credential_name(self):
+        self.patch_object(
+            deployment_env,
+            'get_setup_file_contents',
+            return_value={
+                'credential': 'test'})
+        self.assertEqual(
+            deployment_env.get_credential_name(),
+            'test')
+
+    def test_get_credential_name_default(self):
+        self.patch_object(
+            deployment_env,
+            'get_setup_file_contents',
+            return_value={})
+        self.assertEqual(
+            deployment_env.get_credential_name(),
+            None)
+
     def test_get_tmpdir(self):
         self.patch_object(deployment_env.os, 'mkdir')
         self.patch_object(deployment_env.os.path, 'exists')

--- a/zaza/charm_lifecycle/prepare.py
+++ b/zaza/charm_lifecycle/prepare.py
@@ -45,6 +45,7 @@ def prepare(model_name, model_alias='default_alias', test_directory=None):
         model_name,
         config=deployment_env.get_model_settings(model_alias),
         cloud_name=deployment_env.get_cloud_name(),
+        credential_name=deployment_env.get_credential_name(),
         region=deployment_env.get_cloud_region())
     zaza.model.set_model_constraints(
         model_name=model_name,

--- a/zaza/controller.py
+++ b/zaza/controller.py
@@ -25,7 +25,8 @@ import zaza.utilities.exceptions
 
 
 async def async_add_model(
-        model_name, config=None, cloud_name=None, region=None):
+    model_name, config=None, cloud_name=None, credential_name=None, region=None
+):
     """Add a model to the current controller.
 
     :param model_name: Name to give the new model.
@@ -39,7 +40,12 @@ async def async_add_model(
     await controller.connect()
     logging.debug("Adding model {}".format(model_name))
     model = await controller.add_model(
-        model_name, config=config, cloud_name=cloud_name, region=region)
+        model_name,
+        config=config,
+        cloud_name=cloud_name,
+        credential_name=credential_name,
+        region=region,
+    )
     # issue/135 It is necessary to disconnect the model here or async spews
     # tracebacks even during a successful run.
     await model.disconnect()

--- a/zaza/utilities/deployment_env.py
+++ b/zaza/utilities/deployment_env.py
@@ -206,6 +206,15 @@ def get_cloud_name():
     return get_setup_file_contents().get('cloud')
 
 
+def get_credential_name():
+    """Return a configured credential name to support multi-cloud controllers.
+
+    :returns: A string configured in .zaza.yaml or None
+    :rtype: Union[str, None]
+    """
+    return get_setup_file_contents().get('credential')
+
+
 def get_cloud_region():
     """Return a configured region name to support multi-cloud controllers.
 


### PR DESCRIPTION
Adds feature similar to https://github.com/openstack-charmers/zaza/pull/574/ to support selecting user provided credential from `zaza.yaml`.

Resolves #639 