### PR TITLE
Drop websocket pinning

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -38,7 +38,7 @@ jobs:
           # - 3.1/stable
           # - 3.2/stable
           # - 3.3/stable
-          - 3.4/stable
+          - 3.6/stable
         bundle:
           - first
           - second
@@ -59,9 +59,9 @@ jobs:
           # - juju_channel: 3.3/stable
           #   snap_install_flags: ""
           #   pip_constraints: constraints-juju33.txt
-          - juju_channel: 3.4/stable
+          - juju_channel: 3.6/stable
             snap_install_flags: ""
-            pip_constraints: constraints-juju34.txt
+            pip_constraints: constraints-juju36.txt
             juju3: 1
     env:
       TEST_ZAZA_BUG_LP1987332: "on"  # http://pad.lv/1987332

--- a/constraints-juju36.txt
+++ b/constraints-juju36.txt
@@ -1,0 +1,9 @@
+# NOTE: this constraints file can be (and will be) consumed by downstream users.
+#
+# Known consumers:
+# * zosci-config: job definitions that declare what juju version (snap channel)
+#   is used in tandem with this constraints file to lockdown python-libjuju
+#   version.
+# * zaza-openstack-tests
+#
+juju>=3.6.0,<3.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,3 @@ sphinx
 sphinxcontrib-asyncio
 # https://github.com/go-macaroon-bakery/py-macaroon-bakery/issues/94
 macaroonbakery!=1.3.3
-
-# NOTE(freyes): Set upper bound for websockets until libjuju is compatible with
-# newer versions. See https://github.com/juju/python-libjuju/pull/1208
-websockets<13.0.0

--- a/setup.py
+++ b/setup.py
@@ -43,9 +43,6 @@ install_require = [
 
     # https://github.com/go-macaroon-bakery/py-macaroon-bakery/issues/94
     'macaroonbakery != 1.3.3',
-    # NOTE(freyes): Set upper bound for websockets until libjuju is compatible
-    # with newer versions. See https://github.com/juju/python-libjuju/pull/1208
-    'websockets<13.0.0',
 ]
 if os.environ.get("TEST_JUJU3"):
     install_require.append('juju')

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -16,10 +16,6 @@ keystoneauth1
 oslo.config
 python-novaclient
 tenacity>8.2.0
-# NOTE(freyes): Set upper bound for websockets until libjuju is compatible with
-# newer versions. See https://github.com/juju/python-libjuju/pull/1208
-websockets<13.0.0
-
 # To force the installation of an specific version of libjuju use a constraints
 # file, e.g.: `env PIP_CONSTRAINTS=./constraints-juju31.txt tox -e func-target`
 juju

--- a/unit_tests/test_zaza_charm_lifecycle_test.py
+++ b/unit_tests/test_zaza_charm_lifecycle_test.py
@@ -114,3 +114,17 @@ class TestCharmLifecycleTest(ut_utils.BaseTestCase):
         # Using args
         args = lc_test.parse_args(['-m', 'model', '--log', 'DEBUG'])
         self.assertEqual(args.loglevel, 'DEBUG')
+
+    def test_main(self):
+        self.patch_object(lc_test, 'parse_args')
+        self.patch_object(lc_test.cli_utils, 'setup_logging')
+        self.patch_object(lc_test, 'run_test_list')
+        args_mock = mock.MagicMock()
+        args_mock.loglevel = 'DEBUG'
+        args_mock.model = {'default_alias': 'modelname'}
+        args_mock.tests = ['test_class1', 'test_class2']
+        self.parse_args.return_value = args_mock
+        lc_test.main(['-m', 'modelname', 'test_class1', 'test_class2'])
+        self.setup_logging.assert_called_once_with(log_level='DEBUG')
+        self.run_test_list.assert_called_once_with(
+            ['test_class1', 'test_class2'])

--- a/zaza/__init__.py
+++ b/zaza/__init__.py
@@ -209,6 +209,10 @@ def sync_wrapper(f, timeout=None):
         if not RUN_LIBJUJU_IN_THREAD:
             # run it in this thread's event loop:
             loop = asyncio.get_event_loop()
+            # create a new loop if the existing one is closed
+            if loop.is_closed():
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
             return loop.run_until_complete(_runner())
 
         # ensure that the thread is created

--- a/zaza/charm_lifecycle/test.py
+++ b/zaza/charm_lifecycle/test.py
@@ -208,13 +208,15 @@ def add_config_option(config_item):
     global_options.set_option(option, value)
 
 
-def main():
+def main(argv=None):
     """Run the tests defined by the command line args.
 
     Run the tests defined by the command line args or if none were provided
     read the tests from the charms tests.yaml config file
+
+    :param argv: List of command line arguments
     """
-    args = parse_args(sys.argv[1:])
+    args = parse_args(argv if argv else sys.argv[1:])
     cli_utils.setup_logging(log_level=args.loglevel.upper())
     zaza.model.set_juju_model_aliases(args.model)
     utils.set_base_test_dir(test_dir=args.test_directory)


### PR DESCRIPTION
websocket doesn't need to be pinned anymore, python-libjuju is compatible with newer versions now.

Ref: https://github.com/juju/python-libjuju/pull/1216