### PR TITLE
Add retry mechanism for the Launchpad API

### DIFF
--- a/unit_tests/utilities/test_zaza_utilities_launchpad.py
+++ b/unit_tests/utilities/test_zaza_utilities_launchpad.py
@@ -22,7 +22,7 @@ import zaza.utilities.launchpad as launchpad
 class TestUtilitiesLaunchpad(ut_utils.BaseTestCase):
 
     def test_get_ubuntu_series(self):
-        self.patch_object(launchpad.requests, 'get')
+        self.patch_object(launchpad.requests.Session, 'get')
         expect = {'entries': {}}
         r = unittest.mock.MagicMock()
         r.text = json.dumps(expect)

--- a/zaza/utilities/launchpad.py
+++ b/zaza/utilities/launchpad.py
@@ -16,6 +16,8 @@
 import json
 import requests
 import typing
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
 
 
 def get_ubuntu_series(
@@ -26,8 +28,21 @@ def get_ubuntu_series(
     https://launchpad.net/+apidoc/devel.html#distribution
     https://launchpad.net/+apidoc/devel.html#distro_series
     """
-    r = requests.get('https://api.launchpad.net/devel/ubuntu/series')
-    return json.loads(r.text)
+    retries = Retry(
+        total=10,
+        backoff_factor=2,
+        status_forcelist=[429, 500, 502, 503, 504],
+        allowed_methods=["GET"]
+    )
+    s = requests.Session()
+    s.mount("https://", HTTPAdapter(max_retries=retries))
+
+    try:
+        r = s.get('https://api.launchpad.net/devel/ubuntu/series')
+        r.raise_for_status()
+        return json.loads(r.text)
+    finally:
+        s.close()
 
 
 def get_ubuntu_series_by_version() -> typing.Dict[str, typing.Dict[str, any]]:


### PR DESCRIPTION
Quite often Launchpad API is temporarily unavailable. In such cases, without this patch, a request to get all Ubuntu releases from Launchpad fails immediately, causing the entire test to fail. For example for the charm-octavia it can take up to 2 hours before the functional tests get to this point. And if it fails because of the Launchapad API unavailability, the whole tests suite needs to be restarted. In order to save time and resources, a simple request retry mechanism is introduced by this patch.