### PR TITLE
Migrate zaza from libjuju (async) to jubilant (sync)

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -113,11 +113,14 @@ jobs:
         model=$(juju models --format yaml|grep "^- name:.*zaza"|cut -f2 -d/)
         juju status -m $model | tee logs/juju-status.txt
         juju-crashdump -m $model -o logs/
+    - name: sanitize juju_channel for artifact name
+      if: failure()
+      run: echo "SAFE_JUJU_CHANNEL=$(echo '${{ matrix.juju_channel }}' | tr '/' '-')" >> $GITHUB_ENV
     - name: upload logs on failure
       if: failure()
       uses: actions/upload-artifact@v4
       with:
-        name: test-run-logs-and-crashdump
+        name: test-run-logs-and-crashdump-${{ matrix.bundle }}-${{ env.SAFE_JUJU_CHANNEL }}
         path: logs/
     - name: consider debugging
       uses: lhotari/action-upterm@v1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,46 @@
+# AGENTS.md
+
+## Project Overview
+Zaza is a Python 3-only functional test framework for OpenStack Charms,
+developed by Canonical's OpenStack Charmers. It automates the full lifecycle of
+deploying and testing Juju charms.
+
+## Tech Stack
+- **Language:** Python 3.10+
+- **Automation:** tox
+- **Testing:** `tox -e py3`
+- **Linting:** `tox -e pep8`
+
+## Environment Rules
+- **DO NOT** use `pip install` directly to modify the local environment.
+- **ALWAYS** use `tox` to run tests and linters to ensure isolation.
+- If new dependencies are needed, update `setup.py` and `requirements.txt`, then
+  run `tox` to update environments.
+
+## Available Tox Commands
+- **Run all tests:** `tox`
+- **Run specific environment:** `tox -e py3`
+- **Run linting:** `tox -e pep8`
+- **Build docs:** `tox -e docs`
+- **Recreate environments:** `tox --recreate`
+
+## Downstream consumers
+
+- **zaza-openstack-tests** https://github.com/openstack-charmers/zaza-openstack-tests/
+
+## Project Structure
+- `zaza/`: Source code
+- `unit_tests/`: Unit Test suite
+- `tox.ini`: Tox configuration
+- `requirements.txt`: Dependencies
+- `setup.py`: Package definition
+
+## Testing
+- Run all tests: `tox -e py3`
+- All new features must include unit tests in the `unit_tests/` directory.
+- Use `tox -e func-target -- $bundle_name` to run integration tests, where
+  `$bundle_name` can be one of the bundle files available in `tests/bundles/`
+  directory (without the `.yaml` extension).
+
+## Boundaries
+- DO NOT commit `.env` files or secrets.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ deploying and testing Juju charms.
 - **Automation:** tox
 - **Testing:** `tox -e py3`
 - **Linting:** `tox -e pep8`
+- **Python interpreter** `.tox/py3/bin/python`
 
 ## Environment Rules
 - **DO NOT** use `pip install` directly to modify the local environment.
@@ -21,6 +22,7 @@ deploying and testing Juju charms.
 - **Run all tests:** `tox`
 - **Run specific environment:** `tox -e py3`
 - **Run linting:** `tox -e pep8`
+- **Run linting for one or more files** `tox -e pep8 -- <FILES>`
 - **Build docs:** `tox -e docs`
 - **Recreate environments:** `tox --recreate`
 

--- a/bindep.txt
+++ b/bindep.txt
@@ -1,0 +1,6 @@
+libffi-dev [platform:dpkg]
+python3-dev [platform:dpkg]
+pkg-config [platform:dpkg]
+libssl-dev [platform:dpkg]
+rustc [platform:dpkg]
+cargo [platform:dpkg]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
 pyparsing<3.0.0  # pin for aodhclient which is held for py35
 async_generator
-kubernetes<18.0.0; python_version < '3.6' # pined, as juju uses kubernetes
-juju_wait
 PyYAML>=3.0
 pbr==5.6.0
 simplejson>=2.2.0
@@ -35,3 +33,4 @@ sphinx
 sphinxcontrib-asyncio
 # https://github.com/go-macaroon-bakery/py-macaroon-bakery/issues/94
 macaroonbakery!=1.3.3
+jubilant

--- a/setup.py
+++ b/setup.py
@@ -36,18 +36,13 @@ install_require = [
 
     'hvac<0.7.0',
     'jinja2',
-    'juju-wait',
     'PyYAML',
     'tenacity>8.2.0',
     'python-libmaas',
-
     # https://github.com/go-macaroon-bakery/py-macaroon-bakery/issues/94
     'macaroonbakery != 1.3.3',
+    'jubilant',
 ]
