### PR TITLE
Add bits to release zaza as a python package

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -124,7 +124,9 @@ jobs:
         juju models
         model=$(juju models --format yaml|grep "^- name:.*zaza"|cut -f2 -d/)
         juju status -m $model | tee logs/juju-status.txt
-        juju-crashdump -m $model -o logs/
+        juju status -m controller | tee logs/juju-status-controller.txt
+        juju-crashdump --as-root -m $model -o logs/
+        juju-crashdump --as-root -m controller -o logs/
     - name: upload logs on failure
       if: failure()
       uses: actions/upload-artifact@v4

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -131,6 +131,7 @@ jobs:
       with:
         name: test-run-logs-and-crashdump
         path: logs/
-    - name: consider debugging
-      uses: lhotari/action-upterm@v1
-      if: failure()
+    # # disable upterm
+    # - name: consider debugging
+    #   uses: lhotari/action-upterm@v1
+    #   if: failure()

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -28,6 +28,18 @@ jobs:
       run: |
         set -euxo pipefail
         codecov --verbose --gcov-glob unit_tests/*
+    - name: Build python package
+      run: |
+        set -euxo pipefail
+        tox -e build
+    - name: Validate the python package can be installed
+      run: |
+        set -euxo pipefail
+        VENV=$(mktemp -d)
+        python3 -m venv $VENV
+        source $VENV/bin/activate
+        pip install dist/*.tar.gz
+        functest-run-suite --help
   func:
     runs-on: ubuntu-latest
     strategy:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,6 @@
 [metadata]
 name = zaza
 summary = A Python3-only functional test framework for OpenStack Charms
-version = 0.0.2.dev1
 description_file =
     README.rst
 author = OpenStack Charmers

--- a/setup.py
+++ b/setup.py
@@ -102,6 +102,8 @@ if sys.argv[-1] == 'tag':
 
 
 setup(
+    use_scm_version=True,
+    setup_requires=['setuptools_scm'],
     entry_points={
         'console_scripts': [
             'functest-run-suite = zaza.charm_lifecycle.func_test_runner:main',

--- a/tests/bundles/first.yaml
+++ b/tests/bundles/first.yaml
@@ -13,9 +13,8 @@ applications:
   ubuntu:
     charm: ch:ubuntu
     num_units: 3
-  ntp:
-    charm: ch:ntp
+  local-users:
+    charm: ch:local-users
     num_units: 0
 relations:
-  - - ubuntu
-    - ntp
+  - [ubuntu, local-users]

--- a/tests/bundles/second.yaml
+++ b/tests/bundles/second.yaml
@@ -8,9 +8,8 @@ applications:
   ubuntu:
     charm: ch:ubuntu
     num_units: 3
-  ntp:
-    charm: ch:ntp
+  local-users:
+    charm: ch:local-users
     num_units: 0
 relations:
-  - - ubuntu
-    - ntp
+  - [ubuntu, local-users]

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -14,9 +14,9 @@ target_deploy_status:
     workload-status-message-prefix: icmp ok, local hostname ok
   ubuntu:
     workload-status-message-regex: "^$"
-  ntp:
+  local-users:
     workload-status: active
-    workload-status-message-prefix: 'chrony: Ready'
+    workload-status-message-prefix: ''
 configure:
 - zaza.charm_tests.noop.setup.basic_setup
 tests:

--- a/tox.ini
+++ b/tox.ini
@@ -68,3 +68,15 @@ commands =
 basepython = python3
 commands =
     remove-placement {posargs}
+
+[testenv:build]
+basepython = python3
+deps = build
+commands =
+    python3 -m build -s
+
+[testenv:upload]
+basepython = python3
+deps = twine
+commands =
+    python3 -m twine upload dist/*

--- a/unit_tests/test_zaza_model.py
+++ b/unit_tests/test_zaza_model.py
@@ -33,6 +33,7 @@ import collections
 import concurrent
 import datetime
 import mock
+import tenacity
 import pytest
 import yaml
 
@@ -498,6 +499,78 @@ class TestModel(ut_utils.BaseTestCase):
             self.mymodel.disconnect.assert_called_once_with()
             self.mymodel.connect_model.assert_called_once_with(
                 self.mymodel.info.name)
+
+    def test_ensure_model_connected_reconnects_successfully(self):
+        """Reconnects on first attempt when model is disconnected."""
+        self.patch_object(model, 'is_model_disconnected', return_value=True)
+
+        async def _connect_model(*args):
+            return
+
+        self.mymodel.disconnect.side_effect = None
+        self.mymodel.connect_model.side_effect = _connect_model
+
+        async def _wrapper():
+            await model.ensure_model_connected(self.mymodel)
+
+        with mock.patch.object(zaza, 'RUN_LIBJUJU_IN_THREAD', new=False):
+            model.sync_wrapper(_wrapper)()
+            self.mymodel.connect_model.assert_called_once_with(
+                self.mymodel.info.name)
+
+    def test_ensure_model_connected_retries_then_succeeds(self):
+        """Retries connect_model and succeeds on 3rd attempt."""
+        self.patch_object(model, 'is_model_disconnected', return_value=True)
+
+        call_count = {'n': 0}
+
+        async def _connect_model_flaky(*args):
+            call_count['n'] += 1
+            if call_count['n'] < 3:
+                raise Exception("Temporary failure")
+
+        self.mymodel.disconnect.side_effect = None
+        self.mymodel.connect_model.side_effect = _connect_model_flaky
+
+        async def _wrapper():
+            await model.ensure_model_connected(self.mymodel)
+
+        with mock.patch('tenacity.wait_fixed',
+                        return_value=tenacity.wait_none()):
+            with mock.patch.object(zaza, 'RUN_LIBJUJU_IN_THREAD', new=False):
+                model.sync_wrapper(_wrapper)()
+                self.assertEqual(self.mymodel.connect_model.call_count, 3)
+
+    def test_ensure_model_connected_raises_model_timeout_after_retries(self):
+        """Raises ModelTimeout when all 5 reconnect attempts fail."""
+        self.patch_object(model, 'is_model_disconnected', return_value=True)
+
+        async def _connect_model_always_fails(*args):
+            raise Exception("Connection refused")
+
+        self.mymodel.disconnect.side_effect = None
+        self.mymodel.connect_model.side_effect = _connect_model_always_fails
+
+        async def _wrapper():
+            await model.ensure_model_connected(self.mymodel)
+
+        with mock.patch('tenacity.wait_fixed',
+                        return_value=tenacity.wait_none()):
+            with mock.patch.object(zaza, 'RUN_LIBJUJU_IN_THREAD', new=False):
+                with self.assertRaises(model.ModelTimeout):
+                    model.sync_wrapper(_wrapper)()
+                self.assertEqual(self.mymodel.connect_model.call_count, 5)
+
+    def test_ensure_model_connected_no_reconnect_when_connected(self):
+        """Does nothing when model is already connected."""
+        self.patch_object(model, 'is_model_disconnected', return_value=False)
+
+        async def _wrapper():
+            await model.ensure_model_connected(self.mymodel)
+
+        with mock.patch.object(zaza, 'RUN_LIBJUJU_IN_THREAD', new=False):
+            model.sync_wrapper(_wrapper)()
+            self.mymodel.connect_model.assert_not_called()
 
     def _mocks_for_block_until_auto_reconnect_model(
             self, is_connected=True, is_open=True):

--- a/zaza/charm_tests/libjuju/tests.py
+++ b/zaza/charm_tests/libjuju/tests.py
@@ -57,8 +57,9 @@ class RegressionTest(unittest.TestCase):
         logging.info('Get the list of subordinates.')
         units = [u.entity_id for u in zaza.model.get_units('ubuntu')]
         logging.info('principal units found: %s', units)
-        subordinate = juju_utils.get_subordinate_units([units[0]],
-                                                       charm_name='ntp')
+        subordinate = juju_utils.get_subordinate_units(
+            [units[0]], charm_name='local-users'
+        )
         logging.info('subordinate(s) found %s for principal %s',
                      subordinate, units[0])
         self.assertEqual(len(subordinate), 1)

--- a/zaza/model.py
+++ b/zaza/model.py
@@ -32,6 +32,7 @@ import tempfile
 import yaml
 from oslo_config import cfg
 import concurrent
+import tenacity
 import time
 
 import juju.client
@@ -341,7 +342,22 @@ async def ensure_model_connected(model):
             # model.connection().is_open may be false
             pass
         logging.warning("Attempting to reconnect model %s", model_name)
-        await model.connect_model(model_name)
+        try:
+            i = 0
+            async for attempt in tenacity.AsyncRetrying(
+                    stop=tenacity.stop_after_attempt(5),
+                    wait=tenacity.wait_fixed(5),
+                    reraise=True):
+                with attempt:
+                    logging.info(
+                        "Reconnect attempt #%s for model %s",
+                        i + 1, model_name)
+                    await model.connect_model(model_name)
+                    i += 1
+        except Exception as e:
+            logging.error("Failed to reconnect model %s: %s", model_name, e)
+            raise ModelTimeout("Failed to reconnect model {}: {}".format(
+                model_name, e))
 
 
 async def block_until_auto_reconnect_model(*conditions,


### PR DESCRIPTION
This pull request introduces the necessary infrastructure to release zaza as a proper Python package on PyPI, enabling consumers to pin version ranges (e.g., zaza<2024.2.0) for better dependency management across OpenStack charm releases.

Key changes included:

- setuptools-scm integration — the package version is now derived automatically from Git tags, removing the need for manual version bumping.
- tox environments for build and upload — tox -e build and tox -e upload streamline the release workflow.
- Replaced ntp with local-users charm in testing bundles — ntp/chrony fails in containerised environments (where system clock control is disabled), making it inappropriate for our CI setup.
- Retry logic for model reconnection — uses tenacity to retry reconnecting to a model, improving resilience in flaky environments.
- Controller model log capture — logs from the controller model are now captured for better observability during test runs.
- Disabled upterm in CI workflow.

Motivation:

As the OpenStack charm ecosystem matures, consumers need a reliable way to pin zaza to specific release series (e.g., Caracal). Publishing versioned packages to PyPI makes this straightforward and aligns zaza with standard Python packaging practices.

Please review and let me know if any adjustments are needed. CI is green (modulo the pre-existing ntp container issue, which this PR also fixes).