### PR TITLE
Fix `unit.run` to support Juju 2.9 and 3.x

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -35,7 +35,7 @@ jobs:
       matrix:
         juju_channel:
           - 2.9/stable
-          # - 3.1/stable
+          - 3.1/stable
           # - 3.2/stable
           # - 3.3/stable
         bundle:

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -35,9 +35,10 @@ jobs:
       matrix:
         juju_channel:
           - 2.9/stable
-          - 3.1/stable
+          # - 3.1/stable
           # - 3.2/stable
           # - 3.3/stable
+          - 3.4/stable
         bundle:
           - first
           - second

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -60,6 +60,9 @@ jobs:
           # - juju_channel: 3.3/stable
           #   snap_install_flags: ""
           #   pip_constraints: constraints-juju33.txt
+          - juju_channel: 3.4/stable
+            snap_install_flags: ""
+            pip_constraints: constraints-juju34.txt
     env:
       TEST_ZAZA_BUG_LP1987332: "on"  # http://pad.lv/1987332
     needs: build

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -63,6 +63,7 @@ jobs:
           - juju_channel: 3.4/stable
             snap_install_flags: ""
             pip_constraints: constraints-juju34.txt
+            juju3: 1
     env:
       TEST_ZAZA_BUG_LP1987332: "on"  # http://pad.lv/1987332
     needs: build
@@ -97,6 +98,7 @@ jobs:
         set -euxo pipefail
         mkdir logs
         export PIP_CONSTRAINTS=$(pwd)/${{ matrix.pip_constraints }}
+        export TEST_JUJU3=${{ matrix.juju3 }}
         tox -e func-target -- ${{ matrix.bundle }} | tee logs/tox-output.txt
     - name: crashdump on failure
       if: failure()

--- a/constraints-juju34.txt
+++ b/constraints-juju34.txt
@@ -1,0 +1,9 @@
+# NOTE: this constraints file can be (and will be) consumed by downstream users.
+#
+# Known consumers:
+# * zosci-config: job definitions that declare what juju version (snap channel)
+#   is used in tandem with this constraints file to lockdown python-libjuju
+#   version.
+# * zaza-openstack-tests
+#
+juju>=3.4.0,<3.5.0

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,11 @@ deps =
     -r{toxinidir}/test-requirements.txt
 commands = pytest --cov=./zaza/ {posargs} {toxinidir}/unit_tests
 
+[testenv:.pkg]
+pass_env =
+  # NOTE: This is required because tox>=4 will not pass env. See https://github.com/tox-dev/tox/issues/2543.
+  TEST_JUJU3
+
 [testenv:py3]
 basepython = python3
 

--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -117,8 +117,17 @@ class TestModel(ut_utils.BaseTestCase):
                             scp_opts=None):
             return
 
-        async def _run(command, timeout=None):
+        async def _run(command, timeout=None, block=False):
             return self.action
+
+        async def _run_juju2_x(command, timeout=None):
+            return self.action
+
+        async def _run_wrapper(*args, **kwargs):
+            if self.juju_version >= 3:
+                return await _run(*args, **kwargs)
+            else:
+                return await _run_juju2_x(*args, **kwargs)
 
         async def _run_action(command, **params):
             return self.run_action
@@ -146,6 +155,7 @@ class TestModel(ut_utils.BaseTestCase):
                 return leader
             return _inner_is_leader
 
+        self.juju_version = 3
         self.run_action = mock.MagicMock()
         self.run_action.wait.side_effect = _wait
         self.action = mock.MagicMock()
@@ -191,8 +201,8 @@ class TestModel(ut_utils.BaseTestCase):
         self.unit2.name = 'app/4'
         self.unit2.entity_id = 'app/4'
         self.unit2.machine = self.machine7
-        self.unit2.run.side_effect = _run
-        self.unit1.run.side_effect = _run
+        self.unit2.run.side_effect = _run_wrapper
+        self.unit1.run.side_effect = _run_wrapper
         self.unit1.scp_to.side_effect = _scp_to
         self.unit2.scp_to.side_effect = _scp_to
         self.unit1.scp_from.side_effect = _scp_from
@@ -775,7 +785,6 @@ class TestModel(ut_utils.BaseTestCase):
             mock.call(self.unit2, model_name='model')])
 
     def test_run_on_unit(self):
