### PR TITLE
juju_utils: fix assumptions about 'subordinate-to'

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,10 +2,10 @@
 name = zaza
 summary = A Python3-only functional test framework for OpenStack Charms
 version = 0.0.2.dev1
-description-file =
+description_file =
     README.rst
 author = OpenStack Charmers
-author-email = openstack-charmers@lists.ubuntu.com
+author_email = openstack-charmers@lists.ubuntu.com
 url = https://github.com/openstack-charmers/zaza
 classifier =
     Development Status :: 2 - Pre-Alpha

--- a/tox.ini
+++ b/tox.ini
@@ -52,23 +52,19 @@ commands = sphinx-build -W -b html -d {toxinidir}/doc/build/doctrees . {toxinidi
 [testenv:func]
 basepython = python3
 commands =
-    {envdir}/bin/python3 setup.py install
     functest-run-suite --keep-faulty-model
 
 [testenv:func-target]
 basepython = python3
 commands =
-    {envdir}/bin/python3 setup.py install
     functest-run-suite --keep-model --bundle {posargs}
 
 [testenv:func-target-extended]
 basepython = python3
 commands =
-    {envdir}/bin/python3 setup.py install
     functest-run-suite --keep-model --test-directory {toxinidir}/tests-extended --log INFO --bundle {posargs}
 
 [testenv:remove-placement]
 basepython = python3
 commands =
-    {envdir}/bin/python3 setup.py install
     remove-placement {posargs}

--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -245,6 +245,7 @@ class TestModel(ut_utils.BaseTestCase):
         self.machine_data = {self.key: self.key_data}
         self.unit = "app/1"
         self.application = "app"
+
         self.subordinate_application = "subordinate_application"
         self.subordinate_application_data = {
             "subordinate-to": [self.application],
@@ -252,18 +253,44 @@ class TestModel(ut_utils.BaseTestCase):
         self.subordinate_unit = "subordinate_application/1"
         self.subordinate_unit_data = {
             "workload-status": {"status": "active"}}
+
+        # Second subordinate app is related both to the principal application
+        # and to the first subordinate application
+        self.second_subordinate_application = "second_subordinate_application"
+        self.second_subordinate_application_data = {
+            "subordinate-to": [
+                self.subordinate_application,
+                self.application
+            ],
+            "units": None}
+        self.second_subordinate_unit = "second_subordinate_application/1"
+        self.second_subordinate_unit_data = {
+            "workload-status": {"status": "active"}}
+        # Update the suboridnate list on the first subordinate as well
+        self.subordinate_application_data["subordinate-to"].insert(
+            0,
+            self.second_subordinate_application,
+        )
+
         self.unit_data = {
             "workload-status": {"status": "active"},
             "machine": self.machine,
             "subordinates": {
-                self.subordinate_unit: self.subordinate_unit_data}}
+                self.subordinate_unit: self.subordinate_unit_data,
+                self.second_subordinate_unit:
+                    self.second_subordinate_unit_data,
+            }
+        }
         self.application_data = {"units": {
             self.unit1.name: self.subordinate_unit_data,
             self.unit: self.unit_data}}
         self.juju_status = mock.MagicMock()
         self.juju_status.applications = {
             self.application: self.application_data,
-            self.subordinate_application: self.subordinate_application_data}
+            self.subordinate_application: self.subordinate_application_data,
+            self.second_subordinate_application:
+                self.second_subordinate_application_data,
+        }
         self.juju_status.machines = self.machine_data
 
         async def _connect_model(model_name):

--- a/unit_tests/utilities/test_zaza_utilities_juju.py
+++ b/unit_tests/utilities/test_zaza_utilities_juju.py
@@ -78,18 +78,39 @@ class TestJujuUtils(ut_utils.BaseTestCase):
         self.unit2_mock.data = {'machine-id': self.machine2}
 
         self.application = "app"
+
         self.subordinate_application = "subordinate_application"
         self.subordinate_application_unit = "subordinate_application/0"
         self.subordinate_application_data = {
             "subordinate-to": [self.application]}
+
+        # Second subordinate app is related both to the principal application
+        # and to the first subordinate application
+        self.second_subordinate_application = "second_subordinate"
+        self.second_subordinate_application_unit = "second_subordinate/0"
+        self.second_subordinate_application_data = {
+            "subordinate-to": [self.subordinate_application, self.application]}
+        # Update the suboridnate list on the first subordinate as well
+        self.subordinate_application_data['subordinate-to'].insert(
+            0,
+            self.second_subordinate_application
+        )
+
         self.application_data = {
             "units": {self.unit1: self.unit1_data},
-            "subordinates": {self.subordinate_application_unit: {}}}
+            "subordinates": {
+                self.subordinate_application_unit: {},
+                self.second_subordinate_application_unit: {},
+            }
+        }
         self.juju_status = mock.MagicMock()
         self.juju_status.name = "juju_status_object"
         self.juju_status.applications = {
             self.application: self.application_data,
-            self.subordinate_application: self.subordinate_application_data}
+            self.subordinate_application: self.subordinate_application_data,
+            self.second_subordinate_application:
+                self.second_subordinate_application_data,
+        }
         self.juju_status.machines = {
             self.machine0: self.machine0_mock,
             self.machine1: self.machine1_mock,


### PR DESCRIPTION
Few places in the code made assumption that for subordinate charms, the 'subordinate-to' list would contain only principal charms. However that is not the case. If a suboridnate charm is related to other subordinate charms, they show up in each other's 'subordinate-to' lists.

This was especially problematic in the 'get_machines_for_application' function which would end up in an infinite loop.