### PR TITLE
Pin websockets library [bobcat]

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -80,7 +80,7 @@ jobs:
         juju crashdump -m $model -o logs/
     - name: upload logs on failure
       if: failure()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: test-run-logs-and-crashdump
         path: logs/

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -45,6 +45,13 @@ jobs:
     needs: build
     steps:
     - uses: actions/checkout@v1
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@main
+      with:
+        tool-cache: false
+        large-packages: false
+        docker-images: false
+        swap-storage: false
     - name: Install dependencies
       run: |
         set -euxo pipefail

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,3 +37,7 @@ sphinx
 sphinxcontrib-asyncio
 # https://github.com/go-macaroon-bakery/py-macaroon-bakery/issues/94
 macaroonbakery!=1.3.3
+
+# NOTE(freyes): Set upper bound for websockets until libjuju is compatible with
+# newer versions. See https://github.com/juju/python-libjuju/pull/1208
+websockets<13.0.0

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,9 @@ install_require = [
 
     # https://github.com/go-macaroon-bakery/py-macaroon-bakery/issues/94
     'macaroonbakery != 1.3.3',
+    # NOTE(freyes): Set upper bound for websockets until libjuju is compatible
+    # with newer versions. See https://github.com/juju/python-libjuju/pull/1208
+    'websockets<13.0.0',
 ]
 
 tests_require = [

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -16,6 +16,10 @@ keystoneauth1
 oslo.config
 python-novaclient
 tenacity>8.2.0
+# NOTE(freyes): Set upper bound for websockets until libjuju is compatible with
+# newer versions. See https://github.com/juju/python-libjuju/pull/1208
+websockets<13.0.0
+
 # pinned until 3.0 regressions are handled: https://github.com/openstack-charmers/zaza/issues/545
 juju<3.0
 # https://github.com/go-macaroon-bakery/py-macaroon-bakery/issues/94


### PR DESCRIPTION
* Pin websockets library

Set upper bound for websockets until libjuju is compatible with newer versions.

See https://github.com/juju/python-libjuju/pull/1208

* Migrate to actions/upload-artifact@v4

(cherry picked from commit d758d6dde3cf7af0d9f1bf3e90c80ca83c14f7b5)