-        self.action.status = "pending"
         self.patch_object(model, 'get_juju_model', return_value='mname')
         expected = {
             'Code': '0',
@@ -789,12 +798,11 @@ class TestModel(ut_utils.BaseTestCase):
         self.get_unit_from_name.return_value = self.unit1
         self.Model.return_value = self.Model_mock
         self.assertEqual(model.run_on_unit('app/2', cmd), expected)
-        self.unit1.run.assert_called_once_with(cmd, timeout=None)
-        self.action.wait.assert_called_once_with()
+        self.unit1.run.assert_called_once_with(cmd, timeout=None, block=True)
 
     def test_run_on_unit_juju2_x(self):
         del self.action.results
-        self.action.status = "completed"
+        self.juju_version = 2
         self.patch_object(model, 'get_juju_model', return_value='mname')
         expected = {
             'Code': '0',
@@ -808,7 +816,9 @@ class TestModel(ut_utils.BaseTestCase):
         self.get_unit_from_name.return_value = self.unit1
         self.Model.return_value = self.Model_mock
         self.assertEqual(model.run_on_unit('app/2', cmd), expected)
-        self.unit1.run.assert_called_once_with(cmd, timeout=None)
+        self.unit1.run.assert_has_calls([
+            mock.call(cmd, timeout=None, block=True),
+            mock.call(cmd, timeout=None)])
         self.action.wait.assert_not_called()
 
     def test_run_on_unit_lc_keys(self):
@@ -829,11 +839,12 @@ class TestModel(ut_utils.BaseTestCase):
         self.get_unit_from_name.return_value = self.unit1
         self.Model.return_value = self.Model_mock
         self.assertEqual(model.run_on_unit('app/2', cmd), expected)
-        self.unit1.run.assert_called_once_with(cmd, timeout=None)
+        self.unit1.run.assert_called_once_with(cmd, timeout=None, block=True)
         self.action.wait.assert_not_called()
 
     def test_run_on_unit_lc_keys_juju2_x(self):
         del self.action.results
+        self.juju_version = 2
         self.patch_object(model, 'get_juju_model', return_value='mname')
         self.action.data['results'] = {
             'Code': '0',
@@ -851,7 +862,9 @@ class TestModel(ut_utils.BaseTestCase):
         self.get_unit_from_name.return_value = self.unit1
         self.Model.return_value = self.Model_mock
         self.assertEqual(model.run_on_unit('app/2', cmd), expected)
-        self.unit1.run.assert_called_once_with(cmd, timeout=None)
+        self.unit1.run.assert_has_calls([
+            mock.call(cmd, timeout=None, block=True),
+            mock.call(cmd, timeout=None)])
         self.action.wait.assert_not_called()
 
     def test_run_on_unit_missing_stderr(self):
@@ -869,11 +882,12 @@ class TestModel(ut_utils.BaseTestCase):
         self.get_unit_from_name.return_value = self.unit1
         self.Model.return_value = self.Model_mock
         self.assertEqual(model.run_on_unit('app/2', cmd), expected)
-        self.unit1.run.assert_called_once_with(cmd, timeout=None)
+        self.unit1.run.assert_called_once_with(cmd, timeout=None, block=True)
         self.action.wait.assert_not_called()
 
     def test_run_on_unit_missing_stderr_juju2_x(self):
         del self.action.results
+        self.juju_version = 2
         self.patch_object(model, 'get_juju_model', return_value='mname')
         expected = {
             'Code': '0',
@@ -888,11 +902,12 @@ class TestModel(ut_utils.BaseTestCase):
         self.get_unit_from_name.return_value = self.unit1
         self.Model.return_value = self.Model_mock
         self.assertEqual(model.run_on_unit('app/2', cmd), expected)
-        self.unit1.run.assert_called_once_with(cmd, timeout=None)
+        self.unit1.run.assert_has_calls([
+            mock.call(cmd, timeout=None, block=True),
+            mock.call(cmd, timeout=None)])
         self.action.wait.assert_not_called()
 
     def test_run_on_leader(self):
-        self.action.status = "pending"
         self.patch_object(model, 'get_juju_model', return_value='mname')
         expected = {
             'Code': '0',
@@ -904,12 +919,11 @@ class TestModel(ut_utils.BaseTestCase):
         self.patch_object(model, 'Model')
         self.Model.return_value = self.Model_mock
         self.assertEqual(model.run_on_leader('app', cmd), expected)
-        self.unit2.run.assert_called_once_with(cmd, timeout=None)
-        self.action.wait.assert_called_once_with()
+        self.unit2.run.assert_called_once_with(cmd, timeout=None, block=True)
 
     def test_run_on_leader_juju2_x(self):
         del self.action.results
-        self.action.action.status = "completed"
+        self.juju_version = 2
         self.patch_object(model, 'get_juju_model', return_value='mname')
         expected = {
             'Code': '0',
@@ -921,7 +935,9 @@ class TestModel(ut_utils.BaseTestCase):
         self.patch_object(model, 'Model')
         self.Model.return_value = self.Model_mock
         self.assertEqual(model.run_on_leader('app', cmd), expected)
-        self.unit2.run.assert_called_once_with(cmd, timeout=None)
+        self.unit2.run.assert_has_calls([
+            mock.call(cmd, timeout=None, block=True),
+            mock.call(cmd, timeout=None)])
         self.action.wait.assert_not_called()
 
     def test_get_relation_id(self):
@@ -1637,11 +1653,12 @@ class TestModel(ut_utils.BaseTestCase):
             '/tmp/src/myfile.txt',
             timeout=0.1)
         self.unit1.run.assert_called_once_with(
-            'cat /tmp/src/myfile.txt', timeout=0.1)
+            'cat /tmp/src/myfile.txt', timeout=0.1, block=True)
         self.assertEqual('somestring', contents)
 
     def test_file_contents_success_juju2_x(self):
         del self.action.results
+        self.juju_version = 2
         self.action.data = {
             'results': {'Code': '0', 'Stderr': '', 'Stdout': 'somestring'}
         }
@@ -1653,8 +1670,9 @@ class TestModel(ut_utils.BaseTestCase):
             'app/2',
             '/tmp/src/myfile.txt',
             timeout=0.1)
-        self.unit1.run.assert_called_once_with(
-            'cat /tmp/src/myfile.txt', timeout=0.1)
+        self.unit1.run.assert_has_calls([
+            mock.call('cat /tmp/src/myfile.txt', timeout=0.1, block=True),
+            mock.call('cat /tmp/src/myfile.txt', timeout=0.1)])
         self.assertEqual('somestring', contents)
 
     def test_file_contents_fault(self):
@@ -1670,11 +1688,12 @@ class TestModel(ut_utils.BaseTestCase):
         with self.assertRaises(model.RemoteFileError) as ctxtmgr:
             model.file_contents('app/2', '/tmp/src/myfile.txt', timeout=0.1)
         self.unit1.run.assert_called_once_with(
-            'cat /tmp/src/myfile.txt', timeout=0.1)
+            'cat /tmp/src/myfile.txt', timeout=0.1, block=True)
         self.assertEqual(ctxtmgr.exception.args, ('fault',))
 
     def test_file_contents_fault_juju2_x(self):
         del self.action.results
+        self.juju_version = 2
         self.action.data = {
             'results': {'Code': '0', 'Stderr': 'fault', 'Stdout': ''}
         }
@@ -1684,8 +1703,9 @@ class TestModel(ut_utils.BaseTestCase):
         self.patch_object(model, 'get_juju_model', return_value='mname')
         with self.assertRaises(model.RemoteFileError) as ctxtmgr:
             model.file_contents('app/2', '/tmp/src/myfile.txt', timeout=0.1)
-        self.unit1.run.assert_called_once_with(
-            'cat /tmp/src/myfile.txt', timeout=0.1)
+        self.unit1.run.assert_has_calls([
+            mock.call('cat /tmp/src/myfile.txt', timeout=0.1, block=True),
+            mock.call('cat /tmp/src/myfile.txt', timeout=0.1)])
         self.assertEqual(ctxtmgr.exception.args, ('fault',))
 
     def test_block_until_file_has_contents(self):
@@ -1704,20 +1724,19 @@ class TestModel(ut_utils.BaseTestCase):
         _fileobj = mock.MagicMock()
         _fileobj.__enter__().read.return_value = "somestring"
         self._open.return_value = _fileobj
-        self.patch('inspect.isawaitable', return_value=True,
-                   name='isawaitable')
         model.block_until_file_has_contents(
             'app',
             '/tmp/src/myfile.txt',
             'somestring',
             timeout=0.1)
         self.unit1.run.assert_called_once_with(
-            'cat /tmp/src/myfile.txt')
+            'cat /tmp/src/myfile.txt', timeout=None, block=True)
         self.unit2.run.assert_called_once_with(
-            'cat /tmp/src/myfile.txt')
+            'cat /tmp/src/myfile.txt', timeout=None, block=True)
 
     def test_block_until_file_has_contents_juju2_x(self):
         del self.action.results
