### PR TITLE
fix: pin setuptools<82 for pkg_resources module

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -21,3 +21,6 @@ tenacity>8.2.0
 juju
 # https://github.com/go-macaroon-bakery/py-macaroon-bakery/issues/94
 macaroonbakery!=1.3.3
+
+# https://github.com/openstack-charmers/zaza/issues/691
+setuptools<82


### PR DESCRIPTION
fixes #691

With this, charm-magnum func tests pass on master.