### PR TITLE
utilities: Fix juju_reboot for 3.x.

### DIFF
--- a/unit_tests/utilities/test_zaza_utilities_generic.py
+++ b/unit_tests/utilities/test_zaza_utilities_generic.py
@@ -213,7 +213,8 @@ class TestGenericUtils(ut_utils.BaseTestCase):
         generic_utils.juju_reboot(_unit)
         self.subprocess.check_call.assert_called_once_with(
             ['juju', 'ssh', _unit,
-             f'sudo juju-run -u {_unit} "juju-reboot --now"'])
+             f'sudo juju-run -u {_unit} "juju-reboot --now" || '
+             f'sudo juju-exec -u {_unit} "juju-reboot --now"'])
 
     def test_run_via_ssh(self):
         _unit = "app/2"

--- a/zaza/utilities/generic.py
+++ b/zaza/utilities/generic.py
@@ -519,7 +519,9 @@ def juju_reboot(unit_name):
     with update-status hooks causing intermittent CI failures).
     """
     cmd = ['juju', 'ssh', unit_name,
-           'sudo juju-run -u {} "juju-reboot --now"'.format(unit_name)]
+           'sudo juju-run -u {} "juju-reboot --now" || '
+           'sudo juju-exec -u {} "juju-reboot --now"'
+           .format(unit_name, unit_name)]
     try:
         subprocess.check_call(cmd)
     except subprocess.CalledProcessError as e:


### PR DESCRIPTION
Juju 3.x renames `juju-run` to `juju-exec`.