+        self.juju_version = 2
         self.action.data = {
             'results': {'Code': '0', 'Stderr': '', 'Stdout': 'somestring'}
         }
@@ -1731,17 +1750,17 @@ class TestModel(ut_utils.BaseTestCase):
         _fileobj = mock.MagicMock()
         _fileobj.__enter__().read.return_value = "somestring"
         self._open.return_value = _fileobj
-        self.patch('inspect.isawaitable', return_value=False,
-                   name='isawaitable')
         model.block_until_file_has_contents(
             'app',
             '/tmp/src/myfile.txt',
             'somestring',
             timeout=0.1)
-        self.unit1.run.assert_called_once_with(
-            'cat /tmp/src/myfile.txt')
-        self.unit2.run.assert_called_once_with(
-            'cat /tmp/src/myfile.txt')
+        self.unit1.run.assert_has_calls([
+            mock.call('cat /tmp/src/myfile.txt', timeout=None, block=True),
+            mock.call('cat /tmp/src/myfile.txt', timeout=None)])
+        self.unit2.run.assert_has_calls([
+            mock.call('cat /tmp/src/myfile.txt', timeout=None, block=True),
+            mock.call('cat /tmp/src/myfile.txt', timeout=None)])
 
     def test_block_until_file_has_no_contents(self):
         self.action.results = {'return-code': '0', 'stderr': ''}
@@ -1761,12 +1780,13 @@ class TestModel(ut_utils.BaseTestCase):
             '',
             timeout=0.1)
         self.unit1.run.assert_called_once_with(
-            'cat /tmp/src/myfile.txt')
+            'cat /tmp/src/myfile.txt', timeout=None, block=True)
         self.unit2.run.assert_called_once_with(
-            'cat /tmp/src/myfile.txt')
+            'cat /tmp/src/myfile.txt', timeout=None, block=True)
 
     def test_block_until_file_has_no_contents_juju2_x(self):
         del self.action.results
