### PR TITLE
Unpin python-libjuju based on environment variable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,8 +43,11 @@ install_require = [
 
     # https://github.com/go-macaroon-bakery/py-macaroon-bakery/issues/94
     'macaroonbakery != 1.3.3',
-    'juju<3.0.0',
 ]
+if os.environ.get("TEST_JUJU3"):
+    install_require.append('juju')
+else:
+    install_require.append('juju<3.0.0')
 
 tests_require = [
     'tox >= 2.3.1',


### PR DESCRIPTION
PR#652 pinned python-libjuju to < 3.0.0 to resolve CI issues with OpenStack Charms. However Sunbeam
project requires juju 3.x to run zaza tests.
Unpin python-libjuju if environment variable
JUJU3 is set.
This is a temporary fix until python-libjuju is
unpinned for all the projects.