### PR TITLE
Add full Python 3.14 compatibility support

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.10', '3.11', '3.12', '3.14']
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,7 @@ classifier =
     Topic :: System :: Installation/Setup
     Topic :: System :: Software Distribution
     Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.14
     License :: OSI Approved :: Apache Software License
 
 [build_sphinx]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pep8,py3
+envlist = pep8,py3,py314
 skipsdist = False
 
 # NOTE: https://wiki.canonical.com/engineering/OpenStack/InstallLatestToxOnOsci
@@ -30,6 +30,9 @@ pass_env =
 
 [testenv:py3]
 basepython = python3
+
+[testenv:py314]
+basepython = python3.14
 
 [testenv:pep8]
 basepython = python3

--- a/zaza/__init__.py
+++ b/zaza/__init__.py
@@ -58,6 +58,43 @@ _libjuju_run = False
 LOOP_CLOSE_TIMEOUT = 30.0
 
 
+def _get_or_create_event_loop():
+    """Return a usable event loop for the current thread."""
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+
+    if loop.is_closed():
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+
+    return loop
+
+
+def _attach_child_watcher(loop):
+    """Attach the child watcher to a loop when the API is available."""
+    get_child_watcher = getattr(asyncio, "get_child_watcher", None)
+    if get_child_watcher is None:
+        return
+    try:
+        get_child_watcher().attach_loop(loop)
+    except (RuntimeError, NotImplementedError, AttributeError):
+        # Child watcher management is platform and policy specific.
+        return
+
+
+def close_local_event_loop():
+    """Close the current thread event loop if one exists."""
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        return
+    if not loop.is_closed():
+        loop.close()
+
+
 def get_or_create_libjuju_thread():
     """Get (or Create) the thread that libjuju asyncio is running in.
 
@@ -80,7 +117,7 @@ def get_or_create_libjuju_thread():
             if time.time() > now + 5.0:
                 raise RuntimeError("Async thread didn't start!")
         # enable async subprocess calls in the libjuju thread to work
-        asyncio.get_child_watcher().attach_loop(_libjuju_loop)
+        _attach_child_watcher(_libjuju_loop)
     return _libjuju_thread
 
 
@@ -152,7 +189,7 @@ def join_libjuju_thread():
         logging.debug("stopping the event loop")
         # remove the child watcher (that was for subprocess calls) when
         # dropping the thread.
-        asyncio.get_child_watcher().attach_loop(None)
+        _attach_child_watcher(None)
         _libjuju_run = False
         # wait up to 30 seconds for loop to close.
         now = time.time()
@@ -208,11 +245,7 @@ def sync_wrapper(f, timeout=None):
 
         if not RUN_LIBJUJU_IN_THREAD:
             # run it in this thread's event loop:
-            loop = asyncio.get_event_loop()
-            # create a new loop if the existing one is closed
-            if loop.is_closed():
-                loop = asyncio.new_event_loop()
-                asyncio.set_event_loop(loop)
+            loop = _get_or_create_event_loop()
             return loop.run_until_complete(_runner())
 
         # ensure that the thread is created

--- a/zaza/charm_lifecycle/before_deploy.py
+++ b/zaza/charm_lifecycle/before_deploy.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 """Run configuration phase."""
-import asyncio
 import argparse
 import sys
 
@@ -95,4 +94,4 @@ def main():
         run_report.output_event_report()
     finally:
         zaza.clean_up_libjuju_thread()
-        asyncio.get_event_loop().close()
+        zaza.close_local_event_loop()

--- a/zaza/charm_lifecycle/configure.py
+++ b/zaza/charm_lifecycle/configure.py
@@ -14,7 +14,6 @@
 
 """Run configuration phase."""
 import argparse
-import asyncio
 import sys
 
 import zaza.model
@@ -101,4 +100,4 @@ def main():
         run_report.output_event_report()
     finally:
         zaza.clean_up_libjuju_thread()
-        asyncio.get_event_loop().close()
+        zaza.close_local_event_loop()

--- a/zaza/charm_lifecycle/deploy.py
+++ b/zaza/charm_lifecycle/deploy.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 """Run deploy phase."""
-import asyncio
 import argparse
 import jinja2
 import logging
@@ -470,4 +469,4 @@ def main():
         run_report.output_event_report()
     finally:
         zaza.clean_up_libjuju_thread()
-        asyncio.get_event_loop().close()
+        zaza.close_local_event_loop()

--- a/zaza/charm_lifecycle/destroy.py
+++ b/zaza/charm_lifecycle/destroy.py
@@ -14,7 +14,6 @@
 
 """Run destroy phase."""
 import argparse
-import asyncio
 import sys
 
 import zaza.controller
@@ -68,4 +67,4 @@ def main():
         destroy(args.model_name)
     finally:
         zaza.clean_up_libjuju_thread()
-        asyncio.get_event_loop().close()
+        zaza.close_local_event_loop()

--- a/zaza/charm_lifecycle/func_test_runner.py
+++ b/zaza/charm_lifecycle/func_test_runner.py
@@ -14,7 +14,7 @@
 
 """Run full test lifecycle."""
 import argparse
-import asyncio
+import asyncio  # noqa: F401 - kept for unit test monkeypatch compatibility
 import logging
 import os
 import sys
@@ -415,4 +415,4 @@ def main():
         run_report.output_event_report()
     finally:
         zaza.clean_up_libjuju_thread()
-        asyncio.get_event_loop().close()
+        zaza.close_local_event_loop()

--- a/zaza/charm_lifecycle/prepare.py
+++ b/zaza/charm_lifecycle/prepare.py
@@ -14,7 +14,6 @@
 
 """Run prepare phase."""
 import argparse
-import asyncio
 import logging
 import sys
 
@@ -85,4 +84,4 @@ def main():
         run_report.output_event_report()
     finally:
         zaza.clean_up_libjuju_thread()
-        asyncio.get_event_loop().close()
+        zaza.close_local_event_loop()

--- a/zaza/charm_lifecycle/test.py
+++ b/zaza/charm_lifecycle/test.py
@@ -14,7 +14,6 @@
 
 """Run test phase."""
 import argparse
-import asyncio
 import logging
 import sys
 import unittest
@@ -237,4 +236,4 @@ def main(argv=None):
         run_report.output_event_report()
     finally:
         zaza.clean_up_libjuju_thread()
-        asyncio.get_event_loop().close()
+        zaza.close_local_event_loop()


### PR DESCRIPTION
Update asyncio loop handling and lifecycle cleanup paths to support Python 3.14 behavior changes.

Changes included:
- Added safe event-loop helpers in zaza.__init__ to create/reuse local loops when no current loop exists
- Guarded child-watcher attach/detach usage for runtimes where asyncio.get_child_watcher is unavailable
- Replaced direct asyncio.get_event_loop().close() calls in lifecycle entry points with zaza.close_local_event_loop()
- Added explicit py314 tox environment and included it in tox envlist
- Added Python 3.14 trove classifier in package metadata

Validation:
- tox -e py3 (Python 3.14.4): 725 passed, 2 skipped
- tox -e py314: 725 passed, 2 skipped

Assisted-by: GitHub Copilot (GPT-5.3-Codex)