+        self.juju_version = 2
         self.action.data = {
             'results': {'Code': '0', 'Stderr': ''}
         }
@@ -1785,10 +1805,12 @@ class TestModel(ut_utils.BaseTestCase):
             '/tmp/src/myfile.txt',
             '',
             timeout=0.1)
-        self.unit1.run.assert_called_once_with(
-            'cat /tmp/src/myfile.txt')
-        self.unit2.run.assert_called_once_with(
-            'cat /tmp/src/myfile.txt')
+        self.unit1.run.assert_has_calls([
+            mock.call('cat /tmp/src/myfile.txt', timeout=None, block=True),
+            mock.call('cat /tmp/src/myfile.txt', timeout=None)])
+        self.unit2.run.assert_has_calls([
+            mock.call('cat /tmp/src/myfile.txt', timeout=None, block=True),
+            mock.call('cat /tmp/src/myfile.txt', timeout=None)])
 
     def test_block_until_file_has_contents_missing(self):
         self.patch_object(model, 'Model')
@@ -1806,34 +1828,37 @@ class TestModel(ut_utils.BaseTestCase):
                 '/tmp/src/myfile.txt',
                 'somestring',
                 timeout=0.1)
-        self.unit1.run.assert_called_once_with('cat /tmp/src/myfile.txt')
+        self.unit1.run.assert_called_once_with(
+            'cat /tmp/src/myfile.txt', timeout=None, block=True)
 
     def test_block_until_file_missing(self):
         self.patch_object(model, 'Model')
         self.Model.return_value = self.Model_mock
         self.patch_object(model, 'get_juju_model', return_value='mname')
         self.action.results = {'stdout': "1"}
-        self.patch('inspect.isawaitable', return_value=True,
-                   name='isawaitable')
         model.block_until_file_missing(
             'app',
             '/tmp/src/myfile.txt',
             timeout=0.1)
         self.unit1.run.assert_called_once_with(
-            'test -e "/tmp/src/myfile.txt"; echo $?')
+            'test -e "/tmp/src/myfile.txt"; echo $?', timeout=None, block=True)
 
     def test_block_until_file_missing_juju2_x(self):
         self.patch_object(model, 'Model')
         self.Model.return_value = self.Model_mock
         self.patch_object(model, 'get_juju_model', return_value='mname')
         del self.action.results
+        self.juju_version = 2
         self.action.data['results']['Stdout'] = "1"
         model.block_until_file_missing(
             'app',
             '/tmp/src/myfile.txt',
             timeout=0.1)
-        self.unit1.run.assert_called_once_with(
-            'test -e "/tmp/src/myfile.txt"; echo $?')
+        self.unit1.run.assert_has_calls([
+            mock.call(
+                'test -e "/tmp/src/myfile.txt"; echo $?',
+                timeout=None, block=True),
+            mock.call('test -e "/tmp/src/myfile.txt"; echo $?', timeout=None)])
 
     def test_block_until_file_missing_isnt_missing(self):
         self.patch_object(model, 'Model')
@@ -1862,12 +1887,13 @@ class TestModel(ut_utils.BaseTestCase):
             's.*string',
             timeout=0.1)
         self.unit1.run.assert_called_once_with(
-            'cat /tmp/src/myfile.txt')
+            'cat /tmp/src/myfile.txt', timeout=None, block=True)
         self.unit2.run.assert_called_once_with(
-            'cat /tmp/src/myfile.txt')
+            'cat /tmp/src/myfile.txt', timeout=None, block=True)
 
     def test_block_until_file_matches_re_juju2_x(self):
         del self.action.results
+        self.juju_version = 2
         self.action.data = {
             'results': {'Code': '0', 'Stderr': '', 'Stdout': 'somestring'}
         }
@@ -1880,10 +1906,12 @@ class TestModel(ut_utils.BaseTestCase):
             '/tmp/src/myfile.txt',
             's.*string',
             timeout=0.1)
-        self.unit1.run.assert_called_once_with(
-            'cat /tmp/src/myfile.txt')
-        self.unit2.run.assert_called_once_with(
-            'cat /tmp/src/myfile.txt')
+        self.unit1.run.assert_has_calls([
+            mock.call('cat /tmp/src/myfile.txt', timeout=None, block=True),
+            mock.call('cat /tmp/src/myfile.txt', timeout=None)])
+        self.unit2.run.assert_has_calls([
+            mock.call('cat /tmp/src/myfile.txt', timeout=None, block=True),
+            mock.call('cat /tmp/src/myfile.txt', timeout=None)])
 
     def test_async_block_until_all_units_idle(self):
 
@@ -2231,9 +2259,9 @@ disk_formats = ami,ari,aki,vhd,vmdk,raw,qcow2,vdi,iso,root-tar
             file_contents,
             expected_contents)
         self.unit1.run.assert_called_once_with(
-            'cat /tmp/src/myfile.txt')
+            'cat /tmp/src/myfile.txt', timeout=None, block=True)
         self.unit2.run.assert_called_once_with(
-            'cat /tmp/src/myfile.txt')
+            'cat /tmp/src/myfile.txt', timeout=None, block=True)
 
     def test_block_until_oslo_config_entries_match_fail(self):
         file_contents = """
@@ -2263,7 +2291,7 @@ disk_formats = ami,ari,aki,vhd,vmdk,raw,qcow2,vdi,iso,root-tar
                 file_contents,
                 expected_contents)
         self.unit1.run.assert_called_once_with(
-            'cat /tmp/src/myfile.txt')
+            'cat /tmp/src/myfile.txt', timeout=None, block=True)
 
     def test_block_until_oslo_config_entries_match_missing_entry(self):
         file_contents = """