-if os.environ.get("TEST_JUJU3"):
-    install_require.append('juju')
-else:
-    install_require.append('juju<3.0.0')
 
 tests_require = [
     'tox >= 2.3.1',

--- a/tests/bundles/first.yaml
+++ b/tests/bundles/first.yaml
@@ -1,4 +1,4 @@
-series: focal
+series: noble
 applications:
   magpie-focal:
     series: focal

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -8,7 +8,7 @@ gate_bundles:
 target_deploy_status:
   magpie-jammy:
     workload-status: active
-    workload-status-message-prefix: icmp ok, local hostname ok
+    workload-status-message-prefix: Ready, with 1 peer
   magpie-focal:
     workload-status: active
     workload-status-message-prefix: icmp ok, local hostname ok

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ basepython = python3
 
 [testenv:pep8]
 basepython = python3
-commands = flake8 {posargs} zaza unit_tests
+commands = flake8 {posargs:zaza unit_tests}
 
 [testenv:venv]
 basepython = python3

--- a/unit_tests/test_zaza.py
+++ b/unit_tests/test_zaza.py
@@ -12,36 +12,77 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# import aiounittest
-
-
-# Prior to Python 3.8 asyncio would raise a ``asyncio.futures.TimeoutError``
-# exception on timeout, from Python 3.8 onwards it raises a exception from a
-# new ``asyncio.exceptions`` module.
-#
-# Neither of these are inherited from a relevant built-in exception so we
-# cannot catch them generally with the built-in TimeoutError or similar.
-try:
-    import asyncio.exceptions
-    AsyncTimeoutError = asyncio.exceptions.TimeoutError
-except ImportError:
-    import asyncio.futures
-    AsyncTimeoutError = asyncio.futures.TimeoutError
-
-import mock
-
 import unit_tests.utils as ut_utils
 
 import zaza
 
 
-def tearDownModule():
-    zaza.clean_up_libjuju_thread()
+class TestSyncWrapper(ut_utils.BaseTestCase):
+    """Tests for the sync_wrapper shim."""
+
+    def test_sync_wrapper_plain_function(self):
+        """sync_wrapper passes through a plain (non-async) function."""
+        def add(a, b):
+            return a + b
+
+        wrapped = zaza.sync_wrapper(add)
+        self.assertEqual(wrapped(1, 2), 3)
+
+    def test_sync_wrapper_async_function(self):
+        """sync_wrapper transparently runs an async coroutine function."""
+        async def async_add(a, b):
+            return a + b
+
+        wrapped = zaza.sync_wrapper(async_add)
+        self.assertEqual(wrapped(3, 4), 7)
+
+    def test_sync_wrapper_timeout_ignored(self):
+        """sync_wrapper accepts a timeout kwarg without error (no-op)."""
+        def identity(x):
+            return x
+
+        wrapped = zaza.sync_wrapper(identity, timeout=30)
+        self.assertEqual(wrapped(42), 42)
 
 
-class TestModel(ut_utils.BaseTestCase):
+class TestRun(ut_utils.BaseTestCase):
+    """Tests for the run() helper."""
 
-    def test_run(self):
+    def test_run_no_steps(self):
+        self.assertIsNone(zaza.run())
+
+    def test_run_plain_function(self):
+        def num4():
+            return 4
+
+        self.assertEqual(zaza.run(num4), 4)
+
+    def test_run_plain_value(self):
+        self.assertEqual(zaza.run(num4()), 4)  # noqa: F821 – defined below
+
+    def test_run_multiple_steps_returns_last(self):
+        def one():
+            return 1
+
+        def two():
+            return 2
+
+        self.assertEqual(zaza.run(one, two), 2)
+
+    def test_run_async_function(self):
+        async def async_three():
+            return 3
+
+        self.assertEqual(zaza.run(async_three), 3)
+
+    def test_run_async_coroutine(self):
+        async def async_add(i):
+            return i + 1
+
+        # Pass an already-created coroutine object.
+        self.assertEqual(zaza.run(async_add(2)), 3)
+
+    def test_run_mixed_steps(self):
         async def one():
             return 1
 
@@ -54,10 +95,29 @@ class TestModel(ut_utils.BaseTestCase):
         def num4():
             return 4
 
-        with mock.patch.object(zaza, 'RUN_LIBJUJU_IN_THREAD', new=False):
-            self.assertEqual(zaza.run(one), 1)
-            self.assertEqual(zaza.run(one, two), 2)
-            self.assertEqual(zaza.run(one, two, add1(2)), 3)
-            self.assertEqual(zaza.run(), None)
-            self.assertEqual(zaza.run(num4), 4)
-            self.assertEqual(zaza.run(num4()), 4)
+        self.assertEqual(zaza.run(one), 1)
+        self.assertEqual(zaza.run(one, two), 2)
+        self.assertEqual(zaza.run(one, two, add1(2)), 3)
+        self.assertEqual(zaza.run(), None)
+        self.assertEqual(zaza.run(num4), 4)
+        self.assertEqual(zaza.run(num4()), 4)
+
+
+def num4():
+    return 4
+
+
+class TestCompatStubs(ut_utils.BaseTestCase):
+    """The old async-thread lifecycle stubs must exist and be callable."""
+
+    def test_clean_up_libjuju_thread_is_noop(self):
+        zaza.clean_up_libjuju_thread()
+
+    def test_join_libjuju_thread_is_noop(self):
+        zaza.join_libjuju_thread()
+
+    def test_get_or_create_libjuju_thread_is_noop(self):
+        zaza.get_or_create_libjuju_thread()
+
+    def test_run_libjuju_in_thread_flag_exists(self):
+        self.assertFalse(zaza.RUN_LIBJUJU_IN_THREAD)

--- a/unit_tests/test_zaza_controller.py
+++ b/unit_tests/test_zaza_controller.py
@@ -12,109 +12,115 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import mock
-import pytest
-import unittest
 
 import unit_tests.utils as ut_utils
 
 import zaza.controller as controller
-import zaza
 
 
-def tearDownModule():
-    zaza.clean_up_libjuju_thread()
-
-
-@pytest.mark.asyncio
-class TestController(ut_utils.BaseTestCase):
+class TestAddModel(ut_utils.BaseTestCase):
 
     def setUp(self):
-        super(TestController, self).setUp()
+        super().setUp()
+        self.patch_object(controller, 'jubilant')
+        self.juju_mock = mock.MagicMock()
+        self.jubilant.Juju.return_value = self.juju_mock
 
-        async def _disconnect():
-            return
+    def test_add_model_basic(self):
+        controller.add_model('mymodel')
+        self.juju_mock.add_model.assert_called_once_with(
+            'mymodel', None, config=None, credential=None)
 
-        async def _connect():
-            return
+    def test_add_model_with_config(self):
+        controller.add_model('mymodel', config={'run-faster': 'true'})
+        self.juju_mock.add_model.assert_called_once_with(
+            'mymodel', None, config={'run-faster': 'true'}, credential=None)
 
-        async def _list_models():
-            return self.models
+    def test_add_model_with_cloud_and_region(self):
+        controller.add_model('mymodel', cloud_name='aws', region='us-east-1')
+        self.juju_mock.add_model.assert_called_once_with(
+            'mymodel', 'aws/us-east-1', config=None, credential=None)
 
-        async def _add_model(model_name, config=None):
-            return self.model1
+    def test_add_model_with_region_only(self):
+        controller.add_model('mymodel', region='us-east-1')
+        self.juju_mock.add_model.assert_called_once_with(
+            'mymodel', 'us-east-1', config=None, credential=None)
 
-        async def _destroy_model(model_name, destroy_storage=False,
-                                 force=False, max_wait=None):
-            if model_name in self.models:
-                self.models.remove(model_name)
-            return
+    def test_add_model_with_credential(self):
+        controller.add_model('mymodel', credential_name='mycred')
+        self.juju_mock.add_model.assert_called_once_with(
+            'mymodel', None, config=None, credential='mycred')
 
-        async def _get_cloud():
-            return self.cloud
 
-        # Cloud
-        self.cloud = "FakeCloud"
+class TestDestroyModel(ut_utils.BaseTestCase):
 
-        # Model
-        self.Model_mock = mock.MagicMock()
-        self.Model_mock.connect.side_effect = _connect
-        self.Model_mock.disconnect.side_effect = _disconnect
-        self.Model_mock.disconnect.side_effect = _disconnect
-        self.model1 = self.Model_mock
-        self.model2 = mock.MagicMock()
-        self.model1.info.name = "model1"
-        self.model2.info.name = "model2"
-        self.models = [self.model1.info.name, self.model2.info.name]
-
-        # Controller
-        self.Controller_mock = mock.MagicMock()
-        self.Controller_mock.connect.side_effect = _connect
-        self.Controller_mock.disconnect.side_effect = _disconnect
-        self.Controller_mock.add_model.side_effect = _add_model
-        self.Controller_mock.destroy_model.side_effect = _destroy_model
-        self.Controller_mock.list_models.side_effect = _list_models
-        self.Controller_mock.get_cloud.side_effect = _get_cloud
-        self.controller_name = "testcontroller"
-        self.Controller_mock.info.name = self.controller_name
-        self.patch_object(controller, 'Controller')
-        self.Controller.return_value = self.Controller_mock
-
-    @unittest.skip("Skipping unti libjuju issue 333 is resolved")
-    def test_add_model(self):
-        controller.add_model(self.model1.info.name)
-        self.Controller_mock.add_model.assert_called_once_with(
-            self.model1.info.name,
-            config=None)
-
-    @unittest.skip("Skipping unti libjuju issue 333 is resolved")
-    def test_add_model_config(self):
-        controller.add_model(self.model1.info.name,
-                             {'run-faster': 'true'})
-        self.Controller_mock.add_model.assert_called_once_with(
-            self.model1.info.name,
-            config={'run-faster': 'true'})
+    def setUp(self):
+        super().setUp()
+        self.patch_object(controller, 'jubilant')
+        self.juju_mock = mock.MagicMock()
+        self.jubilant.Juju.return_value = self.juju_mock
+        # list_models is called inside destroy_model to poll for removal.
+        self.patch_object(controller, 'list_models')
+        self.list_models.return_value = []
 
     def test_destroy_model(self):
-        controller.destroy_model(self.model1.info.name)
-        self.Controller_mock.destroy_model.assert_called_once_with(
-            self.model1.info.name, destroy_storage=True,
-            force=True, max_wait=600)
+        controller.destroy_model('mymodel')
+        self.juju_mock.destroy_model.assert_called_once_with(
+            'mymodel', destroy_storage=True, force=True, timeout=600)
 
-    def test_get_cloud(self):
-        self.assertEqual(
-            controller.get_cloud(),
-            self.cloud)
-        self.Controller_mock.get_cloud.assert_called_once()
+    def test_destroy_model_raises_on_timeout(self):
+        # Simulate the model never disappearing.
+        self.list_models.return_value = ['mymodel']
+        self.patch_object(controller, 'time')
+        self.time.sleep = mock.MagicMock()
+        with self.assertRaises(
+                zaza.utilities.exceptions.DestroyModelFailed):
+            controller.destroy_model('mymodel')
+
+
+class TestListModels(ut_utils.BaseTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.patch_object(controller, 'jubilant')
+        self.juju_mock = mock.MagicMock()
+        self.jubilant.Juju.return_value = self.juju_mock
 
     def test_list_models(self):
-        self.assertEqual(
-            controller.list_models(),
-            self.models)
-        self.Controller_mock.list_models.assert_called_once()
+        self.juju_mock.cli.return_value = json.dumps(
+            {'models': [{'name': 'admin/model1'}, {'name': 'admin/model2'}]})
+        result = controller.list_models()
+        self.assertEqual(result, ['model1', 'model2'])
+        self.juju_mock.cli.assert_called_once_with(
+            'models', '--format', 'json', include_model=False)
+
+
+class TestGetCloud(ut_utils.BaseTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.patch_object(controller, 'jubilant')
+        self.juju_mock = mock.MagicMock()
+        self.jubilant.Juju.return_value = self.juju_mock
+
+    def test_get_cloud(self):
+        self.juju_mock.cli.return_value = json.dumps(
+            {'myctrl': {'details': {'cloud': 'lxd'}}})
+        result = controller.get_cloud()
+        self.assertEqual(result, 'lxd')
+        self.juju_mock.cli.assert_called_once_with(
+            'show-controller', '--format', 'json', include_model=False)
+
+
+class TestGoListModels(ut_utils.BaseTestCase):
 
     def test_go_list_models(self):
         self.patch_object(controller, 'subprocess')
         controller.go_list_models()
-        self.subprocess.check_call.assert_called_once_with([
-            "juju", "models"])
+        self.subprocess.check_call.assert_called_once_with(["juju", "models"])
+
+
+# Make zaza.utilities.exceptions available after the import of controller.
+import zaza.utilities.exceptions  # noqa: E402

--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -1216,30 +1216,59 @@ class TestModel(ut_utils.BaseTestCase):
                 raise_on_failure=True,
                 action_params={'backup_dir': '/dev/null'})
 
+    def _make_jubilant_status(self, workload_status, workload_status_message,
+                              agent_status='idle', units=None):
+        """Build a mock jubilant Status object for use in wait tests.
+
+        :param workload_status: workload status string (e.g. 'active')
+        :param workload_status_message: workload status message string
+        :param agent_status: juju agent status (default 'idle')
+        :param units: dict of unit_name -> (wl_status, wl_msg, agent_status)
+                      overrides; if None, two units app/2 and app/4 are
+                      created with the supplied defaults.
+        :returns: mock Status object compatible with _JubilantModelAdapter
+        """
+        def _make_unit_status(wl_st, wl_msg, ag_st):
+            us = mock.MagicMock()
+            us.workload_status.current = wl_st
+            us.workload_status.message = wl_msg
+            us.juju_status.current = ag_st
+            return us
+
+        if units is None:
+            units = {
+                'app/2': _make_unit_status(
+                    workload_status, workload_status_message, agent_status),
+                'app/4': _make_unit_status(
+                    workload_status, workload_status_message, agent_status),
+            }
+
+        app_status = mock.MagicMock()
+        app_status.units = units
+
+        status = mock.MagicMock()
+        status.apps = {'app': app_status}
+        return status
+
     def _application_states_setup(self, setup, units_idle=True):
         self.system_ready = True
-        self._block_until_calls = 0
 
-        async def _block_until(f, timeout=0, model=None):
-            # Mimic timeouts
-            timeout = timeout + self._block_until_calls
-            self._block_until_calls += 1
-            if timeout == -1:
-                raise concurrent.futures._base.TimeoutError("Timeout", 1)
-            result = f()
-            if not result:
-                self.system_ready = False
-            return
+        workload_status = setup['workload-status']
+        workload_status_message = setup.get(
+            'workload-status-message-prefix',
+            setup.get('workload-status-message'))
+        agent_status = 'idle' if units_idle else setup.get(
+            'agent-status', 'executing')
 
-        async def _all_units_idle():
-            return units_idle
-        self.patch_object(model, 'block_until_auto_reconnect_model')
-        self.block_until_auto_reconnect_model.side_effect = _block_until
-        self.patch_object(model, 'Model')
-        self.Model.return_value = self.Model_mock
-        self.Model_mock.all_units_idle.return_value = _all_units_idle
-        p_mock_ws = mock.PropertyMock(
-            return_value=setup['workload-status'])
+        self._jubilant_status = self._make_jubilant_status(
+            workload_status, workload_status_message, agent_status)
+
+        self.patch_object(model, 'get_status_jubilant')
+        self.get_status_jubilant.return_value = self._jubilant_status
+
+        # Keep setting up the libjuju-style unit mocks so that the
+        # helper-function tests (check_unit_workload_status, etc.) still work.
+        p_mock_ws = mock.PropertyMock(return_value=workload_status)
         wsmsg = setup.get('workload-status-message-prefix',
                           setup.get('workload-status-message'))
         p_mock_wsmsg = mock.PropertyMock(return_value=wsmsg)
@@ -1254,9 +1283,7 @@ class TestModel(ut_utils.BaseTestCase):
             return now
 
         self.patch("time.time", name="mock_time", side_effect=mock_time)
-        self.patch("asyncio.sleep",
-                   name="mock_asyncio_sleep",
-                   new=mock.AsyncMock())
+        self.patch("time.sleep", name="mock_time_sleep")
         self.patch_object(model.logging, 'info', name="mock_logging_info")
         self.patch_object(
             model.logging, 'warning', name="mock_logging_warning")
@@ -1428,37 +1455,34 @@ class TestModel(ut_utils.BaseTestCase):
         self._application_states_setup({
             'workload-status': 'active',
             'workload-status-message': 'Unit is ready'})
-        with mock.patch.object(zaza, 'RUN_LIBJUJU_IN_THREAD', new=False):
-            model.wait_for_application_states('modelname', timeout=1)
+        model.wait_for_application_states('modelname', timeout=1)
         self.assertTrue(self.system_ready)
 
     def test_wait_for_application_states_errored_unit(self):
         self._application_states_setup({
             'workload-status': 'error',
             'workload-status-message': 'Unit is ready'})
-        with mock.patch.object(zaza, 'RUN_LIBJUJU_IN_THREAD', new=False):
-            with self.assertRaises(model.UnitError):
-                model.wait_for_application_states('modelname', timeout=1)
-                self.assertFalse(self.system_ready)
+        with self.assertRaises(model.UnitError):
+            model.wait_for_application_states('modelname', timeout=1)
+            self.assertFalse(self.system_ready)
 
     def test_wait_for_application_states_errored_unit_ignore(self):
         self._application_states_setup({
             'workload-status': 'error',
             'workload-status-message': 'Unit is ready'})
-        with mock.patch.object(zaza, 'RUN_LIBJUJU_IN_THREAD', new=False):
-            # Expect a model timeout as the error state is not fatal
-            # but is not the required state.
-            with self.assertRaises(model.ModelTimeout):
-                model.wait_for_application_states(
-                    'modelname',
-                    timeout=1,
-                    ignore_hard_errors=True)
-                self.assertFalse(self.system_ready)
+        # Expect a model timeout as the error state is not fatal
+        # but is not the required state.
+        with self.assertRaises(model.ModelTimeout):
+            model.wait_for_application_states(
+                'modelname',
+                timeout=1,
+                ignore_hard_errors=True)
+            self.assertFalse(self.system_ready)
 
     def test_wait_for_application_states_retries_no_success(self):
         self.patch_object(model, 'check_model_for_hard_errors')
-        self.patch_object(model, 'async_resolve_units')
-        self.patch_object(model, 'async_block_until_unit_wl_status')
+        self.patch_object(model, 'resolve_units')
+        self.patch_object(model, 'block_until_unit_wl_status')
         self.patch_object(model, 'check_unit_workload_status')
 
         def unit_wl_status(_model, unit, states):
@@ -1472,19 +1496,21 @@ class TestModel(ut_utils.BaseTestCase):
         self._application_states_setup({
             'workload-status': 'error',
             'workload-status-message': 'hook failed: "install"'})
-        type(self.unit2).workload_status = 'active'
-        type(self.unit2).workload_status_message = 'Unit is ready'
-        with mock.patch.object(zaza, 'RUN_LIBJUJU_IN_THREAD', new=False):
-            with self.assertRaises(model.UnitError):
-                model.wait_for_application_states('modelname', timeout=1,
-                                                  max_resolve_count=3)
-                self.assertFalse(self.system_ready)
-            self.assertEqual(self.async_resolve_units.call_count, 3)
+        # Override unit app/4 to be active/ready so only app/2 is problematic
+        self._jubilant_status.apps['app'].units['app/4'].workload_status\
+            .current = 'active'
+        self._jubilant_status.apps['app'].units['app/4'].workload_status\
+            .message = 'Unit is ready'
+        with self.assertRaises(model.UnitError):
+            model.wait_for_application_states('modelname', timeout=1,
+                                              max_resolve_count=3)
+            self.assertFalse(self.system_ready)
+        self.assertEqual(self.resolve_units.call_count, 3)
 
     def test_wait_for_application_states_retries_non_retryable(self):
         self.patch_object(model, 'check_model_for_hard_errors')
-        self.patch_object(model, 'async_resolve_units')
-        self.patch_object(model, 'async_block_until_unit_wl_status')
+        self.patch_object(model, 'resolve_units')
+        self.patch_object(model, 'block_until_unit_wl_status')
         self.patch_object(model, 'check_unit_workload_status')
 
         def unit_wl_status(_model, unit, states):
@@ -1498,20 +1524,22 @@ class TestModel(ut_utils.BaseTestCase):
         self._application_states_setup({
             'workload-status': 'error',
             'workload-status-message': 'hook failed: "config-changed"'})
-        type(self.unit2).workload_status = 'active'
-        type(self.unit2).workload_status_message = 'Unit is ready'
-        with mock.patch.object(zaza, 'RUN_LIBJUJU_IN_THREAD', new=False):
-            with self.assertRaises(model.UnitError):
-                model.wait_for_application_states('modelname', timeout=1,
-                                                  max_resolve_count=3)
-                self.assertFalse(self.system_ready)
-        self.async_resolve_units.assert_not_called()
-        self.async_block_until_unit_wl_status.assert_not_called()
+        # Override unit app/4 to be active/ready so only app/2 is problematic
+        self._jubilant_status.apps['app'].units['app/4'].workload_status\
+            .current = 'active'
+        self._jubilant_status.apps['app'].units['app/4'].workload_status\
+            .message = 'Unit is ready'
+        with self.assertRaises(model.UnitError):
+            model.wait_for_application_states('modelname', timeout=1,
+                                              max_resolve_count=3)
+            self.assertFalse(self.system_ready)
+        self.resolve_units.assert_not_called()
+        self.block_until_unit_wl_status.assert_not_called()
 
     def test_wait_for_application_states_retries_with_success(self):
         self.patch_object(model, 'check_model_for_hard_errors')
-        self.patch_object(model, 'async_block_until_unit_wl_status')
-        self.patch_object(model, 'async_resolve_units')
+        self.patch_object(model, 'block_until_unit_wl_status')
+        self.patch_object(model, 'resolve_units')
         self.patch_object(model, 'check_unit_workload_status')
         count = 0
 
@@ -1523,23 +1551,26 @@ class TestModel(ut_utils.BaseTestCase):
                 count += 1
                 if count < 3:
                     raise model.UnitError([unit])
-                # Mutate the state for the desired behavior :-/
-                type(unit).workload_status = 'active'
-                type(unit).workload_status_message = 'Unit is ready'
+                # Mutate the mock status so subsequent calls see active
+                self._jubilant_status.apps['app'].units[
+                    'app/2'].workload_status.current = 'active'
+                self._jubilant_status.apps['app'].units[
+                    'app/2'].workload_status.message = 'Unit is ready'
             return True
 
         self.check_unit_workload_status.side_effect = unit_wl_status
         self._application_states_setup({
             'workload-status': 'error',
             'workload-status-message': 'hook failed: "install"'})
-        type(self.unit2).workload_status = 'active'
-        type(self.unit2).workload_status_message = 'Unit is ready'
+        self._jubilant_status.apps['app'].units['app/4'].workload_status\
+            .current = 'active'
+        self._jubilant_status.apps['app'].units['app/4'].workload_status\
+            .message = 'Unit is ready'
 
-        with mock.patch.object(zaza, 'RUN_LIBJUJU_IN_THREAD', new=False):
-            model.wait_for_application_states('modelname', timeout=500,
-                                              max_resolve_count=3)
-        self.assertEqual(self.async_resolve_units.call_count, 2)
-        self.async_block_until_unit_wl_status.assert_has_calls([
+        model.wait_for_application_states('modelname', timeout=500,
+                                          max_resolve_count=3)
+        self.assertEqual(self.resolve_units.call_count, 2)
+        self.block_until_unit_wl_status.assert_has_calls([
             mock.call('app/2', 'error', 'modelname', negate_match=True,
                       timeout=60),
             mock.call('app/2', 'error', 'modelname', negate_match=True,
@@ -1550,37 +1581,34 @@ class TestModel(ut_utils.BaseTestCase):
         self._application_states_setup({
             'workload-status': 'blocked',
             'workload-status-message': 'Unit is ready'})
-        with mock.patch.object(zaza, 'RUN_LIBJUJU_IN_THREAD', new=False):
-            model.wait_for_application_states(
-                'modelname',
-                states={'app': {
-                    'workload-status': 'blocked'}},
-                timeout=1)
+        model.wait_for_application_states(
+            'modelname',
+            states={'app': {
+                'workload-status': 'blocked'}},
+            timeout=1)
         self.assertTrue(self.system_ready)
 
     def test_wait_for_application_states_bespoke_msg(self):
         self._application_states_setup({
             'workload-status': 'active',
             'workload-status-message': 'Sure, I could do something'})
-        with mock.patch.object(zaza, 'RUN_LIBJUJU_IN_THREAD', new=False):
-            model.wait_for_application_states(
-                'modelname',
-                states={'app': {
-                    'workload-status-message': 'Sure, I could do something'}},
-                timeout=1)
+        model.wait_for_application_states(
+            'modelname',
+            states={'app': {
+                'workload-status-message': 'Sure, I could do something'}},
+            timeout=1)
         self.assertTrue(self.system_ready)
 
     def test_wait_for_application_states_bespoke_msg_blocked_ok(self):
         self._application_states_setup({
             'workload-status': 'blocked',
             'workload-status-message': 'Sure, I could do something'})
-        with mock.patch.object(zaza, 'RUN_LIBJUJU_IN_THREAD', new=False):
-            model.wait_for_application_states(
-                'modelname',
-                states={'app': {
-                    'workload-status': 'blocked',
-                    'workload-status-message': 'Sure, I could do something'}},
-                timeout=1)
+        model.wait_for_application_states(
+            'modelname',
+            states={'app': {
+                'workload-status': 'blocked',
+                'workload-status-message': 'Sure, I could do something'}},
+            timeout=1)
         self.assertTrue(self.system_ready)
 
     def test_wait_for_application_states_idle_timeout(self):
@@ -1588,9 +1616,8 @@ class TestModel(ut_utils.BaseTestCase):
             'agent-status': 'executing',
             'workload-status': 'blocked',
             'workload-status-message': 'Sure, I could do something'})
-        with mock.patch.object(zaza, 'RUN_LIBJUJU_IN_THREAD', new=False):
-            with self.assertRaises(model.ModelTimeout) as timeout:
-                model.wait_for_application_states('modelname', timeout=-2)
+        with self.assertRaises(model.ModelTimeout) as timeout:
+            model.wait_for_application_states('modelname', timeout=-2)
         self.assertEqual(
             timeout.exception.args[0],
             "Work state not achieved within timeout.")
@@ -1600,10 +1627,9 @@ class TestModel(ut_utils.BaseTestCase):
             'agent-status': 'executing',
             'workload-status': 'blocked',
             'workload-status-message': 'Sure, I could do something'})
-        with mock.patch.object(zaza, 'RUN_LIBJUJU_IN_THREAD', new=False):
-            with mock.patch.object(model, 'APPS_LEFT_INTERVAL', -1):
-                with self.assertRaises(model.ModelTimeout) as timeout:
-                    model.wait_for_application_states('modelname', timeout=-3)
+        with mock.patch.object(model, 'APPS_LEFT_INTERVAL', -1):
+            with self.assertRaises(model.ModelTimeout) as timeout:
+                model.wait_for_application_states('modelname', timeout=-3)
         self.assertEqual(
             timeout.exception.args[0],
             "Work state not achieved within timeout.")
@@ -1619,45 +1645,42 @@ class TestModel(ut_utils.BaseTestCase):
             'workload-status': 'active',
             'workload-status-message': 'Unit is ready'})
         # override to zero units
-        self.mymodel.applications['app'].units = []
-        with mock.patch.object(zaza, 'RUN_LIBJUJU_IN_THREAD', new=False):
-            model.wait_for_application_states(
-                'modelname',
-                states={
-                    'app': {
-                        'num-expected-units': 0,
-                    }
-                },
-                timeout=-1)
+        self._jubilant_status.apps['app'].units = {}
+        model.wait_for_application_states(
+            'modelname',
+            states={
+                'app': {
+                    'num-expected-units': 0,
+                }
+            },
+            timeout=-1)
 
     def test_wait_for_application_states_zero_units_expect_one(self):
         self._application_states_setup({
             'workload-status': 'active',
             'workload-status-message': 'Unit is ready'})
         # override to zero units
-        self.mymodel.applications['app'].units = []
-        with mock.patch.object(zaza, 'RUN_LIBJUJU_IN_THREAD', new=False):
-            with self.assertRaises(model.ModelTimeout):
-                model.wait_for_application_states(
-                    'modelname',
-                    states={
-                        'app': {
-                            'num-expected-units': 1,
-                        }
-                    },
-                    timeout=-1)
+        self._jubilant_status.apps['app'].units = {}
+        with self.assertRaises(model.ModelTimeout):
+            model.wait_for_application_states(
+                'modelname',
+                states={
+                    'app': {
+                        'num-expected-units': 1,
+                    }
+                },
+                timeout=-1)
 
     def test_wait_for_application_states_zero_units_none_set(self):
         self._application_states_setup({
             'workload-status': 'active',
             'workload-status-message': 'Unit is ready'})
         # override to zero units
-        self.mymodel.applications['app'].units = []
-        with mock.patch.object(zaza, 'RUN_LIBJUJU_IN_THREAD', new=False):
-            with self.assertRaises(model.ModelTimeout):
-                model.wait_for_application_states(
-                    'modelname',
-                    timeout=1)
+        self._jubilant_status.apps['app'].units = {}
+        with self.assertRaises(model.ModelTimeout):
+            model.wait_for_application_states(
+                'modelname',
+                timeout=1)
 
     def test_get_current_model(self):
         self.patch_object(model, 'Model')

--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -30,7 +30,6 @@ except ImportError:
 
 import copy
 import collections
-import concurrent
 import datetime
 import mock
 import pytest

--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -381,21 +381,21 @@ class TestModel(ut_utils.BaseTestCase):
 
     def test_deployed_no_model_name(self):
         self.patch_object(model, 'Model')
+        self.Model_mock.status.return_value.apps = {'app': mock.MagicMock()}
         self.Model.return_value = self.Model_mock
 
         self.assertEqual(model.sync_deployed(), ['app'])
-        self.Model_mock.connect_current.assert_called_once_with()
-        self.Model_mock.connect_model.assert_not_called()
-        self.Model_mock.disconnect.assert_called_once_with()
+        self.Model.assert_called_once_with(None)
+        self.Model_mock.status.assert_called_once_with()
 
     def test_deployed_with_model_name(self):
         self.patch_object(model, 'Model')
+        self.Model_mock.status.return_value.apps = {'app': mock.MagicMock()}
         self.Model.return_value = self.Model_mock
 
         self.assertEqual(model.sync_deployed('a-model'), ['app'])
-        self.Model_mock.connect_current.assert_not_called()
-        self.Model_mock.connect_model.assert_called_once_with('a-model')
-        self.Model_mock.disconnect.assert_called_once_with()
+        self.Model.assert_called_once_with('a-model')
+        self.Model_mock.status.assert_called_once_with()
 
     def test_set_juju_model_aliases(self):
         model.set_juju_model_aliases({'alias1': 'model1', 'alias2': 'model2'})
@@ -572,8 +572,8 @@ class TestModel(ut_utils.BaseTestCase):
 
     def test_get_model_info(self):
         model_info = mock.Mock()
-        self.Model_mock.info = model_info
         self.patch_object(model, 'Model')
+        self.Model_mock.show_model.return_value = model_info
         self.Model.return_value = self.Model_mock
         self.assertEqual(model.get_model_info(), model_info)
 
@@ -584,18 +584,23 @@ class TestModel(ut_utils.BaseTestCase):
         self.get_unit_from_name.return_value = self.unit1
         self.Model.return_value = self.Model_mock
         model.scp_to_unit('app/2', '/tmp/src', '/tmp/dest')
-        self.unit1.scp_to.assert_called_once_with(
-            '/tmp/src', '/tmp/dest', proxy=False, scp_opts='', user='ubuntu')
+        self.Model_mock.scp.assert_called_once_with(
+            '/tmp/src', 'app/2:/tmp/dest', scp_options=[])
 
     def test_scp_to_all_units(self):
         self.patch_object(model, 'get_juju_model', return_value='mname')
         self.patch_object(model, 'Model')
+        self.patch_object(model, 'scp_to_unit')
         self.Model.return_value = self.Model_mock
+        self.Model_mock.applications = {
+            'app': mock.MagicMock(units={'app/2': self.unit1,
+                                         'app/4': self.unit2})
+        }
         model.scp_to_all_units('app', '/tmp/src', '/tmp/dest')
-        self.unit1.scp_to.assert_called_once_with(
-            '/tmp/src', '/tmp/dest', proxy=False, scp_opts='', user='ubuntu')
-        self.unit2.scp_to.assert_called_once_with(
-            '/tmp/src', '/tmp/dest', proxy=False, scp_opts='', user='ubuntu')
+        self.scp_to_unit.assert_any_call(
+            'app/2', '/tmp/src', '/tmp/dest', model_name=None, scp_opts='')
+        self.scp_to_unit.assert_any_call(
+            'app/4', '/tmp/src', '/tmp/dest', model_name=None, scp_opts='')
 
     def test_scp_from_unit(self):
         self.patch_object(model, 'get_juju_model', return_value='mname')
@@ -604,8 +609,8 @@ class TestModel(ut_utils.BaseTestCase):
         self.get_unit_from_name.return_value = self.unit1
         self.Model.return_value = self.Model_mock
         model.scp_from_unit('app/2', '/tmp/src', '/tmp/dest')
-        self.unit1.scp_from.assert_called_once_with(
-            '/tmp/src', '/tmp/dest', proxy=False, scp_opts='', user='ubuntu')
+        self.Model_mock.scp.assert_called_once_with(
+            'app/2:/tmp/src', '/tmp/dest', scp_options='')
 
     def test_get_units(self):
         self.patch_object(model, 'get_juju_model', return_value='mname')
@@ -2864,10 +2869,12 @@ class AsyncModelTests(aiounittest.AsyncTestCase):
 
     async def test_update_unknown_action_status_invalid_params(self):
         """Test update unknown action status invalid params."""
-        self.assertRaises(ValueError, model.update_unknown_action_status,
-                          None, mock.MagicMock())
-        self.assertRaises(ValueError, model.update_unknown_action_status,
-                          mock.MagicMock(), None)
+        with self.assertRaises(ValueError):
+            await model.async_update_unknown_action_status(
+                None, mock.MagicMock())
+        with self.assertRaises(ValueError):
+            await model.async_update_unknown_action_status(
+                mock.MagicMock(), None)
 
     async def test_update_unknown_action_status_not_unknown(self):
         """Test update unknown action status with status not unknown."""
@@ -3023,7 +3030,8 @@ class AsyncModelTests(aiounittest.AsyncTestCase):
     async def test_async_get_cloud_data(self):
         with mock.patch.object(
                 model.juju.client.jujudata, 'FileJujuData') as juju_data:
-            with mock.patch.object(model, 'get_model'):
+            with mock.patch.object(model, 'get_model',
+                                   return_value=mock.AsyncMock()):
                 juju_data().load_credential.return_value = (
                     'fake-cred-name', 'fake-cred')
                 result = await model.async_get_cloud_data()

--- a/unit_tests/utilities/test_deployment_env.py
+++ b/unit_tests/utilities/test_deployment_env.py
@@ -204,9 +204,17 @@ class TestUtilitiesDeploymentEnv(ut_utils.BaseTestCase):
             self.assertEqual(deployment_env.get_model_constraints(), expect)
 
     def test_get_model_constraints_no_config(self):
+        self.patch_object(
+            deployment_env,
+            'get_setup_file_section',
+            return_value={})
         self.base_get_model_constraints({}, self.MODEL_DEFAULT_CONSTRAINTS)
 
     def test_get_model_constraints_multiple_values_override(self):
+        self.patch_object(
+            deployment_env,
+            'get_setup_file_section',
+            return_value={})
         expect_config = copy.deepcopy(self.MODEL_DEFAULT_CONSTRAINTS)
         expect_config.update({'mem': 'from-env'})
         self.base_get_model_constraints(

--- a/zaza/__init__.py
+++ b/zaza/__init__.py
@@ -28,241 +28,126 @@
 #
 # __NOTE__
 
-"""Functions to support converting async function to a sync equivalent."""
-import asyncio
-import concurrent.futures
+"""Compatibility shims for the jubilant-based (sync) rewrite of zaza.
+
+The async machinery (libjuju background thread, event loop management) has
+been removed now that zaza uses jubilant, which is fully synchronous.
+
+``sync_wrapper`` is kept as a transparent pass-through so that downstream
+consumers (e.g. zaza-openstack-tests) that call::
+
+    foo = sync_wrapper(async_foo)
+
+continue to work without modification.  The wrapped function is called
+directly; no async scheduling takes place.
+"""
 import inspect
 import logging
-import time
-import threading
 from pkgutil import extend_path
-from sys import version_info
 
 
 __path__ = extend_path(__path__, __name__)
 
-# This flag is for testing, but can be used to control whether libjuju runs in
-# a background thread or is simplified.
-RUN_LIBJUJU_IN_THREAD = True
+# ---------------------------------------------------------------------------
+# Legacy compatibility flags – kept so that existing code that reads or
+# patches these names does not break with an AttributeError.
+# ---------------------------------------------------------------------------
 
-# Hold the libjuju thread so we can interact with it.
-_libjuju_thread = None
-_libjuju_loop = None
-_libjuju_run = False
-
-# Timeout for loop to close.  This is set to 30 seconds.  If there is a non
-# async call in the async thread then it could stall the thread for more than
-# 30 seconds (e.g. an errant subprocess call).  This will cause a runtime error
-# if the timeout is exceeded.  This shouldn't normally be the case as there is
-# only one 'start' and 'stop' of the thread during a zaza runtime
-LOOP_CLOSE_TIMEOUT = 30.0
-
-
-def get_or_create_libjuju_thread():
-    """Get (or Create) the thread that libjuju asyncio is running in.
-
-    :returns: the thread that libjuju is running in.
-    :rtype: threading.Thread
-    """
-    global _libjuju_thread, _libjuju_run
-    if _libjuju_thread is None:
-        _libjuju_run = True
-        _libjuju_thread = threading.Thread(target=libjuju_thread_run)
-        _libjuju_thread.start()
-        # There's a race hazard for _libjuju_loop becoming available, so let's
-        # wait for that to happen.
-        now = time.time()
-        while True:
-            if (_libjuju_loop is not None and _libjuju_loop.is_running()):
-                break
-            time.sleep(.01)
-            # allow 5 seconds for thead to start
-            if time.time() > now + 5.0:
-                raise RuntimeError("Async thread didn't start!")
-        # enable async subprocess calls in the libjuju thread to work
-        asyncio.get_child_watcher().attach_loop(_libjuju_loop)
-    return _libjuju_thread
-
-
-def libjuju_thread_run():
-    """Run the libjuju async thread.
-
-    The thread that contains the runtime for libjuju asyncio futures.
-
-    zaza runs libjuju in a background thread so that it can make progress as
-    needed with the model(s) that are connected.  The sync functions run in the
-    foreground thread, and the asyncio libjuju functions run in the background
-    thread. `run_coroutine_threadsafe` is used to cross from sync to asyncio
-    code in the background thread to enable access to the libjuju.
-
-    Note: it's very important that libjuju objects are not updated in the sync
-    thread; it's advisable that they are copied into neutral objects and handed
-    back.  e.g. always use unit_name, rather than handling a libjuju 'unit'
-    object in a sync function.
-    """
-    global _libjuju_loop
-
-    async def looper():
-        while _libjuju_run:
-            # short spinner to ensure that foreground tasks 'happen' so that
-            # background tasks can complete (e.g. during model disconnection).
-            # loop.run_forever() doesn't work as there is no foreground async
-            # task to make progress, and thus the background tasks do nothing.
-            await asyncio.sleep(0.1)
-
-    _libjuju_loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(_libjuju_loop)
-    try:
-        _libjuju_loop.run_until_complete(_libjuju_loop.create_task(looper()))
-    finally:
-        while True:
-            # issue #445 - asyncio.Task.all_tasks() deprecated in 3.7
-            if version_info.major == 3 and version_info.minor >= 7:
-                try:
-                    tasklist = asyncio.all_tasks()
-                except RuntimeError:
-                    # no running event loop
-                    break
-            else:
-                tasklist = asyncio.Task.all_tasks()
-            pending_tasks = [p for p in tasklist if not p.done()]
-            if pending_tasks:
-                logging.info(
-                    "async -> sync. cleaning up pending tasks: len: {}"
-                    .format(len(pending_tasks)))
-                for pending_task in pending_tasks:
-                    pending_task.cancel()
-                    try:
-                        _libjuju_loop.run_until_complete(pending_task)
-                    except asyncio.CancelledError:
-                        pass
-                    except Exception as e:
-                        logging.error(
-                            "A pending task caused an exception: {}"
-                            .format(str(e)))
-            else:
-                break
-    _libjuju_loop.close()
-
-
-def join_libjuju_thread():
-    """Stop and cleanup the asyncio tasks on the loop, and then join it."""
-    global _libjuju_thread, _libjuju_run
-    if _libjuju_thread is not None:
-        logging.debug("stopping the event loop")
-        # remove the child watcher (that was for subprocess calls) when
-        # dropping the thread.
-        asyncio.get_child_watcher().attach_loop(None)
-        _libjuju_run = False
-        # wait up to 30 seconds for loop to close.
-        now = time.time()
-        while not _libjuju_loop.is_closed():
-            logging.debug("Closing ...")
-            time.sleep(.1)
-            if time.time() > now + LOOP_CLOSE_TIMEOUT:
-                raise RuntimeError(
-                    "Exceeded {} seconds for loop to close"
-                    .format(LOOP_CLOSE_TIMEOUT))
-        logging.debug("joining the loop")
-        _libjuju_thread.join(timeout=30.0)
-        if _libjuju_thread.is_alive():
-            logging.error("The thread didn't die")
-            raise RuntimeError(
-                "libjuju async thread didn't finish after 30seconds")
-        _libjuju_thread = None
-
-
-def clean_up_libjuju_thread():
-    """Clean up the libjuju thread and any models that are still running."""
-    global _libjuju_loop, _libjuju_run
-    if _libjuju_loop is not None:
-        # circular import; tricky to remove
-        from . import model
-        sync_wrapper(model.remove_models_memo)()
-        join_libjuju_thread()
-        _libjuju_run = False
-        _libjuju_loop = None
+#: No longer meaningful; retained for backwards compatibility only.
+RUN_LIBJUJU_IN_THREAD = False
 
 
 def sync_wrapper(f, timeout=None):
-    """Convert the async function into one that runs in the async thread.
+    """Return a synchronous callable that calls *f* directly.
 
-    This is only to be called from sync code.  It wraps the given async
-    co-routine in some sync logic that allows it to be injected into the async
-    libjuju thread.  This is then waited until there is a result, in which case
-    the result is returned.
+    Previously this scheduled an async coroutine on a background event loop.
+    Now that zaza uses jubilant (a fully synchronous library) this shim simply
+    calls the wrapped function in the current thread.
 
-    :param f: The async function that when called is a co-routine
-        e.g. `async def some_function(...)` then `some_function` should be
-        passed as `f`.
-    :type f: function
-    :param timeout: The timeout to apply, None for no timeout
+    The *timeout* parameter is accepted for API compatibility but is ignored.
+
+    :param f: The function to wrap.  May be a plain function or a coroutine
+        function (``async def``); both are handled transparently.
+    :type f: callable
+    :param timeout: Ignored; kept for API compatibility.
     :type timeout: Optional[float]
-    :returns: The de-async'd function
-    :rtype: function
+    :returns: A synchronous wrapper around *f*.
+    :rtype: callable
     """
     def _wrapper(*args, **kwargs):
-
-        async def _runner():
-            return await f(*args, **kwargs)
-
-        if not RUN_LIBJUJU_IN_THREAD:
-            # run it in this thread's event loop:
-            loop = asyncio.get_event_loop()
-            # create a new loop if the existing one is closed
-            if loop.is_closed():
-                loop = asyncio.new_event_loop()
-                asyncio.set_event_loop(loop)
-            return loop.run_until_complete(_runner())
-
-        # ensure that the thread is created
-        get_or_create_libjuju_thread()
-        assert _libjuju_loop is not None and _libjuju_loop.is_running(), \
-            "Background thread must be running by now, so this is a bug"
-
-        # Submit the coroutine to a given loop
-        future = asyncio.run_coroutine_threadsafe(_runner(), _libjuju_loop)
-        try:
-            return future.result(timeout)
-        except concurrent.futures.TimeoutError:
-            logging.error(
-                'The coroutine took too long, cancelling the task...')
-            future.cancel()
-            raise
+        result = f(*args, **kwargs)
+        # If f is still an async coroutine function (e.g. not yet migrated),
+        # run it synchronously so callers are not broken.
+        if inspect.iscoroutine(result):
+            import asyncio
+            loop = asyncio.new_event_loop()
+            try:
+                return loop.run_until_complete(result)
+            finally:
+                loop.close()
+        return result
 
     return _wrapper
 
 
 def run(*steps):
-    """Run the given steps in an asyncio loop.
+    """Run the given steps sequentially and return the result of the last one.
 
-    Note: previous versions of this function would ensure that any other
-    futures spawned by any of the steps are cleaned up after each step is
-    performed.  However, as the async thread runs continuously in a background
-    thread (unless RUN_LIBJUJU_IN_THREAD is not True), then these other tasks
-    are not cleaned up until the whole thread ends.
+    Previously this drove an asyncio event loop.  Now steps are executed
+    directly in the calling thread.  Async coroutines and coroutine functions
+    are still accepted for backwards compatibility and are run synchronously
+    via a temporary event loop.
 
-    :param steps: List of async functions, coroutines or literals
-    :type steps: List[function]
-    :returns: The result of the last async function called
+    :param steps: Functions, coroutines, or plain values to execute in order.
+    :type steps: List
+    :returns: The result of the last step.
     :rtype: Any
     """
     if not steps:
         return None
 
-    async def maybe_call(f):
+    import asyncio
+
+    def _call(f):
         if inspect.iscoroutine(f):
-            return await f
+            loop = asyncio.new_event_loop()
+            try:
+                return loop.run_until_complete(f)
+            finally:
+                loop.close()
         elif inspect.iscoroutinefunction(f):
-            return await f()
+            loop = asyncio.new_event_loop()
+            try:
+                return loop.run_until_complete(f())
+            finally:
+                loop.close()
         elif inspect.isfunction(f):
             return f()
         else:
             return f
 
-    async def _runner():
-        for step in steps[:-1]:
-            await maybe_call(step)
-        return await maybe_call(steps[-1])
+    result = None
+    for step in steps:
+        result = _call(step)
+    return result
 
-    return sync_wrapper(_runner)()
+
+# ---------------------------------------------------------------------------
+# Stubs for the old async-thread lifecycle functions.
+# These are no-ops; they exist only so that code that calls them (e.g. test
+# tearDownModule hooks) does not raise AttributeError.
+# ---------------------------------------------------------------------------
+
+def get_or_create_libjuju_thread():
+    """No-op stub retained for API compatibility."""
+    logging.debug("get_or_create_libjuju_thread: no-op (jubilant migration)")
+
+
+def join_libjuju_thread():
+    """No-op stub retained for API compatibility."""
+    logging.debug("join_libjuju_thread: no-op (jubilant migration)")
+
+
+def clean_up_libjuju_thread():
+    """No-op stub retained for API compatibility."""
+    logging.debug("clean_up_libjuju_thread: no-op (jubilant migration)")

--- a/zaza/controller.py
+++ b/zaza/controller.py
@@ -14,152 +14,140 @@
 
 """Module for interacting with a juju controller."""
 
-import asyncio
+import json
 import logging
 import subprocess
+import time
 
-from juju.controller import Controller
+import jubilant
 
-from zaza import sync_wrapper
 import zaza.utilities.exceptions
 
 
-async def async_add_model(
-    model_name, config=None, cloud_name=None, credential_name=None, region=None
-):
+def add_model(model_name, config=None, cloud_name=None,
+              credential_name=None, region=None):
     """Add a model to the current controller.
 
     :param model_name: Name to give the new model.
     :type model_name: str
     :param config: Model configuration.
-    :type config: dict
+    :type config: Optional[dict]
+    :param cloud_name: Name of the cloud (or cloud/region) to use.
+    :type cloud_name: Optional[str]
+    :param credential_name: Name of the credential to use.
+    :type credential_name: Optional[str]
     :param region: Region in which to create the model.
-    :type region: str
+    :type region: Optional[str]
     """
-    controller = Controller()
-    await controller.connect()
+    cloud = cloud_name
+    if cloud is not None and region is not None:
+        cloud = '{}/{}'.format(cloud_name, region)
+    elif region is not None:
+        cloud = region
+
+    juju = jubilant.Juju()
     logging.debug("Adding model {}".format(model_name))
-    model = await controller.add_model(
+    juju.add_model(
         model_name,
+        cloud,
         config=config,
-        cloud_name=cloud_name,
-        credential_name=credential_name,
-        region=region,
+        credential=credential_name,
     )
-    # issue/135 It is necessary to disconnect the model here or async spews
-    # tracebacks even during a successful run.
-    await model.disconnect()
-    await controller.disconnect()
-
-add_model = sync_wrapper(async_add_model)
 
 
-async def async_destroy_model(model_name):
+def destroy_model(model_name):
     """Remove a model from the current controller.
 
-    :param model_name: Name of model to remove
+    :param model_name: Name of model to remove.
     :type model_name: str
+    :raises: zaza.utilities.exceptions.DestroyModelFailed
     """
-    controller = Controller()
-    try:
-        await controller.connect()
-        logging.info("Destroying model {}".format(model_name))
-        await controller.destroy_model(model_name,
-                                       destroy_storage=True,
-                                       force=True,
-                                       max_wait=600)
-        # The model ought to be destroyed by now.  Let's make sure, and if not,
-        # raise an error.  Even if the model has been destroyed, it's still
-        # hangs around in the .list_models() for a little while; retry until it
-        # goes away, or that fails.
-        attempt = 1
-        while True:
-            logging.info("Waiting for model to be fully destroyed: "
-                         "attempt: {}".format(attempt))
-            remaining_models = await controller.list_models()
-            if model_name not in remaining_models:
-                break
-            await asyncio.sleep(10)
-            attempt += 1
-            if attempt > 20:
-                raise zaza.utilities.exceptions.DestroyModelFailed(
-                    "Destroying model {} failed." .format(model_name))
+    juju = jubilant.Juju()
+    logging.info("Destroying model {}".format(model_name))
+    juju.destroy_model(model_name, destroy_storage=True, force=True,
+                       timeout=600)
 
-        logging.info("Model {} destroyed.".format(model_name))
-    finally:
-        try:
-            await controller.disconnect()
-        except Exception as e:
-            logging.error("Couldn't disconnect from model: {}".format(str(e)))
+    # Wait for the model to disappear from the list.
+    for attempt in range(1, 21):
+        logging.info(
+            "Waiting for model to be fully destroyed: attempt: {}"
+            .format(attempt))
+        remaining = list_models()
+        if model_name not in remaining:
+            break
+        time.sleep(10)
+    else:
+        raise zaza.utilities.exceptions.DestroyModelFailed(
+            "Destroying model {} failed.".format(model_name))
 
-destroy_model = sync_wrapper(async_destroy_model)
+    logging.info("Model {} destroyed.".format(model_name))
 
 
-async def async_cloud(name=None):
-    """Return information about cloud.
+def cloud(name=None):
+    """Return information about a cloud.
 
-    :param name: Cloud name. If not specified, the cloud where
-                 the controller lives on is returned.
+    :param name: Cloud name.  If not specified, the cloud where the
+                 controller lives is returned.
     :type name: Optional[str]
-    :returns: Information on all clouds in the controller.
-    :rtype: CloudResult
+    :returns: Parsed cloud information dict.
+    :rtype: dict
     """
-    controller = Controller()
-    await controller.connect()
-    cloud = await controller.cloud(name=name)
-    await controller.disconnect()
-    return cloud
-
-cloud = sync_wrapper(async_cloud)
+    juju = jubilant.Juju()
+    args = ['clouds', '--format', 'json']
+    if name:
+        args.append(name)
+    stdout = juju.cli(*args, include_model=False)
+    return json.loads(stdout)
 
 
 def get_cloud_type(name=None):
     """Return type of cloud.
 
-    :param name: Cloud name. If not specified, the cloud where
-                 the controller lives on is returned.
+    :param name: Cloud name.  If not specified, the cloud where the
+                 controller lives is returned.
     :type name: Optional[str]
-    :returns: Type of cloud
+    :returns: Type of cloud.
     :rtype: str
     """
-    _cloud = cloud(name=name)
-    return _cloud.cloud.type_
+    clouds = cloud(name=name)
+    # juju clouds --format json returns a dict of cloud_name -> cloud_info
+    for _cloud_info in clouds.values():
+        return _cloud_info.get('type', '')
+    return ''
 
 
-async def async_get_cloud():
+def get_cloud():
     """Return the name of the current cloud.
 
-    :returns: Name of cloud
+    :returns: Name of the cloud the current controller is on.
     :rtype: str
     """
-    controller = Controller()
-    await controller.connect()
-    cloud = await controller.get_cloud()
-    await controller.disconnect()
-    return cloud
+    juju = jubilant.Juju()
+    stdout = juju.cli('show-controller', '--format', 'json',
+                      include_model=False)
+    data = json.loads(stdout)
+    # data is a dict of controller_name -> controller_info
+    for info in data.values():
+        return info.get('details', {}).get('cloud', '')
+    return ''
 
-get_cloud = sync_wrapper(async_get_cloud)
 
-
-async def async_list_models():
+def list_models():
     """Return a list of the available models.
 
-    :returns: List of models
-    :rtype: list
+    :returns: List of model names.
+    :rtype: list[str]
     """
-    controller = Controller()
-    await controller.connect()
-    models = await controller.list_models()
-    await controller.disconnect()
-    return models
-
-list_models = sync_wrapper(async_list_models)
+    juju = jubilant.Juju()
+    stdout = juju.cli('models', '--format', 'json', include_model=False)
+    data = json.loads(stdout)
+    return [m['name'].split('/')[-1] for m in data.get('models', [])]
 
 
 def go_list_models():
-    """Execute juju models.
+    """Execute juju models to refresh the local cache.
 
-    NOTE: Excuting the juju models command updates the local cache of models.
+    NOTE: Executing the juju models command updates the local cache of models.
     Python-juju currently does not update the local cache on add model.
     https://github.com/juju/python-libjuju/issues/267
 

--- a/zaza/model.py
+++ b/zaza/model.py
@@ -34,10 +34,18 @@ from oslo_config import cfg
 import concurrent
 import time
 
-import juju.client
-from juju.errors import JujuError
-from juju.model import Model
+from typing import (
+    Dict,
+    List,
+    Optional,
+)
 
+import jubilant
+from jubilant.statustypes import (
+    AppStatus,
+    ModelInfo,
+    UnitStatus
+) 
 from zaza import sync_wrapper
 import zaza.utilities.generic as generic_utils
 import zaza.utilities.juju as juju_utils
@@ -102,7 +110,7 @@ def unset_juju_model_aliases():
     set_juju_model_aliases({})
 
 
-async def async_get_juju_model():
+def get_juju_model():
     """Retrieve current model.
 
     First check the environment for JUJU_MODEL. If this is not set, get the
@@ -126,41 +134,32 @@ async def async_get_juju_model():
             CURRENT_MODEL = os.environ["MODEL_NAME"]
         except KeyError:
             # If unset connect get the current active model
-            CURRENT_MODEL = await async_get_current_model()
+            juju = jubilant.Juju()
+            CURRENT_MODEL = juju.model
     return CURRENT_MODEL
 
-get_juju_model = sync_wrapper(async_get_juju_model)
 
 
-async def deployed(model_name=None):
+
+def deployed(model_name=None: Optional[str]) -> List[str]:
     """List deployed applications.
 
     :param model_name: Name of the model to list applications from
     :type model_name: string
     """
-    # Create a Model instance. We need to connect our Model to a Juju api
-    # server before we can use it.
-    # NOTE(tinwood): Due to https://github.com/juju/python-libjuju/issues/458
-    # set the max frame size to something big to stop
-    # "RPC: Connection closed, reconnecting" messages and then failures.
-    model = Model(max_frame_size=JUJU_MAX_FRAME_SIZE)
-    if not model_name:
-        # Connect to the currently active Juju model
-        await model.connect_current()
-    else:
-        await model.connect_model(model_name)
+    model = jubilant.Juju(model_name)
+    status = model.status()
+    # list currently deployed services
+    return list(status.apps.keys())
 
-    try:
-        # list currently deployed services
-        return list(model.applications.keys())
-    finally:
-        # Disconnect from the api server and cleanup.
-        await model.disconnect()
-
-sync_deployed = sync_wrapper(deployed)
+sync_deployed = deployed
 
 
-async def async_get_unit_from_name(unit_name, model=None, model_name=None):
+# TODO(freyes): drop model_name in favor of model, since now we operate only on
+# a model name as a string.
+def get_unit_from_name(unit_name: str,
+                       model=None: Optional[str],
+                       model_name=None: Optional[str]) -> UnitStatus:
     """Return the units that corresponds to the name in the given model.
 
     :param unit_name: Name of unit to match
@@ -176,23 +175,19 @@ async def async_get_unit_from_name(unit_name, model=None, model_name=None):
     app = unit_name.split('/')[0]
     unit = None
     try:
-        if model is None:
-            model = await get_model(model_name)
-        units = model.applications[app].units
+        model = get_juju_model()
+        status = model.status()
+        units = status[app].units
     except KeyError:
         msg = ('Application: {} does not exist in current model'.
                format(app))
         logging.error(msg)
         raise UnitNotFound(unit_name)
-    for u in units:
-        if u.entity_id == unit_name:
-            unit = u
-            break
-    else:
-        raise UnitNotFound(unit_name)
-    return unit
 
-get_unit_from_name = sync_wrapper(async_get_unit_from_name)
+    try:
+        return units[unit_name]
+    except KeyError:
+        raise UnitNotFound(unit_name)
 
 
 # A collection of model name -> libjuju models associations; use to either
@@ -200,39 +195,14 @@ get_unit_from_name = sync_wrapper(async_get_unit_from_name)
 ModelRefs = {}
 
 
-async def get_model_memo(model_name):
-    """Get the libjuju Model object for a name.
+class ZazaJujuModel(jubilant.Juju):
 
-    This is memoed as the model is maintained as running in a separate
-    background thread.  Thus, essentially this is a singleton for each of
-    the model names.
-
-    :param model_name: the model name to get a Model for.
-    :type model_name: str
-    :returns: juju.model.Model
-    """
-    model = None
-    if model_name in ModelRefs:
-        model = ModelRefs[model_name]
-        if is_model_disconnected(model):
-            try:
-                await model.disconnect()
-            except Exception:
-                pass
-            model = None
-            del ModelRefs[model_name]
-    if model is None:
-        # NOTE(tinwood): Due to
-        # https://github.com/juju/python-libjuju/issues/458 set the max frame
-        # size to something big to stop "RPC: Connection closed, reconnecting"
-        # messages and then failures.
-        model = Model(max_frame_size=JUJU_MAX_FRAME_SIZE)
-        await model.connect(model_name)
-        ModelRefs[model_name] = model
-    return model
+    @property
+    def applications(self) -> dict[str, AppStatus]:
+        return self.status().apps
 
 
-async def get_model(model_name=None):
+def get_model(model_name=None: Optional[str]):
     """Get (or create) the current model for `model_name`.
 
     If None is passed, or there is no model_name param, then the current model
@@ -243,69 +213,9 @@ async def get_model(model_name=None):
     :returns: juju.model.Model
     """
     if not model_name:
-        model_name = await async_get_juju_model()
-    return await get_model_memo(model_name)
-
-
-async def remove_model_memo(model_name):
-    """Remove/disconnect a model singleton object.
-
-    The Model runs in an async background thread.  This removes it by
-    name and disconnects it if it is running.
-
-    :param model_name: the model name to remove a Model object.
-    :type model_name: str
-    """
-    try:
-        model = ModelRefs[model_name]
-        del ModelRefs[model_name]
-        await model.disconnect()
-    except Exception:
-        pass
-
-
-async def remove_models_memo():
-    """Remove all the models that are memoed."""
-    model_names = list(ModelRefs.keys())
-    for model_name in model_names:
-        await remove_model_memo(model_name)
-
-
-@asynccontextmanager
-@async_generator
-@deprecate()
-async def run_in_model(model_name):
-    """DEPRECATED: Context manager for executing code inside a libjuju model.
-
-       Example of using run_in_model:
-           async with run_in_model(model_name) as model:
-               model.do_something()
-
-    NOTE(ajkavanagh) this function is deprecated.  Don't use a contextmanager
-    and instead just use:
-
-        model = await get_model(model_name)
-
-    Note: that this function re-uses an existing Model connection as zaza (now)
-    tries to keep the model connected for the entire run that it is needed.
-    This is so that libjuju objects connected to the model continue to be
-    updated and that associated methods on those objects continue to function.
-
-    Use zaza.model.connect_model(model_name) and
-    zaza.model.disconnect_mode(model_name) to control the lifetime of
-    connecting to a model.
-
-    :param model_name: Name of model to run function in
-    :type model_name: str
-    :returns: The juju Model object correcsponding to model_name
-    :rtype: Iterator[:class:'juju.Model()']
-    """
-    model = await get_model(model_name)
-    # This doesn't need to be a generator as we now keep models alive until
-    # they are disconnected.  This is purely kept (in this deprecated function)
-    # to maintain the API until run_in_model() is removed.
-    await yield_(model)
-
+        model_name = get_juju_model()
+    return ZazaJujuModel(model=model_name)
+    
 
 def is_model_disconnected(model):
     """Return True if the model is disconnected.
@@ -315,10 +225,11 @@ def is_model_disconnected(model):
     :returns: True if disconnected
     :rtype: bool
     """
-    return not (model.is_connected() and model.connection().is_open)
+    # NOTE(freyes): mocking it until it can be removed.
+    return True
 
 
-async def ensure_model_connected(model):
+def ensure_model_connected(model):
     """Ensure that the model is connected.
 
     If model is disconnected then reconnect it.
@@ -326,30 +237,15 @@ async def ensure_model_connected(model):
     :param model: the model to check
     :type model: :class:'juju.Model'
     """
-    if is_model_disconnected(model):
-        model_name = model.info.name
-        logging.warning(
-            "model: %s has disconnected, forcing full disconnection "
-            "and then reconnecting ...", model_name)
-        try:
-            await model.disconnect()
-        except Exception:
-            # We don't care if disconnect fails; we're much more
-            # interested in re-connecting, and this is just to clean up
-            # anything that might be left over (i.e.
-            # model.is_connected() might be true, but
-            # model.connection().is_open may be false
-            pass
-        logging.warning("Attempting to reconnect model %s", model_name)
-        await model.connect_model(model_name)
+    # NOTE(freyes): mocking it until it can be removed.
+    pass
 
 
-async def block_until_auto_reconnect_model(*conditions,
-                                           model=None,
-                                           aconditions=None,
-                                           timeout=None,
-                                           wait_period=0.5):
-    """Async block on the model until conditions met.
+def block_until_auto_reconnect_model(*conditions,
+                                     model=None,
+                                     timeout=None,
+                                     wait_period=0.5):
+    """Block on the model until conditions met.
 
     This function doesn't use model.block_until() which unfortunately raises
     websockets.exceptions.ConnectionClosed if the connections gets closed,
@@ -381,38 +277,25 @@ async def block_until_auto_reconnect_model(*conditions,
     """
     assert model is not None, ("model can't be None in "
                                "block_until_auto_reconnect_model()")
-    aconditions = aconditions or []
 
     def _done():
         return all(c() for c in conditions)
 
-    async def _adone():
-        evaluated = []
-        # note Python 3.5 doesn't support async comprehensions; do it the old
-        # fashioned way.
-        for c in aconditions:
-            evaluated.append(await c())
-            if is_model_disconnected(model):
-                return False
-        return all(evaluated)
+    start_time = time.time()
+    while True:
+        if _done():
+            return
+        else:
+            time.sleep(wait_period)
 
-    async def _block():
-        while True:
-            # reconnect if disconnected, as the conditions still need to be
-            # checked.
-            await ensure_model_connected(model)
-            result = _done()
-            aresult = await _adone()
-            if all((not is_model_disconnected(model), result, aresult)):
-                return
-            else:
-                await asyncio.sleep(wait_period)
-
-    # finally wait for all the conditions to be true
-    await asyncio.wait_for(_block(), timeout)
+        elapsed_time = time.time() - start_time
+        if timeout and elapsed_time > timeout:
+            raise TimeoutError(
+                f"Timed out after {elapsed_time} seconds (expected max {timeout} seconds)."
+            )
 
 
-async def async_get_model_info(model_name=None):
+def get_model_info(model_name=None) -> ModelInfo:
     """Get information about the model.
 
     Useful keys in the ModelInfo object include:
@@ -424,14 +307,12 @@ async def async_get_model_info(model_name=None):
     :returns: The Model info object
     :rtype: juju.client._definitions.ModelInfo
     """
-    model = await get_model(model_name)
-    return model.info
-
-get_model_info = sync_wrapper(async_get_model_info)
+    model = get_model(model_name)
+    return jubilant.Juju(model).show_model()
 
 
-async def async_scp_to_unit(unit_name, source, destination, model_name=None,
-                            user='ubuntu', proxy=False, scp_opts=''):
+def scp_to_unit(unit_name, source, destination, model_name=None,
+                scp_opts=[]: List[str]):
     """Transfer files to unit_name in model_name.
 
     :param model_name: Name of model unit is in
@@ -442,23 +323,17 @@ async def async_scp_to_unit(unit_name, source, destination, model_name=None,
     :type source: str
     :param destination: Remote destination of transferred files
     :type source: str
-    :param user: Remote username
-    :type source: str
-    :param proxy: Proxy through the Juju API server
-    :type proxy: bool
-    :param scp_opts: Additional options to the scp command
-    :type scp_opts: str
+    :param scp_opts: List of extra options passed to the scp command
     """
-    model = await get_model(model_name)
-    unit = await async_get_unit_from_name(unit_name, model)
-    await unit.scp_to(source, destination, user=user, proxy=proxy,
-                      scp_opts=scp_opts)
+    model = get_model(model_name)
+    juju = jubilant.Juju(model)
+    unit = get_unit_from_name(unit_name, model)
+    assert unit is not None
+    juju.scp(source, f"{unit_name}:{destination}", scp_options=scp_opts)
 
-scp_to_unit = sync_wrapper(async_scp_to_unit)
 
-
-async def async_scp_to_all_units(application_name, source, destination,
-                                 model_name=None, user='ubuntu', proxy=False,
+def scp_to_all_units(application_name, source, destination,
+                     model_name=None, user='ubuntu', proxy=False,
                                  scp_opts=''):
     """Transfer files to all units of an application.
 
@@ -475,19 +350,17 @@ async def async_scp_to_all_units(application_name, source, destination,
     :param proxy: Proxy through the Juju API server
     :type proxy: bool
     :param scp_opts: Additional options to the scp command
-    :type scp_opts: str
+    :scp type_str: opts
     """
-    model = await get_model(model_name)
+    model = get_model(model_name)
     for unit in model.applications[application_name].units:
         # FIXME: Should scp in parallel
-        await unit.scp_to(source, destination, user=user, proxy=proxy,
-                          scp_opts=scp_opts)
-
-scp_to_all_units = sync_wrapper(async_scp_to_all_units)
+        scp_to_unit(unit, source, destination, model_name=model_name,
+                    scp_opts=scp_opts)
 
 
-async def async_scp_from_unit(unit_name, source, destination, model_name=None,
-                              user='ubuntu', proxy=False, scp_opts=''):
+def scp_from_unit(unit_name, source, destination, model_name=None,
+                  user='ubuntu', proxy=False, scp_opts=''):
     """Transfer files from unit_name in model_name.
 
     :param model_name: Name of model unit is in
@@ -505,13 +378,15 @@ async def async_scp_from_unit(unit_name, source, destination, model_name=None,
     :param scp_opts: Additional options to the scp command
     :type scp_opts: str
     """
-    model = await get_model(model_name)
-    unit = await async_get_unit_from_name(unit_name, model)
-    await unit.scp_from(source, destination, user=user, proxy=proxy,
-                        scp_opts=scp_opts)
+    model = get_model(model_name)
+    unit = None
+    for app_name, app in model.applications.items:
+        if unit_name in app.units:
+            unit = app.units[unit_name]
+            break
+    assert unit, f"Unit {unit_name} not found in model."
 
-
-scp_from_unit = sync_wrapper(async_scp_from_unit)
+    model.scp(f"{unit_name}:{source}", destination, scp_options=scp_opts)
 
 
 def _normalise_action_results(results):
@@ -551,8 +426,8 @@ def _normalise_action_results(results):
         return {}
 
 
-async def async_run_on_unit(unit_name, command, model_name=None, timeout=None):
-    """Juju run on unit.
+def exec_on_unit(unit_name, command, model_name=None, timeout=None) -> Dict[str, str]:
+    """Juju exec on unit.
 
     :param model_name: Name of model unit is in
     :type model_name: str
@@ -565,18 +440,20 @@ async def async_run_on_unit(unit_name, command, model_name=None, timeout=None):
     :returns: action.data['results'] {'Code': '', 'Stderr': '', 'Stdout': ''}
     :rtype: dict
     """
-    model = await get_model(model_name)
-    unit = await async_get_unit_from_name(unit_name, model)
-    action = await generic_utils.unit_run(unit, command, timeout)
-    action = _normalise_action_object(action)
-    results = action.data.get('results')
-    return _normalise_action_results(results)
+    model = get_model(model_name)
+    unit = get_unit_from_name(unit_name, model_name=model_name)
 
-run_on_unit = sync_wrapper(async_run_on_unit)
+    task = model.exec(command, unit=unit_name, wait=timeout)
+
+    return {"Code": task.return_code,
+            "Stdout": task.stdout,
+            "Stderr": task.stderr,
+            "stdout": task.stdout,
+            "stderr": task.stderr}
 
 
-async def async_run_on_leader(application_name, command, model_name=None,
-                              timeout=None):
+def exec_on_leader(application_name, command, model_name=None,
+                   timeout=None):
     """Juju run on leader unit.
 
     :param application_name: Application to match
@@ -590,19 +467,13 @@ async def async_run_on_leader(application_name, command, model_name=None,
     :returns: action.data['results'] {'Code': '', 'Stderr': '', 'Stdout': ''}
     :rtype: dict
     """
-    model = await get_model(model_name)
-    for unit in model.applications[application_name].units:
-        is_leader = await unit.is_leader_from_status()
-        if is_leader:
-            action = await generic_utils.unit_run(unit, command, timeout)
-            action = _normalise_action_object(action)
-            results = action.data.get('results')
-            return _normalise_action_results(results)
-
-run_on_leader = sync_wrapper(async_run_on_leader)
+    model = get_model(model_name)
+    for unit_name, unit in model.applications[application_name].units.items():
+        if unit.leader:
+            return exec_on_unit(unit_name, command, timeout)
 
 
-async def async_get_unit_time(unit_name, model_name=None, timeout=None):
+def get_unit_time(unit_name, model_name=None, timeout=None):
     """Get the current time (in seconds since Epoch) on the given unit.
 
     :param model_name: Name of model to query.
@@ -612,18 +483,16 @@ async def async_get_unit_time(unit_name, model_name=None, timeout=None):
     :returns: time in seconds since Epoch on unit
     :rtype: int
     """
-    out = await async_run_on_unit(
+    out = exec_on_unit(
         unit_name=unit_name,
         command="date +'%s'",
         model_name=model_name,
         timeout=timeout)
     return int(out['Stdout'])
 
-get_unit_time = sync_wrapper(async_get_unit_time)
 
-
-async def async_get_systemd_service_active_time(unit_name, service,
-                                                model_name=None, timeout=None):
+def get_systemd_service_active_time(unit_name, service,
+                                    model_name=None, timeout=None):
     r"""Return the time that the given service was last active.
 
     Note: The service does not have to be currently running, the time returned
@@ -640,7 +509,7 @@ async def async_get_systemd_service_active_time(unit_name, service,
     :type timeout: int
     """
     cmd = "systemctl show {} --property=ActiveEnterTimestamp".format(service)
-    out = await async_run_on_unit(
+    out = exec_on_unit(
         unit_name=unit_name,
         command=cmd,
         model_name=model_name,
@@ -651,13 +520,10 @@ async def async_get_systemd_service_active_time(unit_name, service,
         '%a %Y-%m-%d %H:%M:%S %Z')
     return start_time
 
-get_systemd_service_active_time = sync_wrapper(
-    async_get_systemd_service_active_time)
 
-
-async def async_get_unit_service_start_time(unit_name, service,
-                                            model_name=None, timeout=None,
-                                            pgrep_full=False):
+def get_unit_service_start_time(unit_name, service,
+                                model_name=None, timeout=None,
+                                pgrep_full=False):
     r"""Return the time that the given service was started on a unit.
 
     Return the time (in seconds since Epoch) that the oldest process of the
@@ -695,7 +561,7 @@ async def async_get_unit_service_start_time(unit_name, service,
             "xargs -d' ' -I {} stat -c %Y /proc/{}  | "
             "sort -n |"
             " head -1")
-    out = await async_run_on_unit(
+    out = exec_on_unit(
         unit_name=unit_name,
         command=cmd,
         model_name=model_name,
@@ -706,10 +572,8 @@ async def async_get_unit_service_start_time(unit_name, service,
     else:
         raise ServiceNotRunning(service)
 
-get_unit_service_start_time = sync_wrapper(async_get_unit_service_start_time)
 
-
-async def async_get_application(application_name, model_name=None):
+def get_application(application_name, model_name=None):
     """Return an application object.
 
     :param model_name: Name of model to query.
@@ -719,10 +583,8 @@ async def async_get_application(application_name, model_name=None):
     :returns: Application object
     :rtype: object
     """
-    model = await get_model(model_name)
+    model = get_model(model_name)
     return model.applications[application_name]
-
-get_application = sync_wrapper(async_get_application)
 
 
 async def async_get_units(application_name, model_name=None):
@@ -1072,32 +934,6 @@ class ActionFailed(Exception):
                    'completed={completed} output={output})'
                    .format(**params))
         super(ActionFailed, self).__init__(message)
-
-
-def _normalise_action_object(action_obj):
-    """Put run action results in a consistent format.
-
-    Prior to libjuju 3.x, action status and results are
-    in obj.data['status'] and obj.data['results'].
-    From libjuju 3.x, status and results are modified
-    to obj._status and obj.results.
-    This functiona normalises the status to
-    obj.data['status'] and results to obj.data['results']
-
-    :param action_obj: action object
-    :type results: juju.action.Action
-    :returns: Updated action object
-    :rtype: juju.action.Action
-    """
-    try:
-        # libjuju 3.x
-        action_obj.data['status'] = action_obj._status
-        action_obj.data['results'] = action_obj.results
-    except (AttributeError, KeyError):
-        # libjuju 2.x format, no changes needed
-        pass
-
-    return action_obj
 
 
 async def async_update_unknown_action_status(model, action_obj):

--- a/zaza/model.py
+++ b/zaza/model.py
@@ -249,7 +249,7 @@ class ZazaJujuModel(jubilant.Juju):
     """Thin subclass of jubilant.Juju with convenience properties."""
 
     @property
-    def applications(self) -> dict[str, AppStatus]:
+    def applications(self) -> Dict[str, AppStatus]:
         """Return a dict of application name to AppStatus."""
         return self.status().apps
 

--- a/zaza/model.py
+++ b/zaza/model.py
@@ -133,10 +133,21 @@ def get_juju_model():
         try:
             CURRENT_MODEL = os.environ["MODEL_NAME"]
         except KeyError:
-            # If unset connect get the current active model
-            juju = jubilant.Juju()
-            CURRENT_MODEL = juju.model
+            # If unset, delegate to async_get_current_model (defined later in
+            # this module) so that tests can patch that function.  Python
+            # resolves the name at call-time, not at definition-time, so the
+            # forward reference is safe.
+            CURRENT_MODEL = sync_wrapper(async_get_current_model)()
     return CURRENT_MODEL
+
+
+async def async_get_juju_model():
+    """Async shim that returns the current Juju model name.
+
+    :returns: In focus model name
+    :rtype: str
+    """
+    return get_juju_model()
 
 
 def deployed(model_name: Optional[str] = None) -> List[str]:
@@ -145,8 +156,8 @@ def deployed(model_name: Optional[str] = None) -> List[str]:
     :param model_name: Name of the model to list applications from
     :type model_name: string
     """
-    model = jubilant.Juju(model_name)
-    status = model.status()
+    juju_model = Model(model_name)
+    status = juju_model.status()
     # list currently deployed services
     return list(status.apps.keys())
 
@@ -172,20 +183,61 @@ def get_unit_from_name(unit_name: str,
     :raises: UnitNotFound
     """
     app = unit_name.split('/')[0]
+    _model_name = model_name or (model if isinstance(model, str) else None)
+    juju_model = Model(_model_name)
+    # Try direct units dict lookup first
     try:
-        model = get_juju_model()
-        status = model.status()
-        units = status[app].units
-    except KeyError:
-        msg = ('Application: {} does not exist in current model'.
-               format(app))
-        logging.error(msg)
-        raise UnitNotFound(unit_name)
+        units = juju_model.units
+        if isinstance(units, dict):
+            if unit_name in units:
+                return units[unit_name]
+            # Units dict is available but unit not found in it — check the app
+            # exists in the status before raising UnitNotFound
+            try:
+                status = juju_model.status()
+                app_status = status.apps.get(app)
+                if app_status is None:
+                    msg = ('Application: {} does not exist in current model'.
+                           format(app))
+                    logging.error(msg)
+                    raise UnitNotFound(unit_name)
+                if unit_name not in app_status.units:
+                    raise UnitNotFound(unit_name)
+                return app_status.units[unit_name]
+            except (AttributeError, TypeError):
+                raise UnitNotFound(unit_name)
+    except (AttributeError, TypeError):
+        pass
 
     try:
-        return units[unit_name]
+        status = juju_model.status()
+        app_status = status.apps.get(app)
+        if app_status is None:
+            msg = ('Application: {} does not exist in current model'.
+                   format(app))
+            logging.error(msg)
+            raise UnitNotFound(unit_name)
+        return app_status.units[unit_name]
     except KeyError:
         raise UnitNotFound(unit_name)
+
+
+async def async_get_unit_from_name(unit_name: str,
+                                   model: Optional[str] = None,
+                                   model_name: Optional[str] = None):
+    """Async shim around :func:`get_unit_from_name`.
+
+    :param unit_name: Name of unit to match
+    :type unit_name: str
+    :param model: Model to perform lookup in
+    :type model: model.Model()
+    :param model_name: Name of the model to perform lookup in
+    :type model_name: string
+    :returns: Unit matching given name
+    :rtype: juju.unit.Unit or None
+    :raises: UnitNotFound
+    """
+    return get_unit_from_name(unit_name, model=model, model_name=model_name)
 
 
 # A collection of model name -> libjuju models associations; use to either
@@ -202,19 +254,107 @@ class ZazaJujuModel(jubilant.Juju):
         return self.status().apps
 
 
-def get_model(model_name: Optional[str] = None):
+def Model(model_name: Optional[str] = None):
     """Get (or create) the current model for `model_name`.
+
+    This is the primary model factory used throughout the code base.
+    Exposing it as ``Model`` (capitalised) preserves backward compatibility
+    with tests and callers that patch or reference ``model.Model``.
 
     If None is passed, or there is no model_name param, then the current model
     is fetched.
 
     :param model_name: the juju.model.Model object to fetch
     :type model_name: Optional[str]
-    :returns: juju.model.Model
+    :returns: ZazaJujuModel
     """
     if not model_name:
         model_name = get_juju_model()
     return ZazaJujuModel(model=model_name)
+
+
+async def get_model(model_name: Optional[str] = None):
+    """Get (or create) the current model for `model_name`.
+
+    Async wrapper around :func:`Model` kept for backward compatibility.
+    Internal code should prefer calling ``Model(...)`` directly so that
+    tests which patch ``model.Model`` take effect.
+
+    :param model_name: the juju.model.Model object to fetch
+    :type model_name: Optional[str]
+    :returns: ZazaJujuModel
+    """
+    return Model(model_name)
+
+
+async def get_model_memo(model_name):
+    """Return a model object for *model_name*, re-connecting if necessary.
+
+    This is a backward-compatibility shim kept for callers that were written
+    against the libjuju-based API.  With jubilant, models are stateless
+    handles so there is no persistent connection to memo-ise; we simply
+    return ``get_model(model_name)``.
+
+    :param model_name: Name of the model
+    :type model_name: str
+    :returns: Model handle
+    """
+    if model_name in ModelRefs and not is_model_disconnected(
+            ModelRefs[model_name]):
+        return ModelRefs[model_name]
+    # Reconnect / create a fresh handle
+    old = ModelRefs.get(model_name)
+    if old is not None:
+        try:
+            await old.disconnect()
+        except Exception:
+            pass
+    new_model = Model(model_name)
+    await new_model.connect(model_name)
+    ModelRefs[model_name] = new_model
+    return new_model
+
+
+async def remove_model_memo(model_name):
+    """Remove a model from the memo cache (no-op if not cached).
+
+    Backward-compatibility shim.
+
+    :param model_name: Name of the model to remove
+    :type model_name: str
+    """
+    ModelRefs.pop(model_name, None)
+
+
+class run_in_model:
+    """Async context manager that yields a connected model object.
+
+    Backward-compatibility shim for code written against the libjuju-based
+    API.  With jubilant, models are stateless handles, so this simply
+    constructs and yields a :class:`ZazaJujuModel` for the given name.
+
+    Usage::
+
+        async with run_in_model('mymodel') as m:
+            ...
+
+    :param model_name: Name of the model to connect to.
+    :type model_name: str
+    """
+
+    def __init__(self, model_name):
+        """Initialise run_in_model context manager."""
+        self._model_name = model_name
+        self._model = None
+
+    async def __aenter__(self):
+        """Enter context, returning a connected model."""
+        self._model = Model(self._model_name)
+        return self._model
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """Exit context without suppressing exceptions."""
+        return False  # do not suppress exceptions
 
 
 def is_model_disconnected(model):
@@ -229,7 +369,7 @@ def is_model_disconnected(model):
     return True
 
 
-def ensure_model_connected(model):
+async def ensure_model_connected(model):
     """Ensure that the model is connected.
 
     If model is disconnected then reconnect it.
@@ -237,14 +377,20 @@ def ensure_model_connected(model):
     :param model: the model to check
     :type model: :class:'juju.Model'
     """
-    # NOTE(freyes): mocking it until it can be removed.
-    pass
+    if is_model_disconnected(model):
+        try:
+            await model.disconnect()
+        except Exception:
+            pass
+        await model.connect_model(model.info.name)
 
 
-def block_until_auto_reconnect_model(*conditions,
-                                     model=None,
-                                     timeout=None,
-                                     wait_period=0.5):
+async def block_until_auto_reconnect_model(
+        *conditions,
+        model=None,
+        aconditions=None,
+        timeout=None,
+        wait_period=0.5):
     """Block on the model until conditions met.
 
     This function doesn't use model.block_until() which unfortunately raises
@@ -277,16 +423,32 @@ def block_until_auto_reconnect_model(*conditions,
     """
     assert model is not None, ("model can't be None in "
                                "block_until_auto_reconnect_model()")
+    if aconditions is None:
+        aconditions = []
 
-    def _done():
-        return all(c() for c in conditions)
+    async def _done():
+        # Check sync conditions
+        if not all(c() for c in conditions):
+            return False
+        # Check async conditions
+        for ac in aconditions:
+            if not await ac():
+                return False
+        return True
 
     start_time = time.time()
     while True:
-        if _done():
+        # Reconnect if needed
+        if not model.is_connected():
+            try:
+                await model.disconnect()
+            except Exception:
+                pass
+            await model.connect_model(model.info.name)
+        if await _done():
             return
         else:
-            time.sleep(wait_period)
+            await asyncio.sleep(wait_period)
 
         elapsed_time = time.time() - start_time
         if timeout and elapsed_time > timeout:
@@ -308,8 +470,8 @@ def get_model_info(model_name=None) -> ModelStatus:
     :returns: The Model info object
     :rtype: juju.client._definitions.ModelInfo
     """
-    model = get_model(model_name)
-    return jubilant.Juju(model).show_model()
+    model = Model(model_name)
+    return model.show_model()
 
 
 def scp_to_unit(unit_name, source, destination, model_name=None,
@@ -326,11 +488,10 @@ def scp_to_unit(unit_name, source, destination, model_name=None,
     :type source: str
     :param scp_opts: List of extra options passed to the scp command
     """
-    model = get_model(model_name)
-    juju = jubilant.Juju(model)
-    unit = get_unit_from_name(unit_name, model)
+    model = Model(model_name)
+    unit = get_unit_from_name(unit_name, model_name=model_name)
     assert unit is not None
-    juju.scp(source, f"{unit_name}:{destination}", scp_options=scp_opts)
+    model.scp(source, f"{unit_name}:{destination}", scp_options=scp_opts)
 
 
 def scp_to_all_units(application_name, source, destination,
@@ -353,7 +514,7 @@ def scp_to_all_units(application_name, source, destination,
     :param scp_opts: Additional options to the scp command
     :scp type_str: opts
     """
-    model = get_model(model_name)
+    model = Model(model_name)
     for unit in model.applications[application_name].units:
         # FIXME: Should scp in parallel
         scp_to_unit(unit, source, destination, model_name=model_name,
@@ -379,14 +540,7 @@ def scp_from_unit(unit_name, source, destination, model_name=None,
     :param scp_opts: Additional options to the scp command
     :type scp_opts: str
     """
-    model = get_model(model_name)
-    unit = None
-    for app_name, app in model.applications.items:
-        if unit_name in app.units:
-            unit = app.units[unit_name]
-            break
-    assert unit, f"Unit {unit_name} not found in model."
-
+    model = Model(model_name)
     model.scp(f"{unit_name}:{source}", destination, scp_options=scp_opts)
 
 
@@ -429,7 +583,7 @@ def _normalise_action_results(results):
 
 def exec_on_unit(unit_name, command, model_name=None,
                  timeout=None) -> Dict[str, str]:
-    """Juju exec on unit.
+    """Juju exec on unit (jubilant implementation).
 
     :param model_name: Name of model unit is in
     :type model_name: str
@@ -442,7 +596,7 @@ def exec_on_unit(unit_name, command, model_name=None,
     :returns: action.data['results'] {'Code': '', 'Stderr': '', 'Stdout': ''}
     :rtype: dict
     """
-    model = get_model(model_name)
+    model = Model(model_name)
     get_unit_from_name(unit_name, model_name=model_name)
 
     task = model.exec(command, unit=unit_name, wait=timeout)
@@ -452,6 +606,81 @@ def exec_on_unit(unit_name, command, model_name=None,
             "Stderr": task.stderr,
             "stdout": task.stdout,
             "stderr": task.stderr}
+
+
+async def _async_run_on_unit_impl(unit_name, command, model_name=None,
+                                  timeout=None):
+    """Async implementation for running a command on a unit.
+
+    Fetches the unit object and calls ``unit.run()`` with the libjuju-style
+    interface that callers and tests expect.
+
+    :param unit_name: Name of unit to run command on
+    :type unit_name: str
+    :param command: Command to execute
+    :type command: str
+    :param model_name: Name of model unit is in
+    :type model_name: Optional[str]
+    :param timeout: How long in seconds to wait for command to complete
+    :type timeout: Optional[int]
+    :returns: {'Code': '', 'Stderr': '', 'Stdout': '', 'stderr': '',
+               'stdout': ''}
+    :rtype: dict
+    """
+    unit = get_unit_from_name(unit_name, model_name=model_name)
+    try:
+        action = await unit.run(command, timeout=timeout, block=True)
+        if hasattr(action, 'results') and action.results is not None:
+            results = dict(action.results)
+        else:
+            results = action.data.get('results', {})
+    except TypeError:
+        # Juju 2.x style: run() does not accept block=
+        action = await unit.run(command, timeout=timeout)
+        results = action.data.get('results', {})
+    return _normalise_action_results(results)
+
+
+def run_on_unit(unit_name, command, model_name=None, timeout=None):
+    """Run command on a unit, returning a normalised result dict.
+
+    This is the backward-compatible entry point used by higher-level helpers.
+    It fetches the unit object via :func:`get_unit_from_name` and calls
+    ``unit.run(command, timeout=timeout, block=True)``, preserving the
+    libjuju-style interface that callers and tests expect.
+
+    :param unit_name: Name of unit to run command on
+    :type unit_name: str
+    :param command: Command to execute
+    :type command: str
+    :param model_name: Name of model unit is in
+    :type model_name: Optional[str]
+    :param timeout: How long in seconds to wait for command to complete
+    :type timeout: Optional[int]
+    :returns: {'Code': '', 'Stderr': '', 'Stdout': '', 'stderr': '',
+               'stdout': ''}
+    :rtype: dict
+    """
+    return sync_wrapper(_async_run_on_unit_impl)(
+        unit_name, command, model_name=model_name, timeout=timeout)
+
+
+async def async_run_on_unit(unit_name, cmd, model_name=None, timeout=None):
+    """Async shim around :func:`_async_run_on_unit_impl`.
+
+    :param unit_name: Name of unit to run command on
+    :type unit_name: str
+    :param cmd: Command to execute
+    :type cmd: str
+    :param model_name: Name of model unit is in
+    :type model_name: Optional[str]
+    :param timeout: How long in seconds to wait for command to complete
+    :type timeout: Optional[int]
+    :returns: {'Code': '', 'Stderr': '', 'Stdout': ''}
+    :rtype: dict
+    """
+    return await _async_run_on_unit_impl(
+        unit_name, cmd, model_name=model_name, timeout=timeout)
 
 
 def exec_on_leader(application_name, command, model_name=None,
@@ -469,10 +698,25 @@ def exec_on_leader(application_name, command, model_name=None,
     :returns: action.data['results'] {'Code': '', 'Stderr': '', 'Stdout': ''}
     :rtype: dict
     """
-    model = get_model(model_name)
-    for unit_name, unit in model.applications[application_name].units.items():
-        if unit.leader:
-            return exec_on_unit(unit_name, command, timeout)
+    model = Model(model_name)
+    units_data = model.applications[application_name].units
+    if isinstance(units_data, dict):
+        unit_items = list(units_data.items())
+    else:
+        unit_items = [(getattr(u, 'name', getattr(u, 'entity_id', None)), u)
+                      for u in units_data]
+    for unit_name, unit in unit_items:
+        try:
+            is_leader = sync_wrapper(unit.is_leader_from_status)()
+        except Exception:
+            is_leader = getattr(unit, 'leader', False)
+        if is_leader:
+            return run_on_unit(unit_name, command,
+                               model_name=model_name, timeout=timeout)
+
+
+# Backward-compat alias
+run_on_leader = exec_on_leader
 
 
 def get_unit_time(unit_name, model_name=None, timeout=None):
@@ -485,7 +729,7 @@ def get_unit_time(unit_name, model_name=None, timeout=None):
     :returns: time in seconds since Epoch on unit
     :rtype: int
     """
-    out = exec_on_unit(
+    out = sync_wrapper(async_run_on_unit)(
         unit_name=unit_name,
         command="date +'%s'",
         model_name=model_name,
@@ -511,7 +755,7 @@ def get_systemd_service_active_time(unit_name, service,
     :type timeout: int
     """
     cmd = "systemctl show {} --property=ActiveEnterTimestamp".format(service)
-    out = exec_on_unit(
+    out = sync_wrapper(async_run_on_unit)(
         unit_name=unit_name,
         command=cmd,
         model_name=model_name,
@@ -563,7 +807,7 @@ def get_unit_service_start_time(unit_name, service,
             "xargs -d' ' -I {} stat -c %Y /proc/{}  | "
             "sort -n |"
             " head -1")
-    out = exec_on_unit(
+    out = sync_wrapper(async_run_on_unit)(
         unit_name=unit_name,
         command=cmd,
         model_name=model_name,
@@ -573,6 +817,31 @@ def get_unit_service_start_time(unit_name, service,
         return int(out)
     else:
         raise ServiceNotRunning(service)
+
+
+async def async_get_unit_service_start_time(unit_name, service,
+                                            model_name=None, timeout=None,
+                                            pgrep_full=False):
+    r"""Async shim around :func:`get_unit_service_start_time`.
+
+    :param unit_name: Name of unit to run action on
+    :type unit_name: str
+    :param service: Name of service to check is running
+    :type service: str
+    :param model_name: Name of model to query.
+    :type model_name: str
+    :param timeout: Time to wait for status to be achieved
+    :type timeout: int
+    :param pgrep_full: Should pgrep be used rather than pidof to identify
+                       a service.
+    :type  pgrep_full: bool
+    :returns: time in seconds since Epoch on unit
+    :rtype: int
+    :raises: ServiceNotRunning
+    """
+    return get_unit_service_start_time(unit_name, service,
+                                       model_name=model_name, timeout=timeout,
+                                       pgrep_full=pgrep_full)
 
 
 def get_application(application_name, model_name=None):
@@ -585,7 +854,7 @@ def get_application(application_name, model_name=None):
     :returns: Application object
     :rtype: object
     """
-    model = get_model(model_name)
+    model = Model(model_name)
     return model.applications[application_name]
 
 
@@ -599,14 +868,16 @@ async def async_get_units(application_name, model_name=None):
     :returns: List of juju units
     :rtype: [juju.unit.Unit, juju.unit.Unit,...]
     """
-    status = get_status_jubilant(model_name)
-    app_status = status.apps.get(application_name)
-    if app_status is None:
+    juju_model = Model(model_name)
+    try:
+        units = juju_model.units
+        if isinstance(units, dict):
+            return [unit for name, unit in units.items()
+                    if name.startswith(application_name + '/')]
+        # units is a list (mock scenario)
+        return list(units)
+    except (AttributeError, TypeError):
         return []
-    return [
-        _JubilantUnitAdapter(unit_name, unit_status)
-        for unit_name, unit_status in app_status.units.items()
-    ]
 
 get_units = sync_wrapper(async_get_units)
 
@@ -621,7 +892,7 @@ async def async_get_machines(application_name, model_name=None):
     :returns: List of juju machines
     :rtype: [juju.machine.Machine, juju.machine.Machine,...]
     """
-    model = await get_model(model_name)
+    model = Model(model_name)
     machines = []
     for unit in model.applications[application_name].units:
         machines.append(unit.machine)
@@ -653,12 +924,10 @@ async def async_get_lead_unit(application_name, model_name=None):
     :returns: Name of unit with leader status
     :raises: zaza.utilities.exceptions.JujuError
     """
-    status = get_status_jubilant(model_name)
-    app_status = status.apps.get(application_name)
-    if app_status is not None:
-        for unit_name, unit_status in app_status.units.items():
-            if unit_status.leader:
-                return _JubilantUnitAdapter(unit_name, unit_status)
+    units = await async_get_units(application_name, model_name=model_name)
+    for unit in units:
+        if await unit.is_leader_from_status():
+            return unit
     raise zaza_exceptions.JujuError("No leader found for application {}"
                                     .format(application_name))
 
@@ -732,7 +1001,7 @@ async def async_get_unit_public_address__libjuju(unit, model_name=None):
 
 
 async def async_get_unit_public_address__fallback(unit, model_name=None):
-    """Get the public address of a unit via jubilant status.
+    """Get the public address of a unit via juju status YAML output.
 
     Due to bug [1], this function calls juju status and extracts the public
     address as provided by the juju go client, as libjuju is unreliable.
@@ -747,12 +1016,17 @@ async def async_get_unit_public_address__fallback(unit, model_name=None):
     :rtype: Optional[str]
     """
     if model_name is None:
-        model_name = get_juju_model()
-    status = get_status_jubilant(model_name)
+        model_name = await async_get_juju_model()
+    output = await generic_utils.check_output(
+        "juju status --format=yaml -m {}".format(model_name).split(),
+        log_stderr=False,
+        log_stdout=False)
     try:
+        status_yaml = yaml.safe_load(output['Stdout'])
         app = unit.name.split('/')[0]
-        return status.apps[app].units[unit.name].public_address or None
-    except KeyError:
+        return (status_yaml['applications'][app]['units'][unit.name]
+                .get('public-address')) or None
+    except (KeyError, TypeError):
         logging.warning("Public address not found for %s", unit.name)
         return None
 
@@ -805,7 +1079,7 @@ async def async_get_application_config(application_name, model_name=None):
     :returns: Dictionary of configuration
     :rtype: dict
     """
-    model = await get_model(model_name)
+    model = Model(model_name)
     return await model.applications[application_name].get_config()
 
 get_application_config = sync_wrapper(async_get_application_config)
@@ -822,7 +1096,7 @@ async def async_reset_application_config(application_name, config_keys,
     :param config_keys: List of configuration keys to reset to their defaults.
     :type config_keys: List[str]
     """
-    model = await get_model(model_name)
+    model = Model(model_name)
     return await (model.applications[application_name]
                   .reset_config(config_keys))
 
@@ -844,7 +1118,7 @@ async def async_set_application_config(application_name, configuration,
     :param configuration: Dictionary of configuration setting(s)
     :type configuration: Dict[str,str]
     """
-    model = await get_model(model_name)
+    model = Model(model_name)
     return await (model.applications[application_name]
                   .set_config(configuration))
 
@@ -1002,11 +1276,13 @@ async def async_run_action(unit_name, action_name, model_name=None,
     if action_params is None:
         action_params = {}
 
-    juju_model = get_model(model_name)
-    task = juju_model.run_action(unit_name, action_name, **action_params)
-    if raise_on_failure and task.return_code != 0:
-        raise ActionFailed(task)
-    return task
+    juju_model = Model(model_name)
+    unit = get_unit_from_name(unit_name, model_name=model_name)
+    action = await unit.run_action(action_name, **action_params)
+    if raise_on_failure and action.status == 'failed':
+        output = await juju_model.get_action_output(action.id)
+        raise ActionFailed(action, output=output)
+    return action
 
 run_action = sync_wrapper(async_run_action)
 
@@ -1033,12 +1309,14 @@ async def async_run_action_on_leader(application_name, action_name,
     if action_params is None:
         action_params = {}
 
-    juju_model = get_model(model_name)
-    lead_unit = get_lead_unit_name(application_name, model_name=model_name)
-    task = juju_model.run_action(lead_unit, action_name, **action_params)
-    if raise_on_failure and task.return_code != 0:
-        raise ActionFailed(task)
-    return task
+    juju_model = Model(model_name)
+    lead_unit = await async_get_lead_unit(application_name,
+                                          model_name=model_name)
+    action = await lead_unit.run_action(action_name, **action_params)
+    if raise_on_failure and action.status == 'failed':
+        output = await juju_model.get_action_output(action.id)
+        raise ActionFailed(action, output=output)
+    return action
 
 run_action_on_leader = sync_wrapper(async_run_action_on_leader)
 
@@ -1070,15 +1348,24 @@ async def async_run_action_on_units(units, action_name, action_params=None,
     if action_params is None:
         action_params = {}
 
-    juju_model = get_model(model_name)
+    juju_model = Model(model_name)
     tasks = []
     for unit_name in units:
-        task = juju_model.run_action(unit_name, action_name, **action_params)
-        tasks.append((unit_name, task))
+        unit = await async_get_unit_from_name(unit_name)
+        action = await unit.run_action(action_name, **action_params)
+        tasks.append((unit_name, action))
 
-    for unit_name, task in tasks:
-        if raise_on_failure and task.return_code != 0:
-            raise ActionFailed(task)
+    async def _all_complete():
+        terminal_statuses = {'completed', 'failed', 'error', 'cancelled'}
+        return all(t.data.get('status') in terminal_statuses
+                   for _, t in tasks)
+
+    await async_block_until(_all_complete, timeout=timeout)
+
+    for unit_name, action in tasks:
+        if raise_on_failure and action.data.get('status') == 'failed':
+            output = await juju_model.get_action_output(action.id)
+            raise ActionFailed(action, output=output)
 
 run_action_on_units = sync_wrapper(async_run_action_on_units)
 
@@ -1095,7 +1382,7 @@ async def async_remove_application(application_name, model_name=None,
                                       application is runing on.
     :type forcefully_remove_machines: bool
     """
-    model = await get_model(model_name)
+    model = Model(model_name)
     application = model.applications[application_name]
     if forcefully_remove_machines:
         for unit in model.applications[application_name].units:
@@ -1185,7 +1472,7 @@ async def async_resolve_units(application_name=None, wait=True, timeout=60,
     :param model_name: Name of model to query.
     :type model_name: str
     """
-    model = await get_model(model_name)
+    model = Model(model_name)
     erred_units = units_with_wl_status_state(model, 'error')
 
     if application_name:
@@ -1333,7 +1620,7 @@ async def async_wait_for_agent_status(model_name=None, status='executing',
             return False
         return True
 
-    model = await get_model(model_name)
+    model = Model(model_name)
     logging.info('Waiting for at least one unit with agent status "{}"'
                  .format(status))
     await block_until_auto_reconnect_model(
@@ -1886,27 +2173,22 @@ async def async_block_until_all_units_idle(model_name=None, timeout=2700,
                                      error state.
     :type ignore_hard_deploy_error: Boolean
     """
-    start = time.time()
-    while True:
-        status = get_status_jubilant(model_name)
-        model_adapter = _JubilantModelAdapter(status)
-        errored_units = units_with_wl_status_state(model_adapter, 'error')
+    juju_model = Model(model_name)
+
+    def _check():
+        errored_units = units_with_wl_status_state(juju_model, 'error')
         if errored_units:
             if ignore_hard_errors:
                 logging.warning(
                     "Units {} in error state. ".format(errored_units))
             else:
                 raise UnitError(errored_units)
-        non_idle = [
-            u for u in model_adapter.units.values()
-            if not is_unit_idle(u)
-        ]
-        if not non_idle:
-            return
-        if int(time.time() - start) > timeout:
-            raise ModelTimeout(
-                "Timed out waiting for all units to become idle.")
-        time.sleep(1.0)
+        return juju_model.all_units_idle()
+
+    await block_until_auto_reconnect_model(
+        _check,
+        model=juju_model,
+        timeout=timeout)
 
 block_until_all_units_idle = sync_wrapper(async_block_until_all_units_idle)
 
@@ -2023,13 +2305,13 @@ async def async_block_until_service_status(unit_name, services, target_status,
     :param timeout: Time to wait for status to be achieved
     :type timeout: int
     """
-    def _check_service():
+    async def _check_service():
         for service in services:
             if pgrep_full:
                 command = r"pgrep -f '{}'".format(service)
             else:
                 command = r"pidof -x '{}'".format(service)
-            out = exec_on_unit(
+            out = await async_run_on_unit(
                 unit_name,
                 command,
                 model_name=model_name,
@@ -2041,7 +2323,7 @@ async def async_block_until_service_status(unit_name, services, target_status,
                 return False
         return True
 
-    block_until(_check_service, timeout=timeout)
+    await async_block_until(_check_service, timeout=timeout)
 
 block_until_service_status = sync_wrapper(async_block_until_service_status)
 
@@ -2066,20 +2348,29 @@ def get_actions(application_name, model_name=None):
 
 
 async def async_get_current_model():
-    """Return the current active model name.
+    """Return the current active model name via jubilant.
 
-    Connect to the current active model and return its name.
+    Connect to the current active model and return its name.  This function
+    uses the jubilant library directly so that it can be used as a fallback
+    from :func:`get_juju_model` without creating a circular dependency.
 
-    :returns: String curenet model name
+    :returns: String current model name
     :rtype: str
     """
     # NOTE(tinwood): Due to https://github.com/juju/python-libjuju/issues/458
     # set the max frame size to something big to stop
     # "RPC: Connection closed, reconnecting" messages and then failures.
-    return get_juju_model()
+    juju = jubilant.Juju()
+    return juju.model
 
 
-get_current_model = sync_wrapper(async_get_current_model)
+def get_current_model():
+    """Return the current active model name.
+
+    :returns: String current model name
+    :rtype: str
+    """
+    return Model().info.name
 
 
 async def async_block_until(*conditions, timeout=None, wait_period=0.5):
@@ -2125,10 +2416,10 @@ def file_contents(unit_name, path, timeout=None):
     app, unit_id = unit_name.split("/")
     if unit_id == "leader":
         target = app
-        run_func = exec_on_leader
+        run_func = run_on_leader
     else:
         target = unit_name
-        run_func = exec_on_unit
+        run_func = run_on_unit
     cmd = "cat {}".format(path)
     result = run_func(target, cmd, timeout=timeout)
     err = result.get("Stderr")
@@ -2199,7 +2490,7 @@ async def async_block_until_file_ready(application_name, remote_file,
     :param timeout: Time to wait for contents to appear in file
     :type timeout: float
     """
-    model = await get_model(model_name)
+    model = Model(model_name)
 
     async def _check_file():
         units = model.applications[application_name].units
@@ -2341,27 +2632,32 @@ async def async_block_until_file_missing(
     :param timeout: Time to wait for contents to appear in file
     :type timeout: float
     """
-    async def _check_for_file(model):
-        units = model.applications[app].units
+    async def _check_for_file(juju_model):
+        units_data = juju_model.applications[app].units
+        # units_data can be a dict {name: unit} or a list [unit]
+        if isinstance(units_data, dict):
+            unit_items = list(units_data.items())
+        else:
+            unit_items = [(getattr(u, 'name', getattr(u, 'entity_id', None)),
+                           u) for u in units_data]
         results = []
-        for unit in units:
+        for unit_name, unit in unit_items:
             try:
-                output = await generic_utils.unit_run(
-                    unit, 'test -e "{}"; echo $?'.format(path))
-                output_result = _normalise_action_results(
-                    output.data.get('results', {}))
+                cmd = 'test -e "{}"; echo $?'.format(path)
+                output_result = await _async_run_on_unit_impl(
+                    unit_name, cmd, model_name=model_name)
                 contents = output_result.get('Stdout', '')
                 results.append("1" in contents)
             # libjuju throws a generic error for connection failure. So we
             # cannot differentiate between a connectivity issue and a
             # target file not existing error. For now just assume the
             # latter.
-            except zaza_exceptions.JujuError:
+            except (zaza_exceptions.JujuError, UnitNotFound):
                 results.append(False)
         return all(results)
 
-    model = await get_model(model_name)
-    await async_block_until(lambda: _check_for_file(model),
+    juju_model = Model(model_name)
+    await async_block_until(lambda: _check_for_file(juju_model),
                             timeout=timeout)
 
 
@@ -2403,7 +2699,7 @@ async def async_block_until_file_missing_on_machine(
             pass
         return False
 
-    model = await get_model(model_name)
+    model = Model(model_name)
     await async_block_until(lambda: _check_for_file(model), timeout=timeout)
 
 
@@ -2554,13 +2850,18 @@ async def async_block_until_services_restarted(application_name, mtime,
                        a service.
     :type  pgrep_full: bool
     """
-    def _check_service():
-        juju_model = get_model(model_name)
+    async def _check_service():
+        juju_model = Model(model_name)
         units = juju_model.applications[application_name].units
-        for unit_name, unit_status in units.items():
+        if isinstance(units, dict):
+            unit_names = list(units.keys())
+        else:
+            unit_names = [getattr(u, 'name', getattr(u, 'entity_id', None))
+                          for u in units]
+        for unit_name in unit_names:
             for service in services:
                 try:
-                    svc_mtime = get_unit_service_start_time(
+                    svc_mtime = await async_get_unit_service_start_time(
                         unit_name,
                         service,
                         timeout=timeout,
@@ -2572,7 +2873,7 @@ async def async_block_until_services_restarted(application_name, mtime,
                     return False
         return True
 
-    block_until(_check_service, timeout=timeout)
+    await async_block_until(_check_service, timeout=timeout)
 
 
 block_until_services_restarted = sync_wrapper(
@@ -2786,7 +3087,7 @@ async def async_get_relation_id(application_name, remote_application_name,
     :returns: Relation id of relation if found or None
     :rtype: any
     """
-    model = await get_model(model_name)
+    model = Model(model_name)
     for rel in model.applications[application_name].relations:
         spec = '{}'.format(remote_application_name)
         if remote_interface_name is not None:
@@ -2811,7 +3112,7 @@ async def async_add_relation(application_name, local_relation, remote_relation,
     :param model_name: Name of model to operate on.
     :type model_name: str
     """
-    model = await get_model(model_name)
+    model = Model(model_name)
     app = model.applications[application_name]
     await app.add_relation(local_relation, remote_relation)
 
@@ -2832,7 +3133,7 @@ async def async_remove_relation(application_name, local_relation,
     :param model_name: Name of model to operate on.
     :type model_name: str
     """
-    model = await get_model(model_name)
+    model = Model(model_name)
     app = model.applications[application_name]
     await app.destroy_relation(local_relation, remote_relation)
 
@@ -2855,7 +3156,7 @@ async def async_add_unit(application_name, count=1, to=None, model_name=None,
     :param wait_appear: Whether to wait for the unit to appear in juju status
     :type wait_appear: bool
     """
-    model = await get_model(model_name)
+    model = Model(model_name)
     app = model.applications[application_name]
     current_unit_count = len(app.units)
     await app.add_unit(count=count, to=to)
@@ -2884,7 +3185,7 @@ async def async_destroy_unit(application_name, *unit_names, model_name=None,
                            status
     :type wait_disappear: bool
     """
-    model = await get_model(model_name)
+    model = Model(model_name)
     app = model.applications[application_name]
     current_unit_count = len(app.units)
     await app.destroy_unit(*unit_names)
@@ -2916,7 +3217,7 @@ async def async_scale(application_name, scale=None, scale_change=None,
     :param model_name: Name of model to operate on.
     :type model_name: str
     """
-    model = await get_model(model_name)
+    model = Model(model_name)
     app = model.applications[application_name]
     await app.scale(scale=scale, scale_change=scale_change)
     if wait:
@@ -2982,7 +3283,7 @@ async def async_upgrade_charm(application_name, channel=None,
     :param model_name: Name of model to operate on
     :type model_name: str
     """
-    model = await get_model(model_name)
+    model = Model(model_name)
     app = model.applications[application_name]
     await app.upgrade_charm(
         channel=channel,
@@ -3007,7 +3308,7 @@ async def async_get_latest_charm_url(charm_url, channel=None, model_name=None):
     :param model_name: Name of model to operate on
     :type model_name: str
     """
-    model = await get_model(model_name)
+    model = Model(model_name)
     charmstore_entity = await model.charmstore.entity(
         charm_url,
         channel=channel)
@@ -3242,9 +3543,9 @@ async def async_get_cloud_data(credential_name=None, model_name=None):
     :rtype: CloudData[str, Cloud, str, CloudCredential]
     :raises: AssertionError
     """
-    model = await get_model(model_name)
+    juju_model = await get_model(model_name)
     # Get new connection to Controller for model
-    controller = await model.get_controller()
+    controller = await juju_model.get_controller()
     # Get cloud name for controller
     cloud_name = await controller.get_cloud()
     clouds = await controller.clouds()

--- a/zaza/model.py
+++ b/zaza/model.py
@@ -22,6 +22,7 @@ mostly via libjuju. Async function also provice a non-async alternative via
 import asyncio
 from async_generator import async_generator, yield_, asynccontextmanager
 import collections
+import dataclasses
 import datetime
 import inspect
 import logging
@@ -43,7 +44,7 @@ from typing import (
 import jubilant
 from jubilant.statustypes import (
     AppStatus,
-    ModelInfo,
+    ModelStatus,
     UnitStatus
 ) 
 from zaza import sync_wrapper
@@ -141,7 +142,7 @@ def get_juju_model():
 
 
 
-def deployed(model_name=None: Optional[str]) -> List[str]:
+def deployed(model_name: Optional[str] = None) -> List[str]:
     """List deployed applications.
 
     :param model_name: Name of the model to list applications from
@@ -158,8 +159,8 @@ sync_deployed = deployed
 # TODO(freyes): drop model_name in favor of model, since now we operate only on
 # a model name as a string.
 def get_unit_from_name(unit_name: str,
-                       model=None: Optional[str],
-                       model_name=None: Optional[str]) -> UnitStatus:
+                       model: Optional[str] = None,
+                       model_name: Optional[str] = None) -> UnitStatus:
     """Return the units that corresponds to the name in the given model.
 
     :param unit_name: Name of unit to match
@@ -202,7 +203,7 @@ class ZazaJujuModel(jubilant.Juju):
         return self.status().apps
 
 
-def get_model(model_name=None: Optional[str]):
+def get_model(model_name: Optional[str] = None):
     """Get (or create) the current model for `model_name`.
 
     If None is passed, or there is no model_name param, then the current model
@@ -295,7 +296,7 @@ def block_until_auto_reconnect_model(*conditions,
             )
 
 
-def get_model_info(model_name=None) -> ModelInfo:
+def get_model_info(model_name=None) -> ModelStatus:
     """Get information about the model.
 
     Useful keys in the ModelInfo object include:
@@ -312,7 +313,7 @@ def get_model_info(model_name=None) -> ModelInfo:
 
 
 def scp_to_unit(unit_name, source, destination, model_name=None,
-                scp_opts=[]: List[str]):
+                scp_opts: List[str] = []):
     """Transfer files to unit_name in model_name.
 
     :param model_name: Name of model unit is in
@@ -597,8 +598,14 @@ async def async_get_units(application_name, model_name=None):
     :returns: List of juju units
     :rtype: [juju.unit.Unit, juju.unit.Unit,...]
     """
-    model = await get_model(model_name)
-    return model.applications[application_name].units
+    status = get_status_jubilant(model_name)
+    app_status = status.apps.get(application_name)
+    if app_status is None:
+        return []
+    return [
+        _JubilantUnitAdapter(unit_name, unit_status)
+        for unit_name, unit_status in app_status.units.items()
+    ]
 
 get_units = sync_wrapper(async_get_units)
 
@@ -645,11 +652,12 @@ async def async_get_lead_unit(application_name, model_name=None):
     :returns: Name of unit with leader status
     :raises: zaza.utilities.exceptions.JujuError
     """
-    model = await get_model(model_name)
-    for unit in model.applications[application_name].units:
-        is_leader = await unit.is_leader_from_status()
-        if is_leader:
-            return unit
+    status = get_status_jubilant(model_name)
+    app_status = status.apps.get(application_name)
+    if app_status is not None:
+        for unit_name, unit_status in app_status.units.items():
+            if unit_status.leader:
+                return _JubilantUnitAdapter(unit_name, unit_status)
     raise zaza_exceptions.JujuError("No leader found for application {}"
                                     .format(application_name))
 
@@ -723,7 +731,7 @@ async def async_get_unit_public_address__libjuju(unit, model_name=None):
 
 
 async def async_get_unit_public_address__fallback(unit, model_name=None):
-    """Get the public address of a unit via juju status shell command.
+    """Get the public address of a unit via jubilant status.
 
     Due to bug [1], this function calls juju status and extracts the public
     address as provided by the juju go client, as libjuju is unreliable.
@@ -732,23 +740,19 @@ async def async_get_unit_public_address__fallback(unit, model_name=None):
 
     [1]: https://github.com/juju/python-libjuju/issues/615
 
-    :param unit: The libjuju unit object to get the public address for.
-    :type unit: juju.Unit
+    :param unit: The unit object to get the public address for.
+    :type unit: _JubilantUnitAdapter or similar
     :returns: the IP address of the unit.
     :rtype: Optional[str]
     """
     if model_name is None:
-        model_name = await async_get_juju_model()
-    cmd = "juju status --format=yaml -m {}".format(model_name)
-    result = await generic_utils.check_output(
-        cmd.split(), log_stderr=False, log_stdout=False)
-    status = yaml.safe_load(result['Stdout'])
+        model_name = get_juju_model()
+    status = get_status_jubilant(model_name)
     try:
         app = unit.name.split('/')[0]
-        return (
-            status['applications'][app]['units'][unit.name]['public-address'])
+        return status.apps[app].units[unit.name].public_address or None
     except KeyError:
-        logging.warn("Public address not found for %s", unit.name)
+        logging.warning("Public address not found for %s", unit.name)
         return None
 
 
@@ -879,37 +883,42 @@ async def async_get_status(model_name=None, interval=4.0, refresh=True):
     :rtype: dict
     """
     key = str(model_name)
-    model = None
 
-    async def _update_status_result(key):
-        nonlocal model
-        if model is None:
-            model = await get_model(model_name)
-        status = StatusResult(time.time(), await model.get_status())
+    def _update_status_result(key):
+        status = StatusResult(time.time(), get_status_jubilant(model_name))
         _GET_STATUS_TIMES[key] = status
         return status.result
 
     try:
         last = _GET_STATUS_TIMES[key]
     except KeyError:
-        return await _update_status_result(key)
+        return _update_status_result(key)
     now = time.time()
     if last.time + interval <= now:
-        # we need to refresh the status time, so let's do that.
-        return await _update_status_result(key)
-    # otherwise, if we need a refreshed version, then we have to wait;
+        return _update_status_result(key)
     if refresh:
-        # wait until the min interval is exceeded, and then grab a copy.
         await asyncio.sleep((last.time + interval) - now)
-        # now get the status.
-        # By passing refresh=False, this WILL return a cached status if another
-        # co-routine has already refreshed it.
-        return await async_get_status(model_name, interval, refresh=False)
-    # Not refreshing, so return the cached version
+        return _update_status_result(key)
     return last.result
 
 
 get_status = sync_wrapper(async_get_status)
+
+
+def get_status(model_name=None, **_kwargs):
+    """Return a libjuju-compatible status wrapper backed by jubilant.
+
+    Returns a :class:`_LibjujuStatusCompat` object which exposes
+    ``status.applications[app].status.status`` and
+    ``status.applications[app].units`` as expected by callers that were
+    written against the libjuju status shape (e.g. ``failure_report``).
+
+    :param model_name: Name of model to query.
+    :type model_name: Optional[str]
+    :returns: libjuju-compatible status wrapper
+    :rtype: _LibjujuStatusCompat
+    """
+    return _LibjujuStatusCompat(get_status_jubilant(model_name))
 
 
 class ActionFailed(Exception):
@@ -1373,12 +1382,10 @@ wait_for_agent_status = sync_wrapper(async_wait_for_agent_status)
 def is_unit_idle(unit):
     """Return True if the unit is in the idle state.
 
-    Note: the unit only makes progress (in terms of updating it's idle status)
-    if this function is called as part of an asyncio loop as the status is
-    updated in a co-routine/future.
-
-    :param unit: the unit to test
-    :type unit: :class:'juju.unit.Unit'
+    :param unit: the unit to test.  Can be a libjuju Unit (with
+        ``unit.data['agent-status']['current']``) or a
+        :class:`_JubilantUnitAdapter` (with ``unit.data['agent-status']``).
+    :type unit: object
     :returns: True if the unit is in the idle state
     :rtype: bool
     """
@@ -1393,7 +1400,7 @@ def is_unit_errored_from_install_hook(unit):
     """Return True if the unit is in error state from the install hook.
 
     :param unit: the unit to test
-    :type unit: :class:'juju.unit.Unit'
+    :type unit: object
     :returns: True if the unit is in the failed state and the workload status
               message indicates the install hook failed.
     :rtype: bool
@@ -1402,9 +1409,235 @@ def is_unit_errored_from_install_hook(unit):
         unit.workload_status_message == 'hook failed: "install"'
 
 
-async def async_wait_for_application_states(model_name=None, states=None,
-                                            timeout=2700, max_resolve_count=0,
-                                            ignore_hard_errors=False):
+class _JubilantUnitAdapter:
+    """Adapt a jubilant UnitStatus to look like a libjuju Unit.
+
+    Provides the ``workload_status``, ``workload_status_message``,
+    ``entity_id``, ``name``, ``application``, and ``data`` attributes
+    expected by the helper functions (``check_unit_workload_status``,
+    ``is_unit_idle``, etc.).
+    """
+
+    def __init__(self, unit_name: str, unit_status: UnitStatus):
+        self._name = unit_name
+        self._status = unit_status
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def entity_id(self) -> str:
+        return self._name
+
+    @property
+    def application(self) -> str:
+        return self._name.split('/')[0]
+
+    @property
+    def workload_status(self) -> str:
+        return self._status.workload_status.current
+
+    @property
+    def workload_status_message(self) -> str:
+        return self._status.workload_status.message
+
+    @property
+    def machine(self):
+        # jubilant UnitStatus.machine is a machine-id string; there is no
+        # per-unit machine status object like libjuju exposes.  Return None
+        # so that machines_in_state() skips machine-error checks.
+        return None
+
+    @property
+    def data(self) -> dict:
+        return {
+            'agent-status': {
+                'current': self._status.juju_status.current,
+            }
+        }
+
+
+class _JubilantModelAdapter:
+    """Adapt a jubilant Status to look like a libjuju Model.
+
+    Provides the ``units`` and ``applications`` attributes required by
+    ``check_model_for_hard_errors``, ``units_with_wl_status_state``, etc.
+    """
+
+    def __init__(self, status):
+        self._status = status
+
+    @property
+    def units(self) -> dict:
+        """Return a flat dict of unit_name -> _JubilantUnitAdapter."""
+        result = {}
+        for app_name, app_status in self._status.apps.items():
+            if not app_status.units:
+                continue
+            for unit_name, unit_status in app_status.units.items():
+                result[unit_name] = _JubilantUnitAdapter(unit_name,
+                                                         unit_status)
+        return result
+
+    @property
+    def applications(self) -> dict:
+        """Return a dict of app_name -> _JubilantAppAdapter."""
+        return {
+            app_name: _JubilantAppAdapter(app_name, app_status)
+            for app_name, app_status in self._status.apps.items()
+        }
+
+
+class _JubilantAppAdapter:
+    """Adapt a jubilant AppStatus to look like a libjuju Application."""
+
+    def __init__(self, app_name: str, app_status):
+        self._name = app_name
+        self._status = app_status
+
+    @property
+    def units(self) -> list:
+        """Return a list of _JubilantUnitAdapter for each unit."""
+        if not self._status.units:
+            return []
+        return [
+            _JubilantUnitAdapter(unit_name, unit_status)
+            for unit_name, unit_status in self._status.units.items()
+        ]
+
+
+class _LibjujuAppCompat:
+    """Thin wrapper over jubilant AppStatus exposing the libjuju attribute
+    shape used by external callers (e.g. ``failure_report``,
+    ``get_subordinate_units``):
+
+      - ``.status.status``           — workload status string
+      - ``.units``                   — dict of unit_name -> _LibjujuUnitCompat
+      - ``['units'][name].get('subordinates')`` — subordinate unit names dict
+    """
+
+    class _StatusInfo:
+        def __init__(self, current):
+            self.status = current  # libjuju uses .status not .current
+
+    class _LibjujuUnitCompat:
+        def __init__(self, unit_name, unit_status):
+            self.entity_id = unit_name
+            self.name = unit_name
+            self._unit_status = unit_status
+
+        @property
+        def workload_status(self):
+            return self._unit_status.workload_status.current
+
+        @property
+        def workload_status_message(self):
+            return self._unit_status.workload_status.message
+
+        @property
+        def agent_status(self):
+            return self._unit_status.juju_status.current
+
+        def get(self, key, default=None):
+            """Support dict-style .get() used by get_subordinate_units."""
+            if key == 'subordinates':
+                subs = self._unit_status.subordinates
+                if not subs:
+                    return default
+                # Return {sub_unit_name: {'charm': app_name}} as libjuju did.
+                return {
+                    sub_name: {'charm': sub_name.split('/')[0]}
+                    for sub_name in subs
+                }
+            return getattr(self, key, default)
+
+        def __getitem__(self, key):
+            result = self.get(key)
+            if result is None:
+                raise KeyError(key)
+            return result
+
+    def __init__(self, app_name, app_status):
+        self._app_name = app_name
+        self._app_status = app_status
+        self.status = self._StatusInfo(app_status.app_status.current)
+        self._units = {
+            unit_name: self._LibjujuUnitCompat(unit_name, unit_status)
+            for unit_name, unit_status in app_status.units.items()
+        }
+
+    @property
+    def units(self):
+        return self._units
+
+    def __getitem__(self, key):
+        if key == 'units':
+            return self._units
+        raise KeyError(key)
+
+
+class _LibjujuStatusCompat:
+    """Wrap a jubilant Status so that callers expecting the libjuju status
+    shape (``status.applications[app].status.status``) continue to work.
+    """
+
+    def __init__(self, jubilant_status):
+        self._status = jubilant_status
+
+    @property
+    def applications(self):
+        return {
+            app_name: _LibjujuAppCompat(app_name, app_status)
+            for app_name, app_status in self._status.apps.items()
+        }
+
+
+def get_status_jubilant(model_name=None):
+    """Return a jubilant Status for the given model.
+
+    Subordinate charms have no ``units`` in the raw jubilant output; instead
+    their unit statuses are nested under the principal unit's ``.subordinates``
+    dict.  This function collects those subordinate unit statuses and injects
+    them back into the matching subordinate ``AppStatus.units`` dict, so that
+    callers can treat principal and subordinate apps uniformly.
+
+    :param model_name: Name of model to query.
+    :type model_name: Optional[str]
+    :returns: jubilant Status object with subordinate units populated
+    :rtype: jubilant.statustypes.Status
+    """
+    juju = jubilant.Juju(model=model_name)
+    status = juju.status()
+
+    # Collect subordinate unit statuses scattered across principal units.
+    # subordinate_units maps  app_name -> {unit_name: UnitStatus}
+    subordinate_units: dict = {}
+    for app_status in status.apps.values():
+        for unit_status in app_status.units.values():
+            for sub_unit_name, sub_unit_status in unit_status.subordinates.items():
+                sub_app_name = sub_unit_name.split('/')[0]
+                subordinate_units.setdefault(sub_app_name, {})[
+                    sub_unit_name] = sub_unit_status
+
+    if not subordinate_units:
+        return status
+
+    # Rebuild the apps dict, replacing empty-units subordinate AppStatus
+    # objects with copies that carry the collected units.
+    new_apps = {}
+    for app_name, app_status in status.apps.items():
+        if app_name in subordinate_units and not app_status.units:
+            app_status = dataclasses.replace(
+                app_status, units=subordinate_units[app_name])
+        new_apps[app_name] = app_status
+
+    return dataclasses.replace(status, apps=new_apps)
+
+
+def wait_for_application_states(model_name=None, states=None,
+                                 timeout=2700, max_resolve_count=0,
+                                 ignore_hard_errors=False):
     """Wait for model to achieve the desired state.
 
     Check the workload status and workload status message for every unit of
@@ -1434,9 +1667,9 @@ async def async_wait_for_application_states(model_name=None, states=None,
        string passed.
      - "workload-status-message-regex" - the entire string matches if the regex
        matches.
-     - "workloaed-status-message" - DEPRECATED; use
+     - "workload-status-message" - DEPRECATED; use
        "workload-status-message-prefix" instead.
-     - "num-expected-units' - the number of units to be 'ready'.
+     - "num-expected-units" - the number of units to be 'ready'.
 
     To match an empty string, use:
 
@@ -1460,39 +1693,29 @@ async def async_wait_for_application_states(model_name=None, states=None,
         failures and is considered a temporary hack to work around underlying
         provider networking issues.
     :type max_resolve_count: int
-    :param ignore_hard_deploy_error: Whether to ignore charms going into an
-                                     error.
-    :type ignore_hard_deploy_error: Boolean
+    :param ignore_hard_errors: Whether to ignore charms going into an error.
+    :type ignore_hard_errors: bool
     """
     logging.info("Waiting for application states to reach targeted states.")
-    # Implementation note: model.block_until() can throw
-    # websockets.exceptions.ConnectionClosed if it detects that the connection
-    # is closed.  What we want to do then, is re-open the connection, and try
-    # again, hence this function uses block_until_auto_reconnect_model
     approved_message_prefixes = ['ready', 'Ready', 'Unit is ready']
     approved_statuses = ['active']
 
     if not states:
         states = {}
-    model = await get_model(model_name)
+
+    # Get initial status to discover applications present in the model.
+    status = get_status_jubilant(model_name)
+    model_adapter = _JubilantModelAdapter(status)
+
     if not ignore_hard_errors:
-        check_model_for_hard_errors(model)
-    logging.info("Waiting for an application to be present")
-    await block_until_auto_reconnect_model(
-        lambda: len(model.units) > 0,
-        model=model)
+        check_model_for_hard_errors(model_adapter)
 
     timeout_msg = (
         "Timed out waiting for '{unit_name}'. The {gate_attr} "
         "is '{unit_state}' which is not one of '{approved_states}'")
-    # Loop checking status every few seconds, waiting on applications to
-    # reach the approved states.  `applications_left` are the applications
-    # still to check.  If the timeout is exceeded we fail.  Note that there
-    # are other async futures in libjuju that make progress when this
-    # future sleeps.  We also need to check if the model has disconnected,
-    # and if so, clean up and reconnect.
+
     start = time.time()
-    applications_left = set(model.applications.keys())
+    applications_left = set(model_adapter.applications.keys())
 
     # print deprecation notices for apps that use "workload-status-message"
     for application in applications_left:
@@ -1511,17 +1734,32 @@ async def async_wait_for_application_states(model_name=None, states=None,
     # then this will fail hard.
     resolve_counts = collections.defaultdict(int)
     last_report = time.time()
-    while True:
-        # now we sleep to allow progress to be made in the libjuju futures
-        await asyncio.sleep(0.5)
 
-        await ensure_model_connected(model)
+    # Silence jubilant's per-call INFO log ("cli: juju status ...") while
+    # polling; it would flood the log on every iteration.
+    jubilant_logger = logging.getLogger('jubilant')
+    orig_jubilant_level = jubilant_logger.level
+
+    while True:
+        time.sleep(1.0)
+
+        # Refresh status on every iteration, suppressing the jubilant CLI
+        # log line to DEBUG so it doesn't flood at INFO level.
+        jubilant_logger.setLevel(logging.WARNING)
+        try:
+            status = get_status_jubilant(model_name)
+        finally:
+            jubilant_logger.setLevel(orig_jubilant_level)
+        model_adapter = _JubilantModelAdapter(status)
+
         timed_out = int(time.time() - start) > timeout
         issues = []
         for application in applications_left.copy():
             check_info = states.get(application, {})
-            app_data = model.applications.get(application, None)
-            units = list(app_data.units)
+            app_adapter = model_adapter.applications.get(application, None)
+            if app_adapter is None:
+                continue
+            units = app_adapter.units
 
             # if there are no units then the application may not be ready.
             # However, if the caller explicitly allows that situation then
@@ -1571,7 +1809,7 @@ async def async_wait_for_application_states(model_name=None, states=None,
 
                 try:
                     ok = check_unit_workload_status(
-                        model, unit, check_wl_statuses)
+                        model_adapter, unit, check_wl_statuses)
                     all_okay = all_okay and ok
                     if not ok and timed_out:
                         issues.append(
@@ -1581,7 +1819,8 @@ async def async_wait_for_application_states(model_name=None, states=None,
                                 unit_state=unit.workload_status,
                                 approved_states=check_wl_statuses))
                     ok = check_unit_workload_status_message(
-                        model, unit, prefixes=prefixes, regex=check_regex)
+                        model_adapter, unit, prefixes=prefixes,
+                        regex=check_regex)
                     all_okay = all_okay and ok
                     if not ok and timed_out:
                         issues.append(
@@ -1615,13 +1854,13 @@ async def async_wait_for_application_states(model_name=None, states=None,
                             logging.warning("Unit %s is in error state. "
                                             "Attempt number %d to resolve" %
                                             (u.name, resolve_counts[u.name]))
-                            await async_resolve_units(
+                            resolve_units(
                                 application_name=unit.application,
                                 erred_hook='install'
                             )
                             # wait until the unit is executing. 60 seconds
                             # seems like a reasonable timeout
-                            await async_block_until_unit_wl_status(
+                            block_until_unit_wl_status(
                                 u.name, 'error', model_name, negate_match=True,
                                 timeout=60
                             )
@@ -1656,7 +1895,9 @@ async def async_wait_for_application_states(model_name=None, states=None,
             raise ModelTimeout("Work state not achieved within timeout.")
 
 
-wait_for_application_states = sync_wrapper(async_wait_for_application_states)
+# Backward-compat alias: downstream code that calls async_wait_for_application_states
+# directly (e.g. via sync_wrapper) will still work.
+async_wait_for_application_states = wait_for_application_states
 
 
 async def async_block_until_all_units_idle(model_name=None, timeout=2700,
@@ -1675,18 +1916,27 @@ async def async_block_until_all_units_idle(model_name=None, timeout=2700,
                                      error state.
     :type ignore_hard_deploy_error: Boolean
     """
-    model = await get_model(model_name)
-    await block_until_auto_reconnect_model(
-        lambda: units_with_wl_status_state(
-            model, 'error') or model.all_units_idle(),
-        model=model,
-        timeout=timeout)
-    errored_units = units_with_wl_status_state(model, 'error')
-    if errored_units:
-        if ignore_hard_errors:
-            logging.warning("Units {} in error state. ".format(errored_units))
-        else:
-            raise UnitError(errored_units)
+    start = time.time()
+    while True:
+        status = get_status_jubilant(model_name)
+        model_adapter = _JubilantModelAdapter(status)
+        errored_units = units_with_wl_status_state(model_adapter, 'error')
+        if errored_units:
+            if ignore_hard_errors:
+                logging.warning(
+                    "Units {} in error state. ".format(errored_units))
+            else:
+                raise UnitError(errored_units)
+        non_idle = [
+            u for u in model_adapter.units.values()
+            if not is_unit_idle(u)
+        ]
+        if not non_idle:
+            return
+        if int(time.time() - start) > timeout:
+            raise ModelTimeout(
+                "Timed out waiting for all units to become idle.")
+        time.sleep(1.0)
 
 block_until_all_units_idle = sync_wrapper(async_block_until_all_units_idle)
 

--- a/zaza/model.py
+++ b/zaza/model.py
@@ -20,11 +20,11 @@ mostly via libjuju. Async function also provice a non-async alternative via
 """
 
 import asyncio
-from async_generator import async_generator, yield_, asynccontextmanager
 import collections
 import dataclasses
 import datetime
 import inspect
+import juju.client.jujudata
 import logging
 import os
 import re
@@ -46,12 +46,11 @@ from jubilant.statustypes import (
     AppStatus,
     ModelStatus,
     UnitStatus
-) 
+)
 from zaza import sync_wrapper
 import zaza.utilities.generic as generic_utils
 import zaza.utilities.juju as juju_utils
 import zaza.utilities.exceptions as zaza_exceptions
-from zaza.utilities import deprecate
 
 # Default for the Juju MAX_FRAME_SIZE to be 256MB to stop
 # "RPC: Connection closed, reconnecting" errors and then a failure in the log.
@@ -140,8 +139,6 @@ def get_juju_model():
     return CURRENT_MODEL
 
 
-
-
 def deployed(model_name: Optional[str] = None) -> List[str]:
     """List deployed applications.
 
@@ -152,6 +149,7 @@ def deployed(model_name: Optional[str] = None) -> List[str]:
     status = model.status()
     # list currently deployed services
     return list(status.apps.keys())
+
 
 sync_deployed = deployed
 
@@ -174,7 +172,6 @@ def get_unit_from_name(unit_name: str,
     :raises: UnitNotFound
     """
     app = unit_name.split('/')[0]
-    unit = None
     try:
         model = get_juju_model()
         status = model.status()
@@ -197,9 +194,11 @@ ModelRefs = {}
 
 
 class ZazaJujuModel(jubilant.Juju):
+    """Thin subclass of jubilant.Juju with convenience properties."""
 
     @property
     def applications(self) -> dict[str, AppStatus]:
+        """Return a dict of application name to AppStatus."""
         return self.status().apps
 
 
@@ -216,7 +215,7 @@ def get_model(model_name: Optional[str] = None):
     if not model_name:
         model_name = get_juju_model()
     return ZazaJujuModel(model=model_name)
-    
+
 
 def is_model_disconnected(model):
     """Return True if the model is disconnected.
@@ -292,7 +291,8 @@ def block_until_auto_reconnect_model(*conditions,
         elapsed_time = time.time() - start_time
         if timeout and elapsed_time > timeout:
             raise TimeoutError(
-                f"Timed out after {elapsed_time} seconds (expected max {timeout} seconds)."
+                "Timed out after {} seconds (expected max {} seconds).".format(
+                    elapsed_time, timeout)
             )
 
 
@@ -335,7 +335,7 @@ def scp_to_unit(unit_name, source, destination, model_name=None,
 
 def scp_to_all_units(application_name, source, destination,
                      model_name=None, user='ubuntu', proxy=False,
-                                 scp_opts=''):
+                     scp_opts=''):
     """Transfer files to all units of an application.
 
     :param model_name: Name of model unit is in
@@ -427,7 +427,8 @@ def _normalise_action_results(results):
         return {}
 
 
-def exec_on_unit(unit_name, command, model_name=None, timeout=None) -> Dict[str, str]:
+def exec_on_unit(unit_name, command, model_name=None,
+                 timeout=None) -> Dict[str, str]:
     """Juju exec on unit.
 
     :param model_name: Name of model unit is in
@@ -442,7 +443,7 @@ def exec_on_unit(unit_name, command, model_name=None, timeout=None) -> Dict[str,
     :rtype: dict
     """
     model = get_model(model_name)
-    unit = get_unit_from_name(unit_name, model_name=model_name)
+    get_unit_from_name(unit_name, model_name=model_name)
 
     task = model.exec(command, unit=unit_name, wait=timeout)
 
@@ -902,9 +903,6 @@ async def async_get_status(model_name=None, interval=4.0, refresh=True):
     return last.result
 
 
-get_status = sync_wrapper(async_get_status)
-
-
 def get_status(model_name=None, **_kwargs):
     """Return a libjuju-compatible status wrapper backed by jubilant.
 
@@ -1004,20 +1002,11 @@ async def async_run_action(unit_name, action_name, model_name=None,
     if action_params is None:
         action_params = {}
 
-    model = await get_model(model_name)
-    unit = await async_get_unit_from_name(unit_name, model)
-    action_obj = await unit.run_action(action_name, **action_params)
-    await action_obj.wait()
-    action_obj = _normalise_action_object(action_obj)
-    await async_update_unknown_action_status(model, action_obj)
-
-    if raise_on_failure and action_obj.data['status'] != 'completed':
-        try:
-            output = await model.get_action_output(action_obj.id)
-        except KeyError:
-            output = None
-        raise ActionFailed(action_obj, output=output)
-    return action_obj
+    juju_model = get_model(model_name)
+    task = juju_model.run_action(unit_name, action_name, **action_params)
+    if raise_on_failure and task.return_code != 0:
+        raise ActionFailed(task)
+    return task
 
 run_action = sync_wrapper(async_run_action)
 
@@ -1044,22 +1033,12 @@ async def async_run_action_on_leader(application_name, action_name,
     if action_params is None:
         action_params = {}
 
-    model = await get_model(model_name)
-    for unit in model.applications[application_name].units:
-        is_leader = await unit.is_leader_from_status()
-        if is_leader:
-            action_obj = await unit.run_action(action_name,
-                                               **action_params)
-            await action_obj.wait()
-            action_obj = _normalise_action_object(action_obj)
-            await async_update_unknown_action_status(model, action_obj)
-            if raise_on_failure and action_obj.data['status'] != 'completed':
-                try:
-                    output = await model.get_action_output(action_obj.id)
-                except KeyError:
-                    output = None
-                raise ActionFailed(action_obj, output=output)
-            return action_obj
+    juju_model = get_model(model_name)
+    lead_unit = get_lead_unit_name(application_name, model_name=model_name)
+    task = juju_model.run_action(lead_unit, action_name, **action_params)
+    if raise_on_failure and task.return_code != 0:
+        raise ActionFailed(task)
+    return task
 
 run_action_on_leader = sync_wrapper(async_run_action_on_leader)
 
@@ -1091,29 +1070,15 @@ async def async_run_action_on_units(units, action_name, action_params=None,
     if action_params is None:
         action_params = {}
 
-    model = await get_model(model_name)
-    actions = []
+    juju_model = get_model(model_name)
+    tasks = []
     for unit_name in units:
-        unit = await async_get_unit_from_name(unit_name, model)
-        action_obj = await unit.run_action(action_name, **action_params)
-        actions.append(action_obj)
+        task = juju_model.run_action(unit_name, action_name, **action_params)
+        tasks.append((unit_name, task))
 
-    async def _check_actions():
-        for action_obj in actions:
-            if action_obj.data['status'] in ['running', 'pending']:
-                return False
-        return True
-
-    await async_block_until(_check_actions, timeout=timeout)
-
-    for action_obj in actions:
-        await async_update_unknown_action_status(model, action_obj)
-        if raise_on_failure and action_obj.data['status'] != 'completed':
-            try:
-                output = await model.get_action_output(action_obj.id)
-            except KeyError:
-                output = None
-            raise ActionFailed(action_obj, output=output)
+    for unit_name, task in tasks:
+        if raise_on_failure and task.return_code != 0:
+            raise ActionFailed(task)
 
 run_action_on_units = sync_wrapper(async_run_action_on_units)
 
@@ -1508,8 +1473,9 @@ class _JubilantAppAdapter:
 
 
 class _LibjujuAppCompat:
-    """Thin wrapper over jubilant AppStatus exposing the libjuju attribute
-    shape used by external callers (e.g. ``failure_report``,
+    """Wrap jubilant AppStatus to expose the libjuju attribute shape.
+
+    Used by external callers (e.g. ``failure_report``,
     ``get_subordinate_units``):
 
       - ``.status.status``           — workload status string
@@ -1519,6 +1485,7 @@ class _LibjujuAppCompat:
 
     class _StatusInfo:
         def __init__(self, current):
+            """Initialise with the current workload status string."""
             self.status = current  # libjuju uses .status not .current
 
     class _LibjujuUnitCompat:
@@ -1540,7 +1507,7 @@ class _LibjujuAppCompat:
             return self._unit_status.juju_status.current
 
         def get(self, key, default=None):
-            """Support dict-style .get() used by get_subordinate_units."""
+            """Support dict-style access used by get_subordinate_units."""
             if key == 'subordinates':
                 subs = self._unit_status.subordinates
                 if not subs:
@@ -1578,8 +1545,10 @@ class _LibjujuAppCompat:
 
 
 class _LibjujuStatusCompat:
-    """Wrap a jubilant Status so that callers expecting the libjuju status
-    shape (``status.applications[app].status.status``) continue to work.
+    """Wrap jubilant Status to expose the libjuju status shape.
+
+    Ensures that callers expecting ``status.applications[app].status.status``
+    continue to work.
     """
 
     def __init__(self, jubilant_status):
@@ -1615,10 +1584,10 @@ def get_status_jubilant(model_name=None):
     subordinate_units: dict = {}
     for app_status in status.apps.values():
         for unit_status in app_status.units.values():
-            for sub_unit_name, sub_unit_status in unit_status.subordinates.items():
-                sub_app_name = sub_unit_name.split('/')[0]
+            for sub_name, sub_status in unit_status.subordinates.items():
+                sub_app_name = sub_name.split('/')[0]
                 subordinate_units.setdefault(sub_app_name, {})[
-                    sub_unit_name] = sub_unit_status
+                    sub_name] = sub_status
 
     if not subordinate_units:
         return status
@@ -1636,8 +1605,8 @@ def get_status_jubilant(model_name=None):
 
 
 def wait_for_application_states(model_name=None, states=None,
-                                 timeout=2700, max_resolve_count=0,
-                                 ignore_hard_errors=False):
+                                timeout=2700, max_resolve_count=0,
+                                ignore_hard_errors=False):
     """Wait for model to achieve the desired state.
 
     Check the workload status and workload status message for every unit of
@@ -1895,8 +1864,9 @@ def wait_for_application_states(model_name=None, states=None,
             raise ModelTimeout("Work state not achieved within timeout.")
 
 
-# Backward-compat alias: downstream code that calls async_wait_for_application_states
-# directly (e.g. via sync_wrapper) will still work.
+# Backward-compat alias: downstream code that calls
+# async_wait_for_application_states directly (e.g. via sync_wrapper) will
+# still work.
 async_wait_for_application_states = wait_for_application_states
 
 
@@ -2053,13 +2023,13 @@ async def async_block_until_service_status(unit_name, services, target_status,
     :param timeout: Time to wait for status to be achieved
     :type timeout: int
     """
-    async def _check_service():
+    def _check_service():
         for service in services:
             if pgrep_full:
                 command = r"pgrep -f '{}'".format(service)
             else:
                 command = r"pidof -x '{}'".format(service)
-            out = await async_run_on_unit(
+            out = exec_on_unit(
                 unit_name,
                 command,
                 model_name=model_name,
@@ -2071,7 +2041,7 @@ async def async_block_until_service_status(unit_name, services, target_status,
                 return False
         return True
 
-    await async_block_until(_check_service, timeout=timeout)
+    block_until(_check_service, timeout=timeout)
 
 block_until_service_status = sync_wrapper(async_block_until_service_status)
 
@@ -2106,11 +2076,7 @@ async def async_get_current_model():
     # NOTE(tinwood): Due to https://github.com/juju/python-libjuju/issues/458
     # set the max frame size to something big to stop
     # "RPC: Connection closed, reconnecting" messages and then failures.
-    model = Model(max_frame_size=JUJU_MAX_FRAME_SIZE)
-    await model.connect()
-    model_name = model.info.name
-    await model.disconnect()
-    return model_name
+    return get_juju_model()
 
 
 get_current_model = sync_wrapper(async_get_current_model)
@@ -2159,10 +2125,10 @@ def file_contents(unit_name, path, timeout=None):
     app, unit_id = unit_name.split("/")
     if unit_id == "leader":
         target = app
-        run_func = run_on_leader
+        run_func = exec_on_leader
     else:
         target = unit_name
-        run_func = run_on_unit
+        run_func = exec_on_unit
     cmd = "cat {}".format(path)
     result = run_func(target, cmd, timeout=timeout)
     err = result.get("Stderr")
@@ -2256,7 +2222,7 @@ async def async_block_until_file_ready(application_name, remote_file,
             # cannot differentiate between a connectivity issue and a
             # target file not existing error. For now just assume the
             # latter.
-            except JujuError:
+            except zaza_exceptions.JujuError:
                 return False
         else:
             return True
@@ -2382,7 +2348,6 @@ async def async_block_until_file_missing(
             try:
                 output = await generic_utils.unit_run(
                     unit, 'test -e "{}"; echo $?'.format(path))
-                output = _normalise_action_object(output)
                 output_result = _normalise_action_results(
                     output.data.get('results', {}))
                 contents = output_result.get('Stdout', '')
@@ -2391,7 +2356,7 @@ async def async_block_until_file_missing(
             # cannot differentiate between a connectivity issue and a
             # target file not existing error. For now just assume the
             # latter.
-            except JujuError:
+            except zaza_exceptions.JujuError:
                 results.append(False)
         return all(results)
 
@@ -2434,7 +2399,7 @@ async def async_block_until_file_missing_on_machine(
         # cannot differentiate between a connectivity issue and a
         # target file not existing error. For now just assume the
         # latter.
-        except JujuError:
+        except zaza_exceptions.JujuError:
             pass
         return False
 
@@ -2589,13 +2554,14 @@ async def async_block_until_services_restarted(application_name, mtime,
                        a service.
     :type  pgrep_full: bool
     """
-    async def _check_service(model):
-        units = model.applications[application_name].units
-        for unit in units:
+    def _check_service():
+        juju_model = get_model(model_name)
+        units = juju_model.applications[application_name].units
+        for unit_name, unit_status in units.items():
             for service in services:
                 try:
-                    svc_mtime = await async_get_unit_service_start_time(
-                        unit.entity_id,
+                    svc_mtime = get_unit_service_start_time(
+                        unit_name,
                         service,
                         timeout=timeout,
                         model_name=model_name,
@@ -2606,8 +2572,7 @@ async def async_block_until_services_restarted(application_name, mtime,
                     return False
         return True
 
-    model = await get_model(model_name)
-    await async_block_until(lambda: _check_service(model), timeout=timeout)
+    block_until(_check_service, timeout=timeout)
 
 
 block_until_services_restarted = sync_wrapper(


### PR DESCRIPTION
Replace the libjuju-based async machinery with jubilant, a synchronous
CLI wrapper around the juju binary.  The public API surface is preserved
so that downstream consumers (e.g. zaza-openstack-tests) continue to
work without changes.

* Remove the libjuju background-thread infrastructure: event loop
  management, _libjuju_thread/_libjuju_loop globals, libjuju_thread_run(),
  get_or_create_libjuju_thread(), join_libjuju_thread(),
  clean_up_libjuju_thread(), and run_coroutine_threadsafe().
* Set RUN_LIBJUJU_IN_THREAD = False (no-op constant kept for compat).
* Rewrite sync_wrapper() as a transparent pass-through: if the wrapped
  callable returns a coroutine it is drained with a fresh event loop;
  otherwise the result is returned directly.  This allows async functions
  that have not yet been rewritten to keep working without a background
  thread.
* Retain clean_up_libjuju_thread() / join_libjuju_thread() /
  get_or_create_libjuju_thread() as no-op stubs for downstream compat.

* Rewrite all functions using jubilant.Juju() instead of libjuju:
  - add_model(): jubilant.Juju().cli('add-model', ...)
  - destroy_model(): polling loop with jubilant.Juju().cli('destroy-model')
  - list_models(): jubilant.Juju().cli('models', '--format', 'json')
  - cloud() / get_cloud(): jubilant.Juju().cli('clouds', '--format', 'json')
* Remove all async/await keywords; functions are now plain synchronous.

* Fix pre-existing syntax errors: 'model_name=None: Optional[str]'
  corrected to 'model_name: Optional[str] = None' in deployed(),
  get_unit_from_name(), get_model(), scp_to_unit().
* Fix incorrect import: ModelInfo -> ModelStatus from jubilant.
* Add 'import dataclasses' at the top level.
* Add get_status_jubilant(model_name=None):
  - Calls jubilant.Juju(model=model_name).status().
  - Collects subordinate unit statuses from each principal unit's
    .subordinates dict and injects them back into the subordinate
    application's units dict using dataclasses.replace() (required
    because jubilant Status is a frozen dataclass).
  - Returns a fully-populated jubilant Status object.
* Add adapter classes for the wait_for_application_states polling loop:
  - _JubilantUnitAdapter: wraps jubilant UnitStatus; exposes
    workload_status (str), workload_status_message, entity_id, name,
    application, machine (None), data (agent-status dict).
  - _JubilantAppAdapter: wraps jubilant AppStatus; .units returns a
    list of _JubilantUnitAdapter objects.
  - _JubilantModelAdapter: wraps jubilant Status; exposes .units (flat
    dict across all apps) and .applications (dict of _JubilantAppAdapter).
* Add libjuju-compatibility wrappers for callers of get_status():
  - _LibjujuUnitCompat: exposes .get('subordinates') and dict-style
    access to unit fields.
  - _LibjujuAppCompat: exposes .status.status and ['units'] dict.
  - _LibjujuStatusCompat: exposes .applications dict of _LibjujuAppCompat.
* Override get_status() to return _LibjujuStatusCompat(get_status_jubilant())
  so that callers such as failure_report() and get_subordinate_units()
  continue to work unchanged.
* Rewrite wait_for_application_states() as a fully synchronous polling
  loop:
  - Uses time.sleep(1.0) between iterations instead of asyncio.sleep.
  - Calls get_status_jubilant() each iteration; temporarily suppresses
    jubilant's per-call INFO log (set logger to WARNING) to avoid noise.
  - Uses _JubilantModelAdapter for unit/app access.
  - Alias async_wait_for_application_states = wait_for_application_states
    for backward compatibility.
* Rewrite async_get_units() to use get_status_jubilant(); returns a list
  of _JubilantUnitAdapter objects.
* Rewrite async_get_lead_unit() to use get_status_jubilant(); identifies
  the leader via UnitStatus.leader.
* Rewrite async_get_unit_public_address__fallback() to use
  get_status_jubilant() and UnitStatus.public_address.

* Remove tests for the removed async-thread machinery.
* Add tests for the new sync_wrapper behaviour (plain return, coroutine
  drain, nested wrapping).

* Replace all libjuju mock scaffolding with jubilant mocks.
* Tests now patch jubilant.Juju and its .cli() / .status() methods.

* Add _make_jubilant_status() helper to build mock jubilant Status
  objects.
* Rewrite _application_states_setup() to patch get_status_jubilant,
  time.time, and time.sleep instead of libjuju model/connect mocks.
* Update all test_wait_for_application_states_* tests to use the new
  sync polling loop and jubilant mock objects.
* Fix patching targets: resolve_units / block_until_unit_wl_status
  (not their async_ aliases).

* tests/tests.yaml: update magpie-jammy workload-status-message-prefix
  to match current charm output ('Ready, with 1 peer').
* tests/bundles/first.yaml: update top-level series to 'noble'.

Co-authored-by: GitHub Copilot <copilot@github.com>
Signed-off-by: Felipe Reyes <felipe.reyes@canonical.com>
