### PR TITLE
Pin websockets library

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -108,7 +108,7 @@ jobs:
         juju-crashdump -m $model -o logs/
     - name: upload logs on failure
       if: failure()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: test-run-logs-and-crashdump
         path: logs/

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,3 +35,7 @@ sphinx
 sphinxcontrib-asyncio
 # https://github.com/go-macaroon-bakery/py-macaroon-bakery/issues/94
 macaroonbakery!=1.3.3
+
+# NOTE(freyes): Set upper bound for websockets until libjuju is compatible with
+# newer versions. See https://github.com/juju/python-libjuju/pull/1208
+websockets<13.0.0

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,9 @@ install_require = [
 
     # https://github.com/go-macaroon-bakery/py-macaroon-bakery/issues/94
     'macaroonbakery != 1.3.3',
+    # NOTE(freyes): Set upper bound for websockets until libjuju is compatible
+    # with newer versions. See https://github.com/juju/python-libjuju/pull/1208
+    'websockets<13.0.0',
 ]
 if os.environ.get("TEST_JUJU3"):
     install_require.append('juju')

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -16,6 +16,10 @@ keystoneauth1
 oslo.config
 python-novaclient
 tenacity>8.2.0
+# NOTE(freyes): Set upper bound for websockets until libjuju is compatible with
+# newer versions. See https://github.com/juju/python-libjuju/pull/1208
+websockets<13.0.0
+
 # To force the installation of an specific version of libjuju use a constraints
 # file, e.g.: `env PIP_CONSTRAINTS=./constraints-juju31.txt tox -e func-target`
 juju


### PR DESCRIPTION
Set upper bound for websockets until libjuju is compatible with newer versions.

See https://github.com/juju/python-libjuju/pull/1208