### PR TITLE
Fix typo in requirements for readthedocs integration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,4 +12,4 @@ sphinx:
 # Explicitly set the version of Python and its requirements
 python:
   install:
-    - requirements: docs-requirements.txt
+    - requirements: doc-requirements.txt


### PR DESCRIPTION
The job at readthedocs.org is failing due to a typo in .readthedocs.yaml
causing build failures.
