### PR TITLE
Remove model default series and image stream

### DIFF
--- a/zaza/utilities/deployment_env.py
+++ b/zaza/utilities/deployment_env.py
@@ -47,8 +47,6 @@ VALID_ENVIRONMENT_KEY_PREFIXES = [
 MODEL_DEFAULTS = {
     # Model defaults from charm-test-infra
     #   https://jujucharms.com/docs/2.1/models-config
-    'default-series': 'focal',
-    'image-stream': 'daily',
     'test-mode': 'true',
     'transmit-vendor-metrics': 'false',
     # https://bugs.launchpad.net/juju/+bug/1685351


### PR DESCRIPTION
Image stream being daily messes up prodstack juju deployments and doesn't have enough reason to be here to justify this.