### PR TITLE
flake8: Pin snowballstemmer

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -25,3 +25,7 @@ websockets<13.0.0
 juju
 # https://github.com/go-macaroon-bakery/py-macaroon-bakery/issues/94
 macaroonbakery!=1.3.3
+
+# flake8 plugin "flake8-docstrings" isn't compatible with "snowballstemmer>=3"
+# https://github.com/PyCQA/flake8-docstrings/issues/74
+snowballstemmer<3


### PR DESCRIPTION
flake8 plugin "flake8-docstrings" isn't compatible with "snowballstemmer>=3"[0]

[0] https://github.com/PyCQA/flake8-docstrings/issues/74