### PR TITLE
Add action jlumbroso/free-disk-space@main

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -68,6 +68,13 @@ jobs:
     needs: build
     steps:
     - uses: actions/checkout@v1
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@main
+      with:
+        tool-cache: false
+        large-packages: false
+        docker-images: false
+        swap-storage: false
     - name: Install dependencies
       run: |
         set -euxo pipefail


### PR DESCRIPTION
It frees up space from the runner.

It has been found that some CI runs fail due to not enough free disk space in the runner to import the lxd images and deploy charms.