@@ -2292,7 +2320,7 @@ disk_formats = ami,ari,aki,vhd,vmdk,raw,qcow2,vdi,iso,root-tar
                 file_contents,
                 expected_contents)
         self.unit1.run.assert_called_once_with(
-            'cat /tmp/src/myfile.txt')
+            'cat /tmp/src/myfile.txt', timeout=None, block=True)
 
     def test_block_until_oslo_config_entries_match_missing_section(self):
         file_contents = """
@@ -2316,7 +2344,7 @@ disk_formats = ami,ari,aki,vhd,vmdk,raw,qcow2,vdi,iso,root-tar
                 file_contents,
                 expected_contents)
         self.unit1.run.assert_called_once_with(
-            'cat /tmp/src/myfile.txt')
+            'cat /tmp/src/myfile.txt', timeout=None, block=True)
 
     def block_until_services_restarted_base(self, gu_return=None,
                                             gu_raise_exception=False):

--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -775,6 +775,7 @@ class TestModel(ut_utils.BaseTestCase):
             mock.call(self.unit2, model_name='model')])
 
     def test_run_on_unit(self):
+        self.action.status = "pending"
         self.patch_object(model, 'get_juju_model', return_value='mname')
         expected = {
             'Code': '0',
@@ -785,17 +786,15 @@ class TestModel(ut_utils.BaseTestCase):
         self.cmd = cmd = 'somecommand someargument'
         self.patch_object(model, 'Model')
         self.patch_object(model, 'get_unit_from_name')
-        self.patch("inspect.isawaitable", name="isawaitable",
-                   return_value=True)
         self.get_unit_from_name.return_value = self.unit1
         self.Model.return_value = self.Model_mock
-        self.assertEqual(model.run_on_unit('app/2', cmd),
-                         expected)
+        self.assertEqual(model.run_on_unit('app/2', cmd), expected)
         self.unit1.run.assert_called_once_with(cmd, timeout=None)
-        self.action.wait.assert_called_once()
+        self.action.wait.assert_called_once_with()
 
     def test_run_on_unit_juju2_x(self):
         del self.action.results
+        self.action.status = "completed"
         self.patch_object(model, 'get_juju_model', return_value='mname')
         expected = {
             'Code': '0',
@@ -806,12 +805,9 @@ class TestModel(ut_utils.BaseTestCase):
         self.cmd = cmd = 'somecommand someargument'
         self.patch_object(model, 'Model')
         self.patch_object(model, 'get_unit_from_name')
-        self.patch("inspect.isawaitable", name="isawaitable",
-                   return_value=False)
         self.get_unit_from_name.return_value = self.unit1
         self.Model.return_value = self.Model_mock
-        self.assertEqual(model.run_on_unit('app/2', cmd),
-                         expected)
+        self.assertEqual(model.run_on_unit('app/2', cmd), expected)
         self.unit1.run.assert_called_once_with(cmd, timeout=None)
         self.action.wait.assert_not_called()
 
@@ -832,9 +828,9 @@ class TestModel(ut_utils.BaseTestCase):
         self.patch_object(model, 'get_unit_from_name')
         self.get_unit_from_name.return_value = self.unit1
         self.Model.return_value = self.Model_mock
-        self.assertEqual(model.run_on_unit('app/2', cmd),
-                         expected)
+        self.assertEqual(model.run_on_unit('app/2', cmd), expected)
         self.unit1.run.assert_called_once_with(cmd, timeout=None)
+        self.action.wait.assert_not_called()
 
     def test_run_on_unit_lc_keys_juju2_x(self):
         del self.action.results
@@ -854,9 +850,9 @@ class TestModel(ut_utils.BaseTestCase):
         self.patch_object(model, 'get_unit_from_name')
         self.get_unit_from_name.return_value = self.unit1
         self.Model.return_value = self.Model_mock
-        self.assertEqual(model.run_on_unit('app/2', cmd),
-                         expected)
+        self.assertEqual(model.run_on_unit('app/2', cmd), expected)
         self.unit1.run.assert_called_once_with(cmd, timeout=None)
+        self.action.wait.assert_not_called()
 
     def test_run_on_unit_missing_stderr(self):
         self.patch_object(model, 'get_juju_model', return_value='mname')
@@ -872,9 +868,9 @@ class TestModel(ut_utils.BaseTestCase):
         self.patch_object(model, 'get_unit_from_name')
         self.get_unit_from_name.return_value = self.unit1
         self.Model.return_value = self.Model_mock
-        self.assertEqual(model.run_on_unit('app/2', cmd),
-                         expected)
+        self.assertEqual(model.run_on_unit('app/2', cmd), expected)
         self.unit1.run.assert_called_once_with(cmd, timeout=None)
+        self.action.wait.assert_not_called()
 
     def test_run_on_unit_missing_stderr_juju2_x(self):
         del self.action.results
@@ -891,11 +887,12 @@ class TestModel(ut_utils.BaseTestCase):
         self.patch_object(model, 'get_unit_from_name')
         self.get_unit_from_name.return_value = self.unit1
         self.Model.return_value = self.Model_mock
-        self.assertEqual(model.run_on_unit('app/2', cmd),
-                         expected)
+        self.assertEqual(model.run_on_unit('app/2', cmd), expected)
         self.unit1.run.assert_called_once_with(cmd, timeout=None)
+        self.action.wait.assert_not_called()
 
     def test_run_on_leader(self):
+        self.action.status = "pending"
         self.patch_object(model, 'get_juju_model', return_value='mname')
         expected = {
             'Code': '0',
@@ -906,14 +903,13 @@ class TestModel(ut_utils.BaseTestCase):
         self.cmd = cmd = 'somecommand someargument'
         self.patch_object(model, 'Model')
         self.Model.return_value = self.Model_mock
-        self.patch('inspect.isawaitable', return_value=True,
-                   name='isawaitable')
-        self.assertEqual(model.run_on_leader('app', cmd),
-                         expected)
+        self.assertEqual(model.run_on_leader('app', cmd), expected)
         self.unit2.run.assert_called_once_with(cmd, timeout=None)
+        self.action.wait.assert_called_once_with()
 
     def test_run_on_leader_juju2_x(self):
         del self.action.results
+        self.action.action.status = "completed"
         self.patch_object(model, 'get_juju_model', return_value='mname')
         expected = {
             'Code': '0',
@@ -924,9 +920,9 @@ class TestModel(ut_utils.BaseTestCase):
         self.cmd = cmd = 'somecommand someargument'
         self.patch_object(model, 'Model')
         self.Model.return_value = self.Model_mock
-        self.assertEqual(model.run_on_leader('app', cmd),
-                         expected)
+        self.assertEqual(model.run_on_leader('app', cmd), expected)
         self.unit2.run.assert_called_once_with(cmd, timeout=None)
+        self.action.wait.assert_not_called()
 
     def test_get_relation_id(self):
         self.patch_object(model, 'get_juju_model', return_value='mname')

--- a/zaza/model.py
+++ b/zaza/model.py
@@ -570,7 +570,7 @@ async def async_run_on_unit(unit_name, command, model_name=None, timeout=None):
     model = await get_model(model_name)
     unit = await async_get_unit_from_name(unit_name, model)
     action = await unit.run(command, timeout=timeout)
-    if inspect.isawaitable(action):
+    if action.status == "pending":
         await action.wait()
     action = _normalise_action_object(action)
     results = action.data.get('results')
@@ -599,7 +599,7 @@ async def async_run_on_leader(application_name, command, model_name=None,
         is_leader = await unit.is_leader_from_status()
         if is_leader:
             action = await unit.run(command, timeout=timeout)
-            if inspect.isawaitable(action):
+            if action.status == "pending":
                 await action.wait()
             action = _normalise_action_object(action)
             results = action.data.get('results')
@@ -2160,7 +2160,7 @@ async def async_block_until_file_ready(application_name, remote_file,
         for unit in units:
             try:
                 output = await unit.run('cat {}'.format(remote_file))
-                if inspect.isawaitable(output):
+                if output.status == "pending":
                     await output.wait()
                 results = {}
                 try:
@@ -2302,7 +2302,7 @@ async def async_block_until_file_missing(
         for unit in units:
             try:
                 output = await unit.run('test -e "{}"; echo $?'.format(path))
-                if inspect.isawaitable(output):
+                if output.status == "pending":
                     await output.wait()
                 output = _normalise_action_object(output)
                 output_result = _normalise_action_results(

--- a/zaza/model.py
+++ b/zaza/model.py
@@ -569,9 +569,7 @@ async def async_run_on_unit(unit_name, command, model_name=None, timeout=None):
     """
     model = await get_model(model_name)
     unit = await async_get_unit_from_name(unit_name, model)
-    action = await unit.run(command, timeout=timeout)
-    if action.status == "pending":
-        await action.wait()
+    action = await generic_utils.unit_run(unit, command, timeout)
     action = _normalise_action_object(action)
     results = action.data.get('results')
     return _normalise_action_results(results)
@@ -598,9 +596,7 @@ async def async_run_on_leader(application_name, command, model_name=None,
     for unit in model.applications[application_name].units:
         is_leader = await unit.is_leader_from_status()
         if is_leader:
-            action = await unit.run(command, timeout=timeout)
-            if action.status == "pending":
-                await action.wait()
+            action = await generic_utils.unit_run(unit, command, timeout)
             action = _normalise_action_object(action)
             results = action.data.get('results')
             return _normalise_action_results(results)
@@ -2159,9 +2155,8 @@ async def async_block_until_file_ready(application_name, remote_file,
         units = model.applications[application_name].units
         for unit in units:
             try:
-                output = await unit.run('cat {}'.format(remote_file))
-                if output.status == "pending":
-                    await output.wait()
+                output = await generic_utils.unit_run(
+                    unit, 'cat {}'.format(remote_file))
                 results = {}
                 try:
                     results = output.results
@@ -2301,9 +2296,8 @@ async def async_block_until_file_missing(
         results = []
         for unit in units:
             try:
-                output = await unit.run('test -e "{}"; echo $?'.format(path))
-                if output.status == "pending":
-                    await output.wait()
+                output = await generic_utils.unit_run(
+                    unit, 'test -e "{}"; echo $?'.format(path))
                 output = _normalise_action_object(output)
                 output_result = _normalise_action_results(
                     output.data.get('results', {}))

--- a/zaza/utilities/generic.py
+++ b/zaza/utilities/generic.py
@@ -729,3 +729,23 @@ async def check_output(cmd, log_stdout=True, log_stderr=True):
         'Stderr': stderr,
         'Stdout': stdout,
     }
+
+
+async def unit_run(unit, command, timeout=None):
+    """Help function to help support Juju 2.9 and Juju 3>.
+
+    :param unit: juju unit
+    :type unit: juju.unit.Unit
+    :param command: Command to execute
+    :type command: str
+    :param timeout: How long in seconds to wait for command to complete
+    :type timeout: int
+    :returns: completed Action object
+    :rtype: juju.action.Action
+    """
+    try:
+        # block supported in juju>=3.0
+        return await unit.run(command, timeout=timeout, block=True)
+    except TypeError:
+        # juju 2.9 fallback
+        return await unit.run(command, timeout=timeout)


### PR DESCRIPTION
The run_on_unit require to be awaited for juju 3+, and this fix proposes a solution to check status of action and wait for it if it's "pending". This was original described in issue #649 and marked as fixed by #650, however the action object is never awaitable as it can be seen in my examples below.

I tested in with this script
```python
import asyncio
import inspect
from juju.model import Model

async def run_test_command():
    model = Model()
    await model.connect(model_name="test")
    # try to run command
    try:
        action = await model.units["grafana/0"].run("echo HelloWord")
        print("command isawaitable: ", inspect.isawaitable(action))
        print("command action.data: ", action.data)
        print("command action.status: ", action.status)
        print("command action.results: ", action.results)
        if action.status == "pending":
            await action.wait()
        print("command isawaitable: ", inspect.isawaitable(action))
        print("command action.data: ", action.data)
        print("command action.status: ", action.status)
        print("command action.results: ", action.results)
    except Exception as error:
        print(error)
    # try to run actions get-admin-password
    try:
        action = await model.units["grafana/0"].run("actions/get-admin-password")  # `actions/` needs to be specified in Juju 2.9
        print("command isawaitable: ", inspect.isawaitable(action))
        print("command action.data: ", action.data)
        print("command action.status: ", action.status)
        print("command action.results: ", action.results)
        if action.status == "pending":
            await action.wait()
        print("command isawaitable: ", inspect.isawaitable(action))
        print("command action.data: ", action.data)
        print("command action.status: ", action.status)
        print("command action.results: ", action.results)
    except Exception as error:
        print(error)

```

and here are the results for Juju 2.9
```bash
(.venv) ubuntu@rgildein-bastion:~$ juju status
Model  Controller             Cloud/Region             Version  SLA          Timestamp
test   rgildein2-serverstack  serverstack/serverstack  2.9.35   unsupported  18:40:23Z

App      Version  Status  Scale  Charm    Channel  Rev  Exposed  Message
grafana           active      1  grafana  stable    69  no       Ready

Unit        Workload  Agent  Machine  Public address  Ports     Message
grafana/0*  active    idle   0        10.5.1.81       3000/tcp  Ready

Machine  State    Address    Inst id                               Series  AZ    Message
0        started  10.5.1.81  049ee5ba-4cff-4b41-bdca-1f18d676043f  focal   nova  ACTIVE

(.venv) ubuntu@rgildein-bastion:~$ pip freeze | grep juju
juju==2.9.46.1
jujubundlelib==0.5.7
(.venv) ubuntu@rgildein-bastion:~$ python3 ./zaza-test-script.py 
command isawaitable:  False
command action.data:  {'model-uuid': '5972fd83-b71d-4746-8dde-11b1ab1026f5', 'id': '24', 'receiver': 'grafana/0', 'name': 'juju-run', 'parameters': {'command': 'echo HelloWord', 'timeout': 0, 'workload-context': False}, 'status': 'completed', 'message': '', 'results': {'Code': '0', 'Stdout': 'HelloWord\n'}, 'enqueued': '2024-04-15T18:40:51Z', 'started': '2024-04-15T18:40:54Z', 'completed': '2024-04-15T18:40:54Z'}
command action.status:  completed
command action.results:  {'Code': '0', 'Stdout': 'HelloWord\n'}
command isawaitable:  False
command action.data:  {'model-uuid': '5972fd83-b71d-4746-8dde-11b1ab1026f5', 'id': '24', 'receiver': 'grafana/0', 'name': 'juju-run', 'parameters': {'command': 'echo HelloWord', 'timeout': 0, 'workload-context': False}, 'status': 'completed', 'message': '', 'results': {'Code': '0', 'Stdout': 'HelloWord\n'}, 'enqueued': '2024-04-15T18:40:51Z', 'started': '2024-04-15T18:40:54Z', 'completed': '2024-04-15T18:40:54Z'}
command action.status:  completed
command action.results:  {'Code': '0', 'Stdout': 'HelloWord\n'}
command isawaitable:  False
command action.data:  {'model-uuid': '5972fd83-b71d-4746-8dde-11b1ab1026f5', 'id': '26', 'receiver': 'grafana/0', 'name': 'juju-run', 'parameters': {'command': 'actions/get-admin-password', 'timeout': 0, 'workload-context': False}, 'status': 'completed', 'message': '', 'results': {'Code': '0', 'password': 'K5xgXHBM4jYwwtgt'}, 'enqueued': '2024-04-15T18:40:54Z', 'started': '2024-04-15T18:40:54Z', 'completed': '2024-04-15T18:40:55Z'}
command action.status:  completed
command action.results:  {'Code': '0', 'password': 'K5xgXHBM4jYwwtgt'}
command isawaitable:  False
command action.data:  {'model-uuid': '5972fd83-b71d-4746-8dde-11b1ab1026f5', 'id': '26', 'receiver': 'grafana/0', 'name': 'juju-run', 'parameters': {'command': 'actions/get-admin-password', 'timeout': 0, 'workload-context': False}, 'status': 'completed', 'message': '', 'results': {'Code': '0', 'password': 'K5xgXHBM4jYwwtgt'}, 'enqueued': '2024-04-15T18:40:54Z', 'started': '2024-04-15T18:40:54Z', 'completed': '2024-04-15T18:40:55Z'}
command action.status:  completed
command action.results:  {'Code': '0', 'password': 'K5xgXHBM4jYwwtgt'}
```
and results for Juju 3.4:
```bash
(.venv) ubuntu@juju-lxd-34:~$ juju status
Model  Controller  Cloud/Region         Version  SLA          Timestamp
test   lxd         localhost/localhost  3.4.2    unsupported  18:42:50Z

App      Version  Status  Scale  Charm    Channel        Rev  Exposed  Message
grafana           active      1  grafana  latest/stable   69  no       Ready

Unit        Workload  Agent  Machine  Public address  Ports     Message
grafana/0*  active    idle   0        10.205.200.72   3000/tcp  Ready

Machine  State    Address        Inst id        Base          AZ  Message
0        started  10.205.200.72  juju-1d3ff7-0  ubuntu@20.04      Running
(.venv) ubuntu@juju-lxd-34:~$ pip freeze | grep juju
juju==3.4.0.0
(.venv) ubuntu@juju-lxd-34:~$ python3 ./zaza-test-script.py 
command isawaitable:  False
command action.data:  {'model-uuid': 'a330379b-c75f-4a98-8726-10dfd71d3ff7', 'id': '30', 'receiver': 'grafana/0', 'name': 'juju-exec', 'status': 'pending', 'message': '', 'enqueued': '2024-04-15T18:43:15Z', 'started': '0001-01-01T00:00:00Z', 'completed': '0001-01-01T00:00:00Z'}
command action.status:  pending
command action.results:  {}
command isawaitable:  False
command action.data:  {'model-uuid': 'a330379b-c75f-4a98-8726-10dfd71d3ff7', 'id': '30', 'receiver': 'grafana/0', 'name': 'juju-exec', 'status': 'completed', 'message': '', 'enqueued': '2024-04-15T18:43:15Z', 'started': '2024-04-15T18:43:15Z', 'completed': '2024-04-15T18:43:15Z'}
command action.status:  completed
command action.results:  {'return-code': 0, 'stdout': 'HelloWord\n'}
command isawaitable:  False
command action.data:  {'model-uuid': 'a330379b-c75f-4a98-8726-10dfd71d3ff7', 'id': '32', 'receiver': 'grafana/0', 'name': 'juju-exec', 'status': 'pending', 'message': '', 'enqueued': '2024-04-15T18:43:16Z', 'started': '0001-01-01T00:00:00Z', 'completed': '0001-01-01T00:00:00Z'}
command action.status:  pending
command action.results:  {}
command isawaitable:  False
command action.data:  {'model-uuid': 'a330379b-c75f-4a98-8726-10dfd71d3ff7', 'id': '32', 'receiver': 'grafana/0', 'name': 'juju-exec', 'status': 'completed', 'message': '', 'enqueued': '2024-04-15T18:43:16Z', 'started': '2024-04-15T18:43:16Z', 'completed': '2024-04-15T18:43:17Z'}
command action.status:  completed
command action.results:  {'password': 'pxVVZpZGrcgCdqpH', 'return-code': 0}
```

The example of usage on both 2.9 and 3.4 (see logs) can be found [here](https://github.com/canonical/charm-duplicity/actions/runs/8695836394?pr=26). The func tests are failing, but it's not related with zaza.
fixes: https://github.com/openstack-charmers/zaza/issues/649