### PR TITLE
machine_os: Preemptively load vfio kernel module.

### DIFF
--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -1142,7 +1142,6 @@ class TestModel(ut_utils.BaseTestCase):
             'app/2': self.unit2}
 
         async def _async_get_unit_from_name(x, *args):
-            nonlocal units
             return units[x]
 
         self.async_get_unit_from_name.side_effect = _async_get_unit_from_name

--- a/unit_tests/utilities/test_zaza_utilities_machine_os.py
+++ b/unit_tests/utilities/test_zaza_utilities_machine_os.py
@@ -85,6 +85,7 @@ class TestUtils(ut_utils.BaseTestCase):
 
     def test__set_vfio_unsafe_noiommu_mode(self):
         self.patch_object(machine_os_utils.zaza.utilities.juju, 'remote_run')
+        self.patch_object(machine_os_utils, 'load_kernel_module')
         self.remote_run.return_value = 'Y'
         unit = mock.MagicMock()
         unit.name = 'aUnit'
@@ -97,6 +98,7 @@ class TestUtils(ut_utils.BaseTestCase):
         with self.assertRaises(AssertionError):
             machine_os_utils._set_vfio_unsafe_noiommu_mode(unit, True)
 
+        self.load_kernel_module.reset_mock()
         self.remote_run.reset_mock()
         self.remote_run.return_value = 'Y\n'
         expect = (
@@ -105,7 +107,10 @@ class TestUtils(ut_utils.BaseTestCase):
         machine_os_utils._set_vfio_unsafe_noiommu_mode(unit, True)
         self.remote_run.assert_called_once_with(
             'aUnit', expect, model_name=None, fatal=True)
+        self.load_kernel_module.assert_called_once_with(
+            'aUnit', 'vfio', model_name=None)
 
+        self.load_kernel_module.reset_mock()
         self.remote_run.reset_mock()
         self.remote_run.return_value = 'N\n'
         expect = (
@@ -114,6 +119,8 @@ class TestUtils(ut_utils.BaseTestCase):
         machine_os_utils._set_vfio_unsafe_noiommu_mode(unit, False)
         self.remote_run.assert_called_once_with(
             'aUnit', expect, model_name=None, fatal=True)
+        self.load_kernel_module.assert_called_once_with(
+            'aUnit', 'vfio', model_name=None)
 
     def test_enable_vfio_unsafe_noiommu_mode(self):
         self.patch_object(machine_os_utils, '_set_vfio_unsafe_noiommu_mode')

--- a/zaza/__init__.py
+++ b/zaza/__init__.py
@@ -64,7 +64,7 @@ def get_or_create_libjuju_thread():
     :returns: the thread that libjuju is running in.
     :rtype: threading.Thread
     """
-    global _libjuju_thread, _libjuju_loop, _libjuju_run
+    global _libjuju_thread, _libjuju_run
     if _libjuju_thread is None:
         _libjuju_run = True
         _libjuju_thread = threading.Thread(target=libjuju_thread_run)
@@ -103,7 +103,6 @@ def libjuju_thread_run():
     global _libjuju_loop
 
     async def looper():
-        global _libjuju_run
         while _libjuju_run:
             # short spinner to ensure that foreground tasks 'happen' so that
             # background tasks can complete (e.g. during model disconnection).
@@ -148,7 +147,7 @@ def libjuju_thread_run():
 
 def join_libjuju_thread():
     """Stop and cleanup the asyncio tasks on the loop, and then join it."""
-    global _libjuju_thread, _libjuju_loop, _libjuju_run
+    global _libjuju_thread, _libjuju_run
     if _libjuju_thread is not None:
         logging.debug("stopping the event loop")
         # remove the child watcher (that was for subprocess calls) when
@@ -203,7 +202,6 @@ def sync_wrapper(f, timeout=None):
     :rtype: function
     """
     def _wrapper(*args, **kwargs):
-        global _libjuju_loop
 
         async def _runner():
             return await f(*args, **kwargs)

--- a/zaza/charm_lifecycle/utils.py
+++ b/zaza/charm_lifecycle/utils.py
@@ -91,7 +91,6 @@ def get_base_test_dir():
     :returns: Path to test dir.
     :rtype: str
     """
-    global base_test_dir
     return base_test_dir
 
 
@@ -399,7 +398,6 @@ def get_charm_config(yaml_file=None, fatal=True, cached=True):
     :returns: Config dictionary
     :rtype: dict
     """
-    global _charm_config
     if not yaml_file:
         if get_base_test_dir():
             yaml_file = "{}/{}".format(

--- a/zaza/events/collection.py
+++ b/zaza/events/collection.py
@@ -69,7 +69,6 @@ def get_collection(name=None):
     :returns: the colection named, or creates a new one of that name.
     :rtype: Collection
     """
-    global _collections
     if name is None:
         name = get_option("zaza-events.collection-name", "DEFAULT")
     try:

--- a/zaza/events/plugins/conncheck.py
+++ b/zaza/events/plugins/conncheck.py
@@ -109,7 +109,6 @@ def get_plugin_manager(name="DEFAULT"):
     :returns: the conncheck plugin manager
     :rtype: LoggerPluginManager
     """
-    global _conncheck_plugin_managers
     try:
         return _conncheck_plugin_managers[name]
     except KeyError:

--- a/zaza/events/plugins/logging.py
+++ b/zaza/events/plugins/logging.py
@@ -214,7 +214,6 @@ def get_logger(name="DEFAULT"):
     :returns: the logger instance
     :rtype: EventLogger
     """
-    global _loggers
     if name not in _loggers:
         _loggers[name] = EventLogger(name)
     return _loggers[name]
@@ -272,7 +271,6 @@ def get_plugin_manager(name="DEFAULT"):
     :returns:  the Logger plugin manager
     :rtype: LoggerPluginManager
     """
-    global _logger_plugin_managers
     try:
         return _logger_plugin_managers[name]
     except KeyError:

--- a/zaza/model.py
+++ b/zaza/model.py
@@ -93,7 +93,6 @@ def get_juju_model_aliases():
     :returns: Model alias map
     :rtype: dict
     """
-    global MODEL_ALIASES
     return MODEL_ALIASES
 
 
@@ -211,7 +210,6 @@ async def get_model_memo(model_name):
     :type model_name: str
     :returns: juju.model.Model
     """
-    global ModelRefs
     model = None
     if model_name in ModelRefs:
         model = ModelRefs[model_name]
@@ -257,7 +255,6 @@ async def remove_model_memo(model_name):
     :param model_name: the model name to remove a Model object.
     :type model_name: str
     """
-    global ModelRefs
     try:
         model = ModelRefs[model_name]
         del ModelRefs[model_name]

--- a/zaza/notifications/__init__.py
+++ b/zaza/notifications/__init__.py
@@ -124,7 +124,6 @@ def subscribe(f, event=None, when=None):
     :param when: when the function should be called.
     :type when: str
     """
-    global _notify_map
     if event is None:
         events = NotifyEvents
     elif isinstance(event, Iterable):
@@ -163,7 +162,6 @@ def unsubscribe(f, event=None, when=None):
     :param when: when the function should be called.
     :type when: str
     """
-    global _notify_map
     if when is None or when == NotifyType.ALL:
         whens = (NotifyType.BEFORE, NotifyType.AFTER, NotifyType.EXCEPTION)
     elif when == NotifyType.BOTH:

--- a/zaza/utilities/__init__.py
+++ b/zaza/utilities/__init__.py
@@ -32,7 +32,6 @@ def deprecate():
 
         @wraps(f)
         def wrapped_f(*args, **kwargs):
-            global deprecations
             if f not in deprecations:
                 msg = "{} is deprecated. ".format(f.__name__)
                 logging.warning(msg)
@@ -109,7 +108,6 @@ def cached(func):
     """
     @wraps(func)
     def wrapper(*args, **kwargs):
-        global cache
         key = json.dumps((func, args, kwargs), sort_keys=True, default=str)
         try:
             return cache[key]

--- a/zaza/utilities/machine_os.py
+++ b/zaza/utilities/machine_os.py
@@ -133,6 +133,8 @@ def _set_vfio_unsafe_noiommu_mode(unit, enable, model_name=None):
     :type model_name: Optional[str]
     :raises: AssertionError, zaza.model.CommandRunFailed
     """
+    load_kernel_module(unit.name, 'vfio', model_name=model_name)
+
     expected_result = 'Y' if enable else 'N'
     value = 1 if enable else 0
     cmd = (


### PR DESCRIPTION
VFIO kernel module is not always loaded, which causes tests to fail when they try to set No-IOMMU mode. This change calls modprobe to ensure that VFIO is loaded before we try